### PR TITLE
Implement Raid Finder System

### DIFF
--- a/app/Console/Commands/SyncTreaties.php
+++ b/app/Console/Commands/SyncTreaties.php
@@ -2,11 +2,13 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Treaty;
+use App\Exceptions\PWQueryFailedException;
 use App\GraphQL\Models\Treaty as TreatyGraphQL;
+use App\Models\Treaty;
 use App\Services\GraphQLQueryBuilder;
 use App\Services\QueryService;
 use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
 
 class SyncTreaties extends Command
 {
@@ -15,8 +17,8 @@ class SyncTreaties extends Command
 
     /**
      * @return void
-     * @throws \App\Exceptions\PWQueryFailedException
-     * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws PWQueryFailedException
+     * @throws ConnectionException
      */
     public function handle(): void
     {
@@ -41,7 +43,7 @@ class SyncTreaties extends Command
             $graphQLTreaty = new TreatyGraphQL();
             $graphQLTreaty->buildWithJSON((object)$treatyJSON);
 
-            if (! $graphQLTreaty->approved) {
+            if (!$graphQLTreaty->approved) {
                 continue;
             }
 

--- a/app/Console/Commands/SyncTreaties.php
+++ b/app/Console/Commands/SyncTreaties.php
@@ -13,6 +13,11 @@ class SyncTreaties extends Command
     protected $signature = 'sync:treaties';
     protected $description = 'Syncs approved treaties from the Politics & War API';
 
+    /**
+     * @return void
+     * @throws \App\Exceptions\PWQueryFailedException
+     * @throws \Illuminate\Http\Client\ConnectionException
+     */
     public function handle(): void
     {
         $query = (new GraphQLQueryBuilder())

--- a/app/Console/Commands/SyncTreaties.php
+++ b/app/Console/Commands/SyncTreaties.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Treaty;
+use App\GraphQL\Models\Treaty as TreatyGraphQL;
+use App\Services\GraphQLQueryBuilder;
+use App\Services\QueryService;
+use Illuminate\Console\Command;
+
+class SyncTreaties extends Command
+{
+    protected $signature = 'sync:treaties';
+    protected $description = 'Syncs approved treaties from the Politics & War API';
+
+    public function handle(): void
+    {
+        $query = (new GraphQLQueryBuilder())
+            ->setRootField('treaties')
+            ->addArgument('first', 1000)
+            ->addNestedField('data', fn(GraphQLQueryBuilder $builder) => $builder->addFields([
+                'id',
+                'date',
+                'treaty_type',
+                'turns_left',
+                'alliance1_id',
+                'alliance2_id',
+                'approved',
+            ]));
+
+        $response = (new QueryService())->sendQuery($query);
+
+        $treatyIDs = [];
+
+        foreach ($response as $treatyJSON) {
+            $graphQLTreaty = new TreatyGraphQL();
+            $graphQLTreaty->buildWithJSON((object)$treatyJSON);
+
+            if (! $graphQLTreaty->approved) {
+                continue;
+            }
+
+            Treaty::updateOrInsert(
+                ['pw_id' => $graphQLTreaty->id],
+                [
+                    'pw_date' => $graphQLTreaty->date,
+                    'turns_left' => $graphQLTreaty->turns_left,
+                    'alliance1_id' => $graphQLTreaty->alliance1_id,
+                    'alliance2_id' => $graphQLTreaty->alliance2_id,
+                    'type' => $graphQLTreaty->treaty_type,
+                ]
+            );
+
+            $treatyIDs[] = $graphQLTreaty->id;
+        }
+
+        Treaty::whereNotIn('pw_id', $treatyIDs)->delete();
+    }
+}

--- a/app/Console/Commands/SyncWars.php
+++ b/app/Console/Commands/SyncWars.php
@@ -2,11 +2,13 @@
 
 namespace App\Console\Commands;
 
+use App\Exceptions\PWQueryFailedException;
 use App\Jobs\SyncWarsJob;
 use App\Services\GraphQLQueryBuilder;
 use App\Services\QueryService;
 use App\Services\SelectionSetHelper;
 use Illuminate\Console\Command;
+use Illuminate\Http\Client\ConnectionException;
 
 class SyncWars extends Command
 {
@@ -15,8 +17,8 @@ class SyncWars extends Command
 
     /**
      * @return void
-     * @throws \App\Exceptions\PWQueryFailedException
-     * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws PWQueryFailedException
+     * @throws ConnectionException
      */
     public function handle(): void
     {
@@ -34,7 +36,10 @@ class SyncWars extends Command
                 'active' => false,
                 'alliance_id' => (int)env("PW_ALLIANCE_ID"),
             ])
-            ->addNestedField("data", fn(GraphQLQueryBuilder $builder) => $builder->addFields(SelectionSetHelper::warSet()))
+            ->addNestedField(
+                "data",
+                fn(GraphQLQueryBuilder $builder) => $builder->addFields(SelectionSetHelper::warSet())
+            )
             ->withPaginationInfo();
 
         $pagination = $client->getPaginationInfo($builder);

--- a/app/Console/Commands/UpdateTradePrices.php
+++ b/app/Console/Commands/UpdateTradePrices.php
@@ -12,11 +12,17 @@ class UpdateTradePrices extends Command
     protected $signature = 'trades:update';
     protected $description = 'Fetch and save the current trade prices from PW API';
 
+    /**
+     * @param TradePriceService $tradePriceService
+     */
     public function __construct(protected TradePriceService $tradePriceService)
     {
         parent::__construct();
     }
 
+    /**
+     * @return void
+     */
     public function handle(): void
     {
         $this->info('Fetching latest trade prices...');

--- a/app/Console/Commands/UpdateTradePrices.php
+++ b/app/Console/Commands/UpdateTradePrices.php
@@ -6,6 +6,7 @@ use App\Models\TradePrice;
 use App\Services\TradePriceService;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Throwable;
 
 class UpdateTradePrices extends Command
 {
@@ -32,22 +33,22 @@ class UpdateTradePrices extends Command
 
             TradePrice::create([
                 'date' => Carbon::parse($graphqlPrice->date)->toDateString(),
-                'coal' => (int) $graphqlPrice->coal,
-                'oil' => (int) $graphqlPrice->oil,
-                'uranium' => (int) $graphqlPrice->uranium,
-                'iron' => (int) $graphqlPrice->iron,
-                'bauxite' => (int) $graphqlPrice->bauxite,
-                'lead' => (int) $graphqlPrice->lead,
-                'gas' => (int) $graphqlPrice->gasoline,
-                'munitions' => (int) $graphqlPrice->munitions,
-                'steel' => (int) $graphqlPrice->steel,
-                'aluminum' => (int) $graphqlPrice->aluminum,
-                'food' => (int) $graphqlPrice->food,
-                'credits' => (int) $graphqlPrice->credits,
+                'coal' => (int)$graphqlPrice->coal,
+                'oil' => (int)$graphqlPrice->oil,
+                'uranium' => (int)$graphqlPrice->uranium,
+                'iron' => (int)$graphqlPrice->iron,
+                'bauxite' => (int)$graphqlPrice->bauxite,
+                'lead' => (int)$graphqlPrice->lead,
+                'gas' => (int)$graphqlPrice->gasoline,
+                'munitions' => (int)$graphqlPrice->munitions,
+                'steel' => (int)$graphqlPrice->steel,
+                'aluminum' => (int)$graphqlPrice->aluminum,
+                'food' => (int)$graphqlPrice->food,
+                'credits' => (int)$graphqlPrice->credits,
             ]);
 
             $this->info('Trade prices saved successfully.');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->error("Failed to update trade prices: {$e->getMessage()}");
         }
     }

--- a/app/Console/Commands/UpdateTradePrices.php
+++ b/app/Console/Commands/UpdateTradePrices.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\TradePrice;
+use App\Services\TradePriceService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class UpdateTradePrices extends Command
+{
+    protected $signature = 'trades:update';
+    protected $description = 'Fetch and save the current trade prices from PW API';
+
+    public function __construct(protected TradePriceService $tradePriceService)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): void
+    {
+        $this->info('Fetching latest trade prices...');
+
+        try {
+            $graphqlPrice = $this->tradePriceService->pullFromGraphQL();
+
+            TradePrice::create([
+                'date' => Carbon::parse($graphqlPrice->date)->toDateString(),
+                'coal' => (int) $graphqlPrice->coal,
+                'oil' => (int) $graphqlPrice->oil,
+                'uranium' => (int) $graphqlPrice->uranium,
+                'iron' => (int) $graphqlPrice->iron,
+                'bauxite' => (int) $graphqlPrice->bauxite,
+                'lead' => (int) $graphqlPrice->lead,
+                'gas' => (int) $graphqlPrice->gasoline,
+                'munitions' => (int) $graphqlPrice->munitions,
+                'steel' => (int) $graphqlPrice->steel,
+                'aluminum' => (int) $graphqlPrice->aluminum,
+                'food' => (int) $graphqlPrice->food,
+                'credits' => (int) $graphqlPrice->credits,
+            ]);
+
+            $this->info('Trade prices saved successfully.');
+        } catch (\Throwable $e) {
+            $this->error("Failed to update trade prices: {$e->getMessage()}");
+        }
+    }
+}

--- a/app/GraphQL/Models/Attack.php
+++ b/app/GraphQL/Models/Attack.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\GraphQL\Models;
+
+class Attack
+{
+    public ?int $money_looted = 0;
+    public ?int $money_stolen = 0;
+    public ?int $coal_looted = 0;
+    public ?int $oil_looted = 0;
+    public ?int $uranium_looted = 0;
+    public ?int $iron_looted = 0;
+    public ?int $bauxite_looted = 0;
+    public ?int $lead_looted = 0;
+    public ?int $gasoline_looted = 0;
+    public ?int $munitions_looted = 0;
+    public ?int $steel_looted = 0;
+    public ?int $aluminum_looted = 0;
+    public ?int $food_looted = 0;
+
+    public function buildWithJSON(\stdClass $json): void
+    {
+        foreach ($json as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+}

--- a/app/GraphQL/Models/Attack.php
+++ b/app/GraphQL/Models/Attack.php
@@ -2,6 +2,8 @@
 
 namespace App\GraphQL\Models;
 
+use stdClass;
+
 class Attack
 {
     public ?int $money_looted = 0;
@@ -19,10 +21,10 @@ class Attack
     public ?int $food_looted = 0;
 
     /**
-     * @param \stdClass $json
+     * @param stdClass $json
      * @return void
      */
-    public function buildWithJSON(\stdClass $json): void
+    public function buildWithJSON(stdClass $json): void
     {
         foreach ($json as $key => $value) {
             $this->{$key} = $value;

--- a/app/GraphQL/Models/Attack.php
+++ b/app/GraphQL/Models/Attack.php
@@ -18,6 +18,10 @@ class Attack
     public ?int $aluminum_looted = 0;
     public ?int $food_looted = 0;
 
+    /**
+     * @param \stdClass $json
+     * @return void
+     */
     public function buildWithJSON(\stdClass $json): void
     {
         foreach ($json as $key => $value) {

--- a/app/GraphQL/Models/Nation.php
+++ b/app/GraphQL/Models/Nation.php
@@ -2,6 +2,7 @@
 
 namespace App\GraphQL\Models;
 
+use Carbon\Carbon;
 use stdClass;
 
 class Nation
@@ -138,6 +139,7 @@ class Nation
     public ?int $offensive_wars_count = null;
     public ?int $defensive_wars_count = null;
     public ?int $credits_redeemed_this_month = null;
+    public ?string $last_active = null;
 
     /**
      * I hate the function. Look away now.
@@ -304,6 +306,10 @@ class Nation
         $this->money_looted = isset($json->money_looted) ? (float)$json->money_looted : null;
         $this->total_infrastructure_destroyed = isset($json->total_infrastructure_destroyed) ? (float)$json->total_infrastructure_destroyed : null;
         $this->total_infrastructure_lost = isset($json->total_infrastructure_lost) ? (float)$json->total_infrastructure_lost : null;
+
+        if (isset($json->last_active)) {
+            $this->last_active = Carbon::create($json->last_active)->toDateTimeString();
+        }
     }
 
     /**

--- a/app/GraphQL/Models/Nation.php
+++ b/app/GraphQL/Models/Nation.php
@@ -18,6 +18,7 @@ class Nation
     public ?string $color = null;
     public ?int $num_cities = null;
     public ?Cities $cities = null;
+    public ?Wars $wars = null;
     public ?float $score = null;
     public ?float $update_tz = null;
     public ?int $population = null;
@@ -170,6 +171,15 @@ class Nation
                 $cityModel = new City();
                 $cityModel->buildWithJSON((object)$city);
                 $this->cities->add($cityModel);
+            }
+        }
+
+        if (isset($json->wars) && is_array($json->wars)) {
+            $this->wars = new Wars([]);
+            foreach ($json->wars as $war) {
+                $warModel = new War();
+                $warModel->buildWithJSON((object)$war);
+                $this->wars->add($warModel);
             }
         }
 

--- a/app/GraphQL/Models/Nation.php
+++ b/app/GraphQL/Models/Nation.php
@@ -140,6 +140,7 @@ class Nation
     public ?int $defensive_wars_count = null;
     public ?int $credits_redeemed_this_month = null;
     public ?string $last_active = null;
+    public ?Alliance $alliance = null;
 
     /**
      * I hate the function. Look away now.
@@ -174,6 +175,11 @@ class Nation
                 $cityModel->buildWithJSON((object)$city);
                 $this->cities->add($cityModel);
             }
+        }
+
+        if (isset($json->alliance) && is_array($json->alliance)) {
+            $this->alliance = new Alliance([]);
+            $this->alliance->buildWithJSON((object)$json->alliance);
         }
 
         if (isset($json->wars) && is_array($json->wars)) {

--- a/app/GraphQL/Models/TradePrice.php
+++ b/app/GraphQL/Models/TradePrice.php
@@ -2,6 +2,8 @@
 
 namespace App\GraphQL\Models;
 
+use stdClass;
+
 class TradePrice
 {
     public string $id;
@@ -21,10 +23,10 @@ class TradePrice
     public float $credits;
 
     /**
-     * @param \stdClass $json
+     * @param stdClass $json
      * @return void
      */
-    public function buildWithJSON(\stdClass $json): void
+    public function buildWithJSON(stdClass $json): void
     {
         $this->id = $json->id;
         $this->date = $json->date;

--- a/app/GraphQL/Models/TradePrice.php
+++ b/app/GraphQL/Models/TradePrice.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\GraphQL\Models;
+
+class TradePrice
+{
+    public string $id;
+    public string $date;
+
+    public float $coal;
+    public float $oil;
+    public float $uranium;
+    public float $iron;
+    public float $bauxite;
+    public float $lead;
+    public float $gasoline;
+    public float $munitions;
+    public float $steel;
+    public float $aluminum;
+    public float $food;
+    public float $credits;
+
+    public function buildWithJSON(\stdClass $json): void
+    {
+        $this->id = $json->id;
+        $this->date = $json->date;
+
+        $this->coal = $json->coal;
+        $this->oil = $json->oil;
+        $this->uranium = $json->uranium;
+        $this->iron = $json->iron;
+        $this->bauxite = $json->bauxite;
+        $this->lead = $json->lead;
+        $this->gasoline = $json->gasoline;
+        $this->munitions = $json->munitions;
+        $this->steel = $json->steel;
+        $this->aluminum = $json->aluminum;
+        $this->food = $json->food;
+        $this->credits = $json->credits;
+    }
+}

--- a/app/GraphQL/Models/TradePrice.php
+++ b/app/GraphQL/Models/TradePrice.php
@@ -20,6 +20,10 @@ class TradePrice
     public float $food;
     public float $credits;
 
+    /**
+     * @param \stdClass $json
+     * @return void
+     */
     public function buildWithJSON(\stdClass $json): void
     {
         $this->id = $json->id;

--- a/app/GraphQL/Models/Treaty.php
+++ b/app/GraphQL/Models/Treaty.php
@@ -3,6 +3,7 @@
 namespace App\GraphQL\Models;
 
 use Carbon\Carbon;
+use stdClass;
 
 class Treaty
 {
@@ -15,17 +16,17 @@ class Treaty
     public bool $approved;
 
     /**
-     * @param \stdClass $json
+     * @param stdClass $json
      * @return void
      */
-    public function buildWithJSON(\stdClass $json): void
+    public function buildWithJSON(stdClass $json): void
     {
-        $this->id = (int) $json->id;
+        $this->id = (int)$json->id;
         $this->date = Carbon::parse($json->date)->format('Y-m-d H:i:s'); // ✅ convert for MySQL
         $this->treaty_type = $json->treaty_type;
         $this->turns_left = $json->turns_left;
         $this->alliance1_id = $json->alliance1_id;
         $this->alliance2_id = $json->alliance2_id;
-        $this->approved = (bool) $json->approved;
+        $this->approved = (bool)$json->approved;
     }
 }

--- a/app/GraphQL/Models/Treaty.php
+++ b/app/GraphQL/Models/Treaty.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\GraphQL\Models;
+
+use Carbon\Carbon;
+
+class Treaty
+{
+    public int $id;
+    public string $date;
+    public int $turns_left;
+    public int $alliance1_id;
+    public int $alliance2_id;
+    public string $treaty_type;
+    public bool $approved;
+
+    /**
+     * @param \stdClass $json
+     * @return void
+     */
+    public function buildWithJSON(\stdClass $json): void
+    {
+        $this->id = (int) $json->id;
+        $this->date = Carbon::parse($json->date)->format('Y-m-d H:i:s'); // ✅ convert for MySQL
+        $this->treaty_type = $json->treaty_type;
+        $this->turns_left = $json->turns_left;
+        $this->alliance1_id = $json->alliance1_id;
+        $this->alliance2_id = $json->alliance2_id;
+        $this->approved = (bool) $json->approved;
+    }
+}

--- a/app/GraphQL/Models/War.php
+++ b/app/GraphQL/Models/War.php
@@ -75,6 +75,19 @@ class War
     public function buildWithJSON(\stdClass $json): void
     {
         foreach ($json as $key => $value) {
+            // Special case: hydrate attacks into real Attack objects
+            if ($key == 'attacks' && is_array($value)) {
+                $this->attacks = [];
+
+                foreach ($value as $attackData) {
+                    $attack = new Attack();
+                    $attack->buildWithJSON((object) $attackData);
+                    $this->attacks[] = $attack;
+                }
+
+                continue;
+            }
+
             $this->{$key} = $value;
         }
     }

--- a/app/GraphQL/Models/War.php
+++ b/app/GraphQL/Models/War.php
@@ -2,6 +2,8 @@
 
 namespace App\GraphQL\Models;
 
+use stdClass;
+
 class War
 {
     public int $id;
@@ -69,10 +71,10 @@ class War
     public ?string $end_date; // Nullable ISO 8601 format string
 
     /**
-     * @param \stdClass $json
+     * @param stdClass $json
      * @return void
      */
-    public function buildWithJSON(\stdClass $json): void
+    public function buildWithJSON(stdClass $json): void
     {
         foreach ($json as $key => $value) {
             // Special case: hydrate attacks into real Attack objects
@@ -81,7 +83,7 @@ class War
 
                 foreach ($value as $attackData) {
                     $attack = new Attack();
-                    $attack->buildWithJSON((object) $attackData);
+                    $attack->buildWithJSON((object)$attackData);
                     $this->attacks[] = $attack;
                 }
 

--- a/app/GraphQL/Models/Wars.php
+++ b/app/GraphQL/Models/Wars.php
@@ -2,7 +2,9 @@
 
 namespace App\GraphQL\Models;
 
-class Wars implements \Iterator
+use Iterator;
+
+class Wars implements Iterator
 {
     private array $wars;
     private int $position = 0;

--- a/app/Http/Controllers/API/RaidFinderController.php
+++ b/app/Http/Controllers/API/RaidFinderController.php
@@ -9,8 +9,15 @@ use Illuminate\Support\Facades\Auth;
 
 class RaidFinderController extends Controller
 {
+    /**
+     * @param RaidFinderService $raidFinderService
+     */
     public function __construct(protected RaidFinderService $raidFinderService) {}
 
+    /**
+     * @param int|null $nation_id
+     * @return \Illuminate\Http\JsonResponse
+     */
     public function show(?int $nation_id = null)
     {
         $nationId = $nation_id ?? Auth::user()->nation_id;

--- a/app/Http/Controllers/API/RaidFinderController.php
+++ b/app/Http/Controllers/API/RaidFinderController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Nation;
+use App\Services\RaidFinderService;
+use Illuminate\Support\Facades\Auth;
+
+class RaidFinderController extends Controller
+{
+    public function __construct(protected RaidFinderService $raidFinderService) {}
+
+    public function show(?int $nation_id = null)
+    {
+        $nationId = $nation_id ?? Auth::user()->nation_id;
+
+        logger("RaidFinder API called for nation ID: $nationId");
+
+        $nation = Nation::findOrFail($nationId);
+
+        if ($nation->alliance_id !== (int) env('PW_ALLIANCE_ID')) {
+            logger("Blocked request for nation not in alliance.");
+            abort(403, 'You can only run this for your alliance.');
+        }
+
+        $targets = $this->raidFinderService->findTargets($nationId);
+
+        logger("Found " . count($targets) . " targets");
+
+        return response()->json($targets);
+    }
+}

--- a/app/Http/Controllers/API/RaidFinderController.php
+++ b/app/Http/Controllers/API/RaidFinderController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Models\Nation;
 use App\Services\RaidFinderService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 class RaidFinderController extends Controller
@@ -12,11 +13,13 @@ class RaidFinderController extends Controller
     /**
      * @param RaidFinderService $raidFinderService
      */
-    public function __construct(protected RaidFinderService $raidFinderService) {}
+    public function __construct(protected RaidFinderService $raidFinderService)
+    {
+    }
 
     /**
      * @param int|null $nation_id
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function show(?int $nation_id = null)
     {
@@ -26,7 +29,7 @@ class RaidFinderController extends Controller
 
         $nation = Nation::findOrFail($nationId);
 
-        if ($nation->alliance_id !== (int) env('PW_ALLIANCE_ID')) {
+        if ($nation->alliance_id !== (int)env('PW_ALLIANCE_ID')) {
             logger("Blocked request for nation not in alliance.");
             abort(403, 'You can only run this for your alliance.');
         }

--- a/app/Http/Controllers/Admin/RaidController.php
+++ b/app/Http/Controllers/Admin/RaidController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\NoRaidList;
+use App\Models\Setting;
+use App\Services\SettingService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class RaidController extends Controller
+{
+    /**
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|object
+     */
+    public function index()
+    {
+        $noRaidList = NoRaidList::orderBy('alliance_id')->with("alliance")->get();
+        $topCap = SettingService::getTopRaidable();
+
+        return view('admin.defense.raids', [
+            'noRaidList' => $noRaidList,
+            'topCap' => $topCap,
+        ]);
+    }
+
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function storeNoRaid(Request $request)
+    {
+        $request->validate([
+            'alliance_id' => [
+                'required',
+                'integer',
+                'unique:no_raid_list,alliance_id',
+                'exists:alliances,id'
+            ],
+        ]);
+        NoRaidList::create([
+            'alliance_id' => $request->alliance_id
+        ]);
+
+        return redirect()->route('admin.raids.index')->with('alert-message', 'Alliance added to no-raid list')->with('alert-type', 'success');
+    }
+
+    /**
+     * @param int $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroyNoRaid(int $id)
+    {
+        NoRaidList::where('id', $id)->delete();
+
+        return redirect()->route('admin.raids.index')->with('alert-message', 'Alliance removed from no-raid list')->with('alert-type', 'success');
+    }
+
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function updateTopCap(Request $request)
+    {
+        $request->validate(['top_cap' => 'required|integer|min:1|max:1000']);
+
+        SettingService::setTopRaidable($request->input('top_cap'));
+
+        return redirect()->route('admin.raids.index')->with('alert-message', 'Top alliance cap updated')->with('alert-type', 'success');
+    }
+}

--- a/app/Http/Controllers/Admin/WarAidController.php
+++ b/app/Http/Controllers/Admin/WarAidController.php
@@ -7,17 +7,22 @@ use App\Models\WarAidRequest;
 use App\Services\PWHelperService;
 use App\Services\SettingService;
 use App\Services\WarAidService;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class WarAidController extends Controller
 {
     /**
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|object
+     * @return Factory|View|Application|object
      */
     public function index()
     {
         $pending = WarAidRequest::where('status', 'pending')->with('nation', 'account')->get();
-        $history = WarAidRequest::whereIn('status', ['approved', 'denied'])->with('nation', 'account')->latest()->paginate(25);
+        $history = WarAidRequest::whereIn('status', ['approved', 'denied'])->with('nation', 'account')->latest(
+        )->paginate(25);
         $enabled = SettingService::isWarAidEnabled();
 
         return view('admin.defense.war-aid', compact('pending', 'history', 'enabled'));
@@ -27,12 +32,13 @@ class WarAidController extends Controller
      * @param Request $request
      * @param WarAidRequest $aidRequest
      * @param WarAidService $warAidService
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function approve(Request $request, WarAidRequest $aidRequest, WarAidService $warAidService)
     {
         $data = $request->validate(
-            collect(PWHelperService::resources())->mapWithKeys(fn ($r) => [$r => ['nullable', 'integer', 'min:0']])->toArray()
+            collect(PWHelperService::resources())->mapWithKeys(fn($r) => [$r => ['nullable', 'integer', 'min:0']]
+            )->toArray()
         );
 
         $warAidService->approveAidRequest($aidRequest, $data);
@@ -46,7 +52,7 @@ class WarAidController extends Controller
     /**
      * @param WarAidRequest $aidRequest
      * @param WarAidService $warAidService
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function deny(WarAidRequest $aidRequest, WarAidService $warAidService)
     {
@@ -59,12 +65,12 @@ class WarAidController extends Controller
     }
 
     /**
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function toggle()
     {
         $currently = SettingService::isWarAidEnabled();
-        SettingService::setWarAidEnabled(! $currently);
+        SettingService::setWarAidEnabled(!$currently);
 
         return back()->with([
             'alert-message' => 'War aid has been ' . ($currently ? 'disabled' : 'enabled') . '.',

--- a/app/Http/Controllers/Admin/WarController.php
+++ b/app/Http/Controllers/Admin/WarController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Services\WarService;
-use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class WarController extends Controller

--- a/app/Http/Controllers/CounterFinderController.php
+++ b/app/Http/Controllers/CounterFinderController.php
@@ -4,6 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Models\Nation;
 use App\Services\NationMatchService;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class CounterFinderController extends Controller
@@ -12,7 +16,7 @@ class CounterFinderController extends Controller
      * @param Request $request
      * @param NationMatchService $matchService
      * @param int|null $nation
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|\Illuminate\Http\RedirectResponse|object
+     * @return Factory|View|Application|RedirectResponse|object
      */
     public function index(Request $request, NationMatchService $matchService, ?int $nation = null)
     {

--- a/app/Http/Controllers/RaidFinderController.php
+++ b/app/Http/Controllers/RaidFinderController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Nation;
+use App\Models\NoRaidList;
+use App\Services\RaidFinderService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+
+class RaidFinderController extends Controller
+{
+    public function __construct(protected RaidFinderService $raidFinderService) {}
+
+    public function index(Request $request)
+    {
+        $nationId = $request->get('nation_id') ?? Auth::user()->nation_id;
+        $nation = Nation::findOrFail($nationId);
+
+        if ($nation->alliance_id !== (int) env('PW_ALLIANCE_ID')) {
+            abort(403, 'This nation is not in your alliance.');
+        }
+
+        $cacheKey = "raid-finder:{$nationId}";
+        $targets = Cache::remember($cacheKey, now()->addMinutes(30), function () use ($nationId) {
+            return $this->raidFinderService->findTargets($nationId);
+        });
+
+        // ✅ AJAX request? Return just the data.
+        if ($request->ajax()) {
+            return response()->json($targets);
+        }
+
+        return view('defense.raid-finder', [
+            'nationId' => $nationId,
+        ]);
+    }
+}

--- a/app/Http/Controllers/RaidFinderController.php
+++ b/app/Http/Controllers/RaidFinderController.php
@@ -3,8 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Nation;
-use App\Models\NoRaidList;
 use App\Services\RaidFinderService;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
@@ -14,18 +17,20 @@ class RaidFinderController extends Controller
     /**
      * @param RaidFinderService $raidFinderService
      */
-    public function __construct(protected RaidFinderService $raidFinderService) {}
+    public function __construct(protected RaidFinderService $raidFinderService)
+    {
+    }
 
     /**
      * @param Request $request
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|\Illuminate\Http\JsonResponse|object
+     * @return Factory|View|Application|JsonResponse|object
      */
     public function index(Request $request)
     {
         $nationId = $request->get('nation_id') ?? Auth::user()->nation_id;
         $nation = Nation::findOrFail($nationId);
 
-        if ($nation->alliance_id !== (int) env('PW_ALLIANCE_ID')) {
+        if ($nation->alliance_id !== (int)env('PW_ALLIANCE_ID')) {
             abort(403, 'This nation is not in your alliance.');
         }
 

--- a/app/Http/Controllers/RaidFinderController.php
+++ b/app/Http/Controllers/RaidFinderController.php
@@ -28,21 +28,6 @@ class RaidFinderController extends Controller
     public function index(Request $request)
     {
         $nationId = $request->get('nation_id') ?? Auth::user()->nation_id;
-        $nation = Nation::findOrFail($nationId);
-
-        if ($nation->alliance_id !== (int)env('PW_ALLIANCE_ID')) {
-            abort(403, 'This nation is not in your alliance.');
-        }
-
-        $cacheKey = "raid-finder:{$nationId}";
-        $targets = Cache::remember($cacheKey, now()->addMinutes(30), function () use ($nationId) {
-            return $this->raidFinderService->findTargets($nationId);
-        });
-
-        // ✅ AJAX request? Return just the data.
-        if ($request->ajax()) {
-            return response()->json($targets);
-        }
 
         return view('defense.raid-finder', [
             'nationId' => $nationId,

--- a/app/Http/Controllers/RaidFinderController.php
+++ b/app/Http/Controllers/RaidFinderController.php
@@ -11,8 +11,15 @@ use Illuminate\Support\Facades\Cache;
 
 class RaidFinderController extends Controller
 {
+    /**
+     * @param RaidFinderService $raidFinderService
+     */
     public function __construct(protected RaidFinderService $raidFinderService) {}
 
+    /**
+     * @param Request $request
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|\Illuminate\Http\JsonResponse|object
+     */
     public function index(Request $request)
     {
         $nationId = $request->get('nation_id') ?? Auth::user()->nation_id;

--- a/app/Http/Controllers/WarAidController.php
+++ b/app/Http/Controllers/WarAidController.php
@@ -2,18 +2,23 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\WarAidRequest;
 use App\Models\War;
+use App\Models\WarAidRequest;
 use App\Services\PWHelperService;
 use App\Services\SettingService;
 use App\Services\WarAidService;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
 
 class WarAidController extends Controller
 {
     /**
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application|object
+     * @return Factory|View|Application|object
      */
     public function index()
     {
@@ -34,8 +39,8 @@ class WarAidController extends Controller
     /**
      * @param Request $request
      * @param WarAidService $warAidService
-     * @return \Illuminate\Http\RedirectResponse
-     * @throws \Illuminate\Validation\ValidationException
+     * @return RedirectResponse
+     * @throws ValidationException
      */
     public function store(Request $request, WarAidService $warAidService)
     {
@@ -50,7 +55,7 @@ class WarAidController extends Controller
             'account_id' => ['required', 'exists:accounts,id'],
             'note' => ['required', 'string', 'max:255'],
             ...collect(PWHelperService::resources())
-                ->mapWithKeys(fn ($r) => [$r => ['nullable', 'integer', 'min:0']])
+                ->mapWithKeys(fn($r) => [$r => ['nullable', 'integer', 'min:0']])
                 ->toArray()
         ]);
 

--- a/app/Jobs/SyncNationsJob.php
+++ b/app/Jobs/SyncNationsJob.php
@@ -11,9 +11,9 @@
 namespace App\Jobs;
 
 use App\Models\City;
+use App\Models\Nation;
 use App\Models\NationMilitary;
 use App\Models\NationResources;
-use App\Models\Nation;
 use App\Services\NationQueryService;
 use App\Services\PWHelperService;
 use Exception;

--- a/app/Jobs/UpdateWarJob.php
+++ b/app/Jobs/UpdateWarJob.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\War;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -30,7 +31,7 @@ class UpdateWarJob implements ShouldQueue
                 // Convert to stdClass and hydrate the model
                 War::updateFromAPI((object)$warData);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::error('Failed to update wars', ['error' => $e->getMessage()]);
         }
     }

--- a/app/Models/NoRaidList.php
+++ b/app/Models/NoRaidList.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class NoRaidList extends Model
 {
@@ -14,4 +15,12 @@ class NoRaidList extends Model
     protected $fillable = [
         'alliance_id',
     ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function alliance(): BelongsTo
+    {
+        return $this->belongsTo(Alliance::class, "alliance_id");
+    }
 }

--- a/app/Models/NoRaidList.php
+++ b/app/Models/NoRaidList.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class NoRaidList extends Model
+{
+    use HasFactory;
+
+    protected $table = 'no_raid_list';
+
+    protected $fillable = [
+        'alliance_id',
+    ];
+}

--- a/app/Models/TradePrice.php
+++ b/app/Models/TradePrice.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TradePrice extends Model
+{
+    use HasFactory;
+
+    protected $table = 'trade_prices';
+
+    protected $fillable = [
+        'date',
+        'coal',
+        'oil',
+        'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'gas',
+        'munitions',
+        'steel',
+        'aluminum',
+        'food',
+        'credits',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+    ];
+}

--- a/app/Models/Treaty.php
+++ b/app/Models/Treaty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Treaty extends Model
+{
+    protected $fillable = [
+        'pw_id', 'pw_date', 'turns_left',
+        'alliance1_id', 'alliance2_id', 'type',
+    ];
+}

--- a/app/Models/Treaty.php
+++ b/app/Models/Treaty.php
@@ -7,7 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 class Treaty extends Model
 {
     protected $fillable = [
-        'pw_id', 'pw_date', 'turns_left',
-        'alliance1_id', 'alliance2_id', 'type',
+        'pw_id',
+        'pw_date',
+        'turns_left',
+        'alliance1_id',
+        'alliance2_id',
+        'type',
     ];
 }

--- a/app/Models/War.php
+++ b/app/Models/War.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use App\GraphQL\Models\War as WarGraphQL;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use stdClass;
 
 class War extends Model
 {
@@ -12,28 +14,12 @@ class War extends Model
     protected $guarded = [];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function attacker()
-    {
-        return $this->belongsTo(Nation::class, 'att_id');
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function defender()
-    {
-        return $this->belongsTo(Nation::class, 'def_id');
-    }
-
-    /**
-     * @param WarGraphQL|array|\stdClass $war
+     * @param WarGraphQL|array|stdClass $war
      * @return War
      */
-    public static function updateFromAPI(WarGraphQL|array|\stdClass $war): War
+    public static function updateFromAPI(WarGraphQL|array|stdClass $war): War
     {
-        if ($war instanceof WarGraphQL || $war instanceof \stdClass) {
+        if ($war instanceof WarGraphQL || $war instanceof stdClass) {
             $war = (array)$war;
         }
 
@@ -41,7 +27,23 @@ class War extends Model
         $war['end_date'] = isset($war['end_date']) ? Carbon::parse($war['end_date'])->toDateTimeString() : null;
 
         return self::updateOrCreate(['id' => $war['id']], $war);
-//        return self::updateOrCreate(['id' => $war['id']], collect($war)->except(['__typename'])->toArray());
+        //        return self::updateOrCreate(['id' => $war['id']], collect($war)->except(['__typename'])->toArray());
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function attacker()
+    {
+        return $this->belongsTo(Nation::class, 'att_id');
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function defender()
+    {
+        return $this->belongsTo(Nation::class, 'def_id');
     }
 
     /**

--- a/app/Models/WarAidRequest.php
+++ b/app/Models/WarAidRequest.php
@@ -42,21 +42,24 @@ class WarAidRequest extends Model
     /**
      * @return BelongsTo
      */
-    public function nation(): BelongsTo {
+    public function nation(): BelongsTo
+    {
         return $this->belongsTo(Nation::class);
     }
 
     /**
      * @return BelongsTo
      */
-    public function account(): BelongsTo {
+    public function account(): BelongsTo
+    {
         return $this->belongsTo(Account::class);
     }
 
     /**
      * @return bool
      */
-    public function isPending(): bool {
+    public function isPending(): bool
+    {
         return $this->status === 'pending';
     }
 }

--- a/app/Services/LoanService.php
+++ b/app/Services/LoanService.php
@@ -3,8 +3,8 @@
 namespace App\Services;
 
 use App\Models\Account;
-use App\Models\LoanPayment;
 use App\Models\Loan;
+use App\Models\LoanPayment;
 use App\Models\Nation;
 use App\Notifications\LoanNotification;
 use Illuminate\Support\Facades\Auth;

--- a/app/Services/LootCalculatorService.php
+++ b/app/Services/LootCalculatorService.php
@@ -2,15 +2,17 @@
 
 namespace App\Services;
 
-use App\GraphQL\Models\TradePrice;
 use App\GraphQL\Models\War as WarGraphQL;
+use Throwable;
 
 class LootCalculatorService
 {
     /**
      * @param TradePriceService $tradePriceService
      */
-    public function __construct(protected TradePriceService $tradePriceService) {}
+    public function __construct(protected TradePriceService $tradePriceService)
+    {
+    }
 
     /**
      * Calculate total estimated loot value using 24h average prices.
@@ -29,20 +31,20 @@ class LootCalculatorService
 
         foreach ($war->attacks as $attack) {
             try {
-                $value += (int) ($attack->money_looted ?? 0);
-                $value += (int) ($attack->money_stolen ?? 0);
-                $value += (int) (($attack->coal_looted ?? 0) * $prices->coal);
-                $value += (int) (($attack->oil_looted ?? 0) * $prices->oil);
-                $value += (int) (($attack->uranium_looted ?? 0) * $prices->uranium);
-                $value += (int) (($attack->iron_looted ?? 0) * $prices->iron);
-                $value += (int) (($attack->bauxite_looted ?? 0) * $prices->bauxite);
-                $value += (int) (($attack->lead_looted ?? 0) * $prices->lead);
-                $value += (int) (($attack->gasoline_looted ?? 0) * $prices->gasoline);
-                $value += (int) (($attack->munitions_looted ?? 0) * $prices->munitions);
-                $value += (int) (($attack->steel_looted ?? 0) * $prices->steel);
-                $value += (int) (($attack->aluminum_looted ?? 0) * $prices->aluminum);
-                $value += (int) (($attack->food_looted ?? 0) * $prices->food);
-            } catch (\Throwable) {
+                $value += (int)($attack->money_looted ?? 0);
+                $value += (int)($attack->money_stolen ?? 0);
+                $value += (int)(($attack->coal_looted ?? 0) * $prices->coal);
+                $value += (int)(($attack->oil_looted ?? 0) * $prices->oil);
+                $value += (int)(($attack->uranium_looted ?? 0) * $prices->uranium);
+                $value += (int)(($attack->iron_looted ?? 0) * $prices->iron);
+                $value += (int)(($attack->bauxite_looted ?? 0) * $prices->bauxite);
+                $value += (int)(($attack->lead_looted ?? 0) * $prices->lead);
+                $value += (int)(($attack->gasoline_looted ?? 0) * $prices->gasoline);
+                $value += (int)(($attack->munitions_looted ?? 0) * $prices->munitions);
+                $value += (int)(($attack->steel_looted ?? 0) * $prices->steel);
+                $value += (int)(($attack->aluminum_looted ?? 0) * $prices->aluminum);
+                $value += (int)(($attack->food_looted ?? 0) * $prices->food);
+            } catch (Throwable) {
                 continue;
             }
         }

--- a/app/Services/LootCalculatorService.php
+++ b/app/Services/LootCalculatorService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\GraphQL\Models\TradePrice;
+use App\GraphQL\Models\War as WarGraphQL;
+
+class LootCalculatorService
+{
+    /**
+     * @param TradePriceService $tradePriceService
+     */
+    public function __construct(protected TradePriceService $tradePriceService) {}
+
+    /**
+     * Calculate total estimated loot value using 24h average prices.
+     *
+     * @param WarGraphQL $war
+     * @return int
+     */
+    public function calculateFromGraphQLWar(WarGraphQL $war): int
+    {
+        $value = 0;
+        $prices = $this->tradePriceService->get24hAverage();
+
+        if (empty($war->attacks) || !is_iterable($war->attacks)) {
+            return 0;
+        }
+
+        foreach ($war->attacks as $attack) {
+            try {
+                $value += (int) ($attack->money_looted ?? 0);
+                $value += (int) ($attack->money_stolen ?? 0);
+                $value += (int) (($attack->coal_looted ?? 0) * $prices->coal);
+                $value += (int) (($attack->oil_looted ?? 0) * $prices->oil);
+                $value += (int) (($attack->uranium_looted ?? 0) * $prices->uranium);
+                $value += (int) (($attack->iron_looted ?? 0) * $prices->iron);
+                $value += (int) (($attack->bauxite_looted ?? 0) * $prices->bauxite);
+                $value += (int) (($attack->lead_looted ?? 0) * $prices->lead);
+                $value += (int) (($attack->gasoline_looted ?? 0) * $prices->gasoline);
+                $value += (int) (($attack->munitions_looted ?? 0) * $prices->munitions);
+                $value += (int) (($attack->steel_looted ?? 0) * $prices->steel);
+                $value += (int) (($attack->aluminum_looted ?? 0) * $prices->aluminum);
+                $value += (int) (($attack->food_looted ?? 0) * $prices->food);
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return $value;
+    }
+}

--- a/app/Services/RaidFinderService.php
+++ b/app/Services/RaidFinderService.php
@@ -150,7 +150,7 @@ class RaidFinderService
                     'num_cities',
                     'war_policy',
                 ])
-                    ->addNestedField('alliance', fn($b) => $b->addFields(['id', 'name'])
+                    ->addNestedField('alliance', fn($b) => $b->addFields(SelectionSetHelper::allianceSet())
                     )
                     ->addNestedField('wars', function (GraphQLQueryBuilder $b) {
                         $b->addArgument('active', false)

--- a/app/Services/RaidFinderService.php
+++ b/app/Services/RaidFinderService.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Services;
+
+use App\GraphQL\Models\Nation as NationModel;
+use App\Models\Alliance;
+use App\Models\Nation;
+use App\Models\NoRaidList;
+use App\Models\Setting;
+use App\Models\Treaty;
+use Illuminate\Support\Collection;
+
+class RaidFinderService
+{
+    public function __construct(
+        protected TradePriceService $priceService,
+        protected LootCalculatorService $lootCalculator,
+    ) {}
+
+    public function findTargets(int $nationId): Collection
+    {
+        $ownNation = Nation::findOrFail($nationId);
+
+        if ($ownNation->alliance_id !== (int)env("PW_ALLIANCE_ID")) {
+            abort(403, 'Nation does not belong to our alliance.');
+        }
+
+        $noRaidAlliances = NoRaidList::pluck('alliance_id')->toArray();
+        $priceSnapshot = $this->priceService->get24hAverage();
+
+        $minScore = $ownNation->score * 0.75;
+        $maxScore = $ownNation->score * 1.75;
+
+        // Load all raidable nations
+        $nations = $this->queryRaidableNations($minScore, $maxScore);
+
+        $targets = collect();
+
+        foreach ($nations as $nation) {
+            // Filter out invalid targets
+            if (in_array($nation->alliance_id, $noRaidAlliances, true)) {
+                continue;
+            }
+
+            $defensiveWars = 0;
+            $lootTotal = 0;
+            $validWarCount = 0;
+            $lastBeigeValue = null;
+
+            foreach ($nation->wars as $war) {
+                if ($defensiveWars >= 3) break;
+                if ($war->def_id !== $nation->id) continue;
+
+                if ($war->turns_left > 0) {
+                    $defensiveWars++;
+                    continue;
+                }
+
+                if ($war->winner_id === $nation->id) continue;
+
+                $loot = $this->lootCalculator->calculateFromGraphQLWar($war);
+
+                if ($validWarCount === 0) {
+                    $lastBeigeValue = $loot;
+                }
+
+                $lootTotal += $loot;
+                $validWarCount++;
+
+                if ($validWarCount > 10) break;
+            }
+
+            if ($defensiveWars >= 3 || $validWarCount === 0) {
+                continue;
+            }
+
+            $averageLoot = (int) round($lootTotal / $validWarCount);
+
+            $targets->push(collect([
+                'nation' => $nation,
+                'value' => $averageLoot,
+                'defensive_wars' => $defensiveWars,
+                'last_beige' => $lastBeigeValue,
+            ]));
+        }
+
+        return $targets->sortByDesc('value')->values();
+    }
+
+    /**
+     * @param float $minScore
+     * @param float $maxScore
+     * @return Collection
+     */
+    private function queryRaidableNations(float $minScore, float $maxScore): Collection
+    {
+        $raidableAlliances = $this->getRaidableAllianceIDs();
+
+        $query = (new GraphQLQueryBuilder())
+            ->setRootField('nations')
+            ->addArgument('min_score', $minScore)
+            ->addArgument('max_score', $maxScore)
+            ->addArgument('vmode', false)
+            ->addArgument('first', 500)
+            ->addArgument('color', [
+                "aqua", "black", "blue", "brown", "green", "lime", "maroon",
+                "olive", "orange", "pink", "purple", "red", "white", "yellow", "gray"
+            ])
+            ->addArgument('alliance_id', $raidableAlliances)
+            ->addNestedField('paginatorInfo', fn($b) =>
+            $b->addFields(['hasMorePages', 'lastPage', 'currentPage'])
+            )
+            ->addNestedField('data', function (GraphQLQueryBuilder $b) {
+                $b->addFields([
+                    'id',
+                    'leader_name',
+                    'alliance_id',
+                    'alliance_position',
+                    'vmode',
+                    'last_active',
+                    'score',
+                    'num_cities',
+                    'war_policy',
+                ])
+                    ->addNestedField('alliance', fn($b) =>
+                    $b->addFields(['id', 'name'])
+                    )
+                    ->addNestedField('wars', function (GraphQLQueryBuilder $b) {
+                        $b->addArgument('active', false)
+                            ->addArgument('orderBy', [
+                                'column' => 'DATE',
+                                'order' => 'DESC',
+                            ])
+                            ->addFields([
+                                'id',
+                                'date',
+                                'def_id',
+                                'winner_id',
+                                'turns_left',
+                            ])
+                            ->addNestedField('attacks', fn($b) =>
+                            $b->addFields([
+                                'money_looted', 'money_stolen',
+                                'coal_looted', 'oil_looted', 'uranium_looted',
+                                'iron_looted', 'bauxite_looted', 'lead_looted',
+                                'gasoline_looted', 'munitions_looted',
+                                'steel_looted', 'aluminum_looted', 'food_looted',
+                            ])
+                            );
+                    });
+            })
+            ->withPaginationInfo();
+
+        try {
+            $results = (new QueryService())->sendQuery($query);
+        } catch (\Throwable $e) {
+            abort(503, 'PW API error while querying nations: ' . $e->getMessage());
+        }
+
+        $nationModels = collect();
+        foreach ($results as $json) {
+            $nation = new \App\GraphQL\Models\Nation();
+            $nation->buildWithJSON((object) $json);
+            $nationModels->push($nation);
+        }
+
+        return $nationModels;
+    }
+
+    /**
+     * @return array
+     */
+    private function getRaidableAllianceIDs(): array
+    {
+        $topN = SettingService::getTopRaidable(); // Admin configurable
+        $topAlliances = Alliance::orderByDesc('score')->take($topN)->pluck('id')->toArray();
+        $eligibleAlliances = Alliance::whereNotIn('id', $topAlliances)->pluck('id')->toArray();
+        $noRaidList = NoRaidList::pluck('alliance_id')->toArray();
+        $treaties = Treaty::all();
+
+        $raidable = [];
+
+        foreach ($eligibleAlliances as $aid) {
+            if (in_array($aid, $noRaidList)) {
+                continue;
+            }
+
+            $hasTreatyWithTop = $treaties->contains(function ($treaty) use ($aid, $topAlliances) {
+                return (
+                    ($treaty->alliance1_id === $aid && in_array($treaty->alliance2_id, $topAlliances)) ||
+                    ($treaty->alliance2_id === $aid && in_array($treaty->alliance1_id, $topAlliances))
+                );
+            });
+
+            if (! $hasTreatyWithTop) {
+                $raidable[] = $aid;
+            }
+        }
+
+        return array_unique($raidable);
+    }
+}

--- a/app/Services/RaidFinderService.php
+++ b/app/Services/RaidFinderService.php
@@ -12,11 +12,19 @@ use Illuminate\Support\Collection;
 
 class RaidFinderService
 {
+    /**
+     * @param TradePriceService $priceService
+     * @param LootCalculatorService $lootCalculator
+     */
     public function __construct(
         protected TradePriceService $priceService,
         protected LootCalculatorService $lootCalculator,
     ) {}
 
+    /**
+     * @param int $nationId
+     * @return Collection
+     */
     public function findTargets(int $nationId): Collection
     {
         $ownNation = Nation::findOrFail($nationId);

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -84,4 +84,28 @@ class SettingService
         self::setValue("war_aid_enabled", $enabled ? 1 : 0);
     }
 
+    /**
+     * @return int
+     */
+    public static function getTopRaidable(): int
+    {
+        $value = self::getValue("raid_top_alliance_cap");
+
+        if (is_null($value)) {
+            self::setTopRaidable(40); // Default to 40
+            return true;
+        }
+
+        return (int)$value;
+    }
+
+    /**
+     * @param int $topN
+     * @return void
+     */
+    public static function setTopRaidable(int $topN): void
+    {
+        self::setValue("raid_top_alliance_cap", $topN);
+    }
+
 }

--- a/app/Services/TradePriceService.php
+++ b/app/Services/TradePriceService.php
@@ -8,7 +8,7 @@ use App\Models\TradePrice;
 class TradePriceService
 {
     /**
-     * Return the most recent row from the database.
+     * @return TradePrice
      */
     public function getLatest(): TradePrice
     {
@@ -16,7 +16,7 @@ class TradePriceService
     }
 
     /**
-     * Calculate the average of each resource across the last 24 rows (i.e., ~24 hours).
+     * @return TradePrice
      */
     public function get24hAverage(): TradePrice
     {
@@ -31,7 +31,9 @@ class TradePriceService
     }
 
     /**
-     * Pull the latest trade prices from the Politics & War GraphQL API.
+     * @return TradePriceGraphQL
+     * @throws \App\Exceptions\PWQueryFailedException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function pullFromGraphQL(): TradePriceGraphQL
     {

--- a/app/Services/TradePriceService.php
+++ b/app/Services/TradePriceService.php
@@ -2,8 +2,10 @@
 
 namespace App\Services;
 
+use App\Exceptions\PWQueryFailedException;
 use App\GraphQL\Models\TradePrice as TradePriceGraphQL;
 use App\Models\TradePrice;
+use Illuminate\Http\Client\ConnectionException;
 
 class TradePriceService
 {
@@ -24,7 +26,7 @@ class TradePriceService
 
         $avg = new TradePrice();
         foreach (PWHelperService::resources(includeCredits: true) as $resource) {
-            $avg->{$resource} = (int) round($rows->avg($resource));
+            $avg->{$resource} = (int)round($rows->avg($resource));
         }
 
         return $avg;
@@ -32,15 +34,15 @@ class TradePriceService
 
     /**
      * @return TradePriceGraphQL
-     * @throws \App\Exceptions\PWQueryFailedException
-     * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws PWQueryFailedException
+     * @throws ConnectionException
      */
     public function pullFromGraphQL(): TradePriceGraphQL
     {
         $query = (new GraphQLQueryBuilder())
             ->setRootField('tradeprices')
             ->addArgument('first', 1)
-            ->addNestedField('data', function(GraphQLQueryBuilder $builder) {
+            ->addNestedField('data', function (GraphQLQueryBuilder $builder) {
                 $builder->addFields([
                     'id',
                     'date',
@@ -62,7 +64,7 @@ class TradePriceService
         $response = (new QueryService())->sendQuery($query);
 
         $model = new TradePriceGraphQL();
-        $model->buildWithJSON((object) $response->{0});
+        $model->buildWithJSON((object)$response->{0});
 
         return $model;
     }

--- a/app/Services/TradePriceService.php
+++ b/app/Services/TradePriceService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services;
+
+use App\GraphQL\Models\TradePrice as TradePriceGraphQL;
+use App\Models\TradePrice;
+
+class TradePriceService
+{
+    /**
+     * Return the most recent row from the database.
+     */
+    public function getLatest(): TradePrice
+    {
+        return TradePrice::latest('created_at')->firstOrFail();
+    }
+
+    /**
+     * Calculate the average of each resource across the last 24 rows (i.e., ~24 hours).
+     */
+    public function get24hAverage(): TradePrice
+    {
+        $rows = TradePrice::latest('created_at')->take(24)->get();
+
+        $avg = new TradePrice();
+        foreach (PWHelperService::resources(includeCredits: true) as $resource) {
+            $avg->{$resource} = (int) round($rows->avg($resource));
+        }
+
+        return $avg;
+    }
+
+    /**
+     * Pull the latest trade prices from the Politics & War GraphQL API.
+     */
+    public function pullFromGraphQL(): TradePriceGraphQL
+    {
+        $query = (new GraphQLQueryBuilder())
+            ->setRootField('tradeprices')
+            ->addArgument('first', 1)
+            ->addNestedField('data', function(GraphQLQueryBuilder $builder) {
+                $builder->addFields([
+                    'id',
+                    'date',
+                    'coal',
+                    'oil',
+                    'uranium',
+                    'iron',
+                    'bauxite',
+                    'lead',
+                    'gasoline',
+                    'munitions',
+                    'steel',
+                    'aluminum',
+                    'food',
+                    'credits'
+                ]);
+            });
+
+        $response = (new QueryService())->sendQuery($query);
+
+        $model = new TradePriceGraphQL();
+        $model->buildWithJSON((object) $response->{0});
+
+        return $model;
+    }
+}

--- a/app/Services/WarQueryService.php
+++ b/app/Services/WarQueryService.php
@@ -7,15 +7,22 @@ use App\GraphQL\Models\Wars;
 
 class WarQueryService
 {
-    public static function getMultipleWars(array $arguments, int $perPage = 1000, bool $pagination = true, bool $handlePagination = true): Wars
-    {
+    public static function getMultipleWars(
+        array $arguments,
+        int $perPage = 1000,
+        bool $pagination = true,
+        bool $handlePagination = true
+    ): Wars {
         $client = new QueryService();
 
         $builder = (new GraphQLQueryBuilder())
             ->setRootField("wars")
             ->addArgument('first', $perPage)
             ->addArgument($arguments)
-            ->addNestedField("data", fn(GraphQLQueryBuilder $builder) => $builder->addFields(SelectionSetHelper::warSet()));
+            ->addNestedField(
+                "data",
+                fn(GraphQLQueryBuilder $builder) => $builder->addFields(SelectionSetHelper::warSet())
+            );
 
         if ($pagination) {
             $builder->withPaginationInfo();

--- a/database/migrations/2025_04_13_163442_add_trade_prices_table.php
+++ b/database/migrations/2025_04_13_163442_add_trade_prices_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('trade_prices', function (Blueprint $table) {
+            $table->id();
+            $table->date('date');
+            $table->integer('coal');
+            $table->integer('oil');
+            $table->integer('uranium');
+            $table->integer('iron');
+            $table->integer('bauxite');
+            $table->integer('lead');
+            $table->integer('gas');
+            $table->integer('munitions');
+            $table->integer('steel');
+            $table->integer('aluminum');
+            $table->integer('food');
+            $table->integer('credits');
+            $table->timestamps();
+
+            $table->index('created_at', 'idx_created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('trade_prices');
+    }
+};

--- a/database/migrations/2025_04_13_163600_create_no_raid_list_table.php
+++ b/database/migrations/2025_04_13_163600_create_no_raid_list_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('no_raid_list', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('alliance_id')->unique()->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('no_raid_list');
+    }
+};

--- a/database/migrations/2025_04_13_165054_create_treaties_table.php
+++ b/database/migrations/2025_04_13_165054_create_treaties_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('treaties', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('pw_id')->unique();
+            $table->dateTime('pw_date');
+            $table->integer('turns_left');
+            $table->unsignedInteger('alliance1_id');
+            $table->unsignedInteger('alliance2_id');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('treaties');
+    }
+};

--- a/resources/views/accounts/components/account_overview.blade.php
+++ b/resources/views/accounts/components/account_overview.blade.php
@@ -1,10 +1,11 @@
+@php use App\Services\PWHelperService; @endphp
 <x-utils.card title="Accounts" extraClasses="mb-2">
     <div class="overflow-x-auto">
         <table class="table w-full table-zebra">
             <thead>
             <tr>
                 <th class="text-left">Account Name</th>
-                @foreach (\App\Services\PWHelperService::resources() as $resource)
+                @foreach (PWHelperService::resources() as $resource)
                     <th class="text-left">{{ ucfirst($resource) }}</th>
                 @endforeach
             </tr>
@@ -27,7 +28,7 @@
                         </div>
                     </td>
                     <td>${{ number_format($account->money, 2) }}</td>
-                    @foreach (\App\Services\PWHelperService::resources(false) as $resource)
+                    @foreach (PWHelperService::resources(false) as $resource)
                         <td>{{ number_format($account->$resource, 2) }}</td>
                     @endforeach
                 </tr>

--- a/resources/views/accounts/components/transfer.blade.php
+++ b/resources/views/accounts/components/transfer.blade.php
@@ -1,3 +1,4 @@
+@php use App\Services\PWHelperService; @endphp
 <x-utils.card title="Transfer" extraClasses="mb-2">
     <form method="POST" action="/accounts/transfer">
         @csrf <!-- Include CSRF token if using Laravel -->
@@ -10,7 +11,7 @@
                     <optgroup label="Accounts">
                         @foreach ($accounts as $account)
                             <option value="{{ $account->id }}"
-                                    @foreach (\App\Services\PWHelperService::resources() as $resource)
+                                    @foreach (PWHelperService::resources() as $resource)
                                         data-{{ $resource }}="{{ $account->$resource }}"
                                     @endforeach >
                                 {{ $account->name }} - ${{ number_format($account->money) }}
@@ -48,7 +49,7 @@
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" id="resource-fields">
-            @foreach(\App\Services\PWHelperService::resources() as $resource)
+            @foreach(PWHelperService::resources() as $resource)
                 <div class="form-control">
                     <label for="{{ $resource }}" class="label font-semibold">
                         {{ ucfirst($resource) }}

--- a/resources/views/accounts/view.blade.php
+++ b/resources/views/accounts/view.blade.php
@@ -1,3 +1,4 @@
+@php use App\Services\PWHelperService; @endphp
 @extends('layouts.main')
 
 @section("content")
@@ -19,7 +20,7 @@
             <table class="table w-full table-zebra">
                 <thead>
                 <tr>
-                    @foreach(\App\Services\PWHelperService::resources() as $resource)
+                    @foreach(PWHelperService::resources() as $resource)
                         <th class="text-left">{{ ucfirst($resource) }}</th>
                     @endforeach
                 </tr>
@@ -27,7 +28,7 @@
                 <tbody>
                 <tr class="hover">
                     <td>${{ number_format($account->money, 2) }}</td>
-                    @foreach(\App\Services\PWHelperService::resources(false) as $resource)
+                    @foreach(PWHelperService::resources(false) as $resource)
                         <td>{{ number_format($account->$resource, 2) }}</td>
                     @endforeach
                 </tr>
@@ -123,7 +124,7 @@
 
                         <td>{{ ucfirst($transaction->transaction_type) }}</td>
                         <td>${{ number_format($transaction->money, 2) }}</td>
-                        @foreach(\App\Services\PWHelperService::resources(false) as $resource)
+                        @foreach(PWHelperService::resources(false) as $resource)
                             <td>{{ number_format($transaction->$resource, 2) }}</td>
                         @endforeach
                     </tr>

--- a/resources/views/admin/accounts/dashboard.blade.php
+++ b/resources/views/admin/accounts/dashboard.blade.php
@@ -99,7 +99,7 @@
                     searchPlaceholder: "Search accounts..."
                 },
                 columnDefs: [
-                    { targets: "_all", className: "align-middle" }
+                    {targets: "_all", className: "align-middle"}
                 ]
             });
         });

--- a/resources/views/admin/accounts/view.blade.php
+++ b/resources/views/admin/accounts/view.blade.php
@@ -1,4 +1,4 @@
-@php use App\Services\AccountService; @endphp
+@php use App\Services\AccountService;use App\Services\PWHelperService; @endphp
 @extends('layouts.admin')
 
 @section("content")
@@ -23,7 +23,7 @@
                         <table class="table table-hover">
                             <thead>
                             <tr>
-                                @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                @foreach(PWHelperService::resources() as $resource)
                                     <th>{{ ucfirst($resource) }}</th>
                                 @endforeach
                             </tr>
@@ -31,7 +31,7 @@
                             <tbody>
                             <tr>
                                 <td>${{ number_format($account->money, 2) }}</td>
-                                @foreach(\App\Services\PWHelperService::resources(false) as $resource)
+                                @foreach(PWHelperService::resources(false) as $resource)
                                     <td>{{ number_format($account->$resource, 2) }}</td>
                                 @endforeach
                             </tr>
@@ -51,7 +51,7 @@
                     <form action="{{ route('admin.accounts.adjust', $account->id) }}" method="POST">
                         @csrf
                         <div class="row">
-                            @foreach (\App\Services\PWHelperService::resources() as $resource)
+                            @foreach (PWHelperService::resources() as $resource)
                                 <div class="col-md-3">
                                     <label for="{{ $resource }}">{{ ucfirst($resource) }}</label>
                                     <input type="number" name="{{ $resource }}" id="{{ $resource }}"
@@ -84,7 +84,7 @@
                                 <th>From Account</th>
                                 <th>To Account</th>
                                 <th>Type</th>
-                                @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                @foreach(PWHelperService::resources() as $resource)
                                     <th>{{ ucfirst($resource) }}</th>
                                 @endforeach
                             </tr>
@@ -137,7 +137,7 @@
 
                                     <td>{{ ucfirst($transaction->transaction_type) }}</td>
                                     <td>${{ number_format($transaction->money, 2) }}</td>
-                                    @foreach(\App\Services\PWHelperService::resources(false) as $resource)
+                                    @foreach(PWHelperService::resources(false) as $resource)
                                         <td>{{ number_format($transaction->$resource, 2) }}</td>
                                     @endforeach
                                 </tr>
@@ -161,7 +161,7 @@
                             <tr>
                                 <th>Date</th>
                                 <th>Admin</th>
-                                @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                @foreach(PWHelperService::resources() as $resource)
                                     <th>{{ ucfirst($resource) }}</th>
                                 @endforeach
                                 <th>Note</th>
@@ -179,7 +179,7 @@
                                         @endif
                                     </td>
                                     <td>${{ number_format($transaction->money, 2) }}</td>
-                                    @foreach(\App\Services\PWHelperService::resources(false) as $resource)
+                                    @foreach(PWHelperService::resources(false) as $resource)
                                         <td>{{ number_format($transaction->$resource, 2) }}</td>
                                     @endforeach
                                     <td>

--- a/resources/views/admin/components/navbar.blade.php
+++ b/resources/views/admin/components/navbar.blade.php
@@ -1,6 +1,6 @@
 @php
     use Carbon\Carbon;
-    use App\Models\Grants;
+    use App\Models\Grants;use Illuminate\Support\Facades\Auth;
 
     $enabledGrants = \Auth::check()
         ? Grants::where('is_enabled', true)->orderBy('name')->get()
@@ -56,15 +56,19 @@
         <ul class="navbar-nav ms-auto">
             <li class="nav-item dropdown user-menu">
                 <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">
-                    <img src="{{ Auth::user()->nation->flag }}" class="user-image rounded-circle shadow" alt="Nation Flag" style="object-fit: cover;">
+                    <img src="{{ Auth::user()->nation->flag }}" class="user-image rounded-circle shadow"
+                         alt="Nation Flag" style="object-fit: cover;">
                     <span class="d-none d-md-inline">{{ Auth::user()->nation->leader_name }}</span>
                 </a>
                 <ul class="dropdown-menu dropdown-menu-lg dropdown-menu-end">
                     <li class="user-header text-bg-primary">
-                        <img src="{{ Auth::user()->nation->flag }}" class="rounded-circle shadow" alt="Nation Flag" style="object-fit: cover;">
+                        <img src="{{ Auth::user()->nation->flag }}" class="rounded-circle shadow" alt="Nation Flag"
+                             style="object-fit: cover;">
                         <p>
-                            {{ Auth::user()->nation->leader_name }} — {{ Auth::user()->nation->alliance_position ?? 'Member' }}
-                            <small>Member since {{ Carbon::now()->subDays(Auth::user()->nation->alliance_seniority)->toFormattedDateString() }}</small>
+                            {{ Auth::user()->nation->leader_name }}
+                            — {{ Auth::user()->nation->alliance_position ?? 'Member' }}
+                            <small>Member
+                                since {{ Carbon::now()->subDays(Auth::user()->nation->alliance_seniority)->toFormattedDateString() }}</small>
                         </p>
                     </li>
                     <li class="user-body">
@@ -84,7 +88,8 @@
                         </div>
                     </li>
                     <li class="user-footer">
-                        <a href="{{ route('admin.members.show', \Illuminate\Support\Facades\Auth::user()->nation_id) }}" class="btn btn-default btn-flat">Profile</a>
+                        <a href="{{ route('admin.members.show', Auth::user()->nation_id) }}"
+                           class="btn btn-default btn-flat">Profile</a>
                         <a class="btn btn-default btn-flat float-end"
                            onclick="event.preventDefault(); document.getElementById('admin-logout-form').submit();">Logout</a>
                     </li>

--- a/resources/views/admin/components/navbar.blade.php
+++ b/resources/views/admin/components/navbar.blade.php
@@ -47,6 +47,7 @@
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item" href="{{ route('defense.counters') }}">Counter Finder</a></li>
                         <li><a class="dropdown-item" href="{{ route('defense.war-aid') }}">War Aid</a></li>
+                        <li><a class="dropdown-item" href="{{ route('defense.raid-finder') }}">Raid Finder</a></li>
                     </ul>
                 </li>
             @endif

--- a/resources/views/admin/components/sidebar.blade.php
+++ b/resources/views/admin/components/sidebar.blade.php
@@ -59,8 +59,14 @@
                 </li>
                 <li class="nav-item">
                     <a href="{{ route('admin.war-aid') }}" class="nav-link">
-                        <i class="bi bi-speedometer"></i>
+                        <i class="bi bi-wallet-fill"></i>
                         <p>War Aid</p>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="{{ route('admin.raids.index') }}" class="nav-link">
+                        <i class="bi bi-currency-exchange"></i>
+                        <p>Raids</p>
                     </a>
                 </li>
                 <li class="nav-header">System</li>

--- a/resources/views/admin/defense/raids.blade.php
+++ b/resources/views/admin/defense/raids.blade.php
@@ -5,7 +5,7 @@
         <div class="container-fluid">
             <div class="row">
                 <div class="col-sm-6">
-                    <h3 class="mb-0">Raid Finder Admin</h3>
+                    <h3 class="mb-0">Raid Finder</h3>
                 </div>
             </div>
         </div>

--- a/resources/views/admin/defense/raids.blade.php
+++ b/resources/views/admin/defense/raids.blade.php
@@ -1,0 +1,81 @@
+@extends('layouts.admin')
+
+@section("content")
+    <div class="app-content-header">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-sm-6">
+                    <h3 class="mb-0">Raid Finder Admin</h3>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- Top Alliance Cap --}}
+    <div class="card mt-4">
+        <div class="card-header">Top Alliance Cap</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('admin.raids.top-cap.update') }}" class="row g-3 align-items-center">
+                @csrf
+                <div class="col-auto">
+                    <label for="top_cap" class="col-form-label">Exclude Top</label>
+                </div>
+                <div class="col-auto">
+                    <input type="number" class="form-control" name="top_cap" id="top_cap"
+                           value="{{ $topCap }}" min="1" max="100" required>
+                </div>
+                <div class="col-auto">
+                    <label class="col-form-label">alliances from raids</label>
+                </div>
+                <div class="col-auto">
+                    <button class="btn btn-success btn-sm" type="submit">Update</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {{-- No-Raid Alliance List --}}
+    <div class="card mt-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span>No-Raid Alliance List</span>
+            <form method="POST" action="{{ route('admin.raids.no-raid.store') }}" class="d-flex align-items-center">
+                @csrf
+                <input type="number" class="form-control me-2" name="alliance_id" placeholder="Alliance ID" required>
+                <button class="btn btn-primary btn-sm" type="submit">Add</button>
+            </form>
+        </div>
+        <div class="card-body p-0">
+            <table class="table table-sm table-striped mb-0">
+                <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Alliance ID</th>
+                    <th>Alliance Name</th>
+                    <th>Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                @forelse($noRaidList as $entry)
+                    <tr>
+                        <td>{{ $entry->id }}</td>
+                        <td>{{ $entry->alliance_id }}</td>
+                        <td><a href="https://politicsandwar.com/alliance/id={{ $entry->alliance_id }}" target="-_blank">{{ $entry->alliance->name}}</a></td>
+                        <td>
+                            <form method="POST" action="{{ route('admin.raids.no-raid.destroy', $entry->id) }}"
+                                  onsubmit="return confirm('Are you sure you want to remove this alliance?')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="3" class="text-center text-muted">No entries in no-raid list.</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/defense/war-aid.blade.php
+++ b/resources/views/admin/defense/war-aid.blade.php
@@ -1,3 +1,4 @@
+@php use App\Services\PWHelperService; @endphp
 @extends('layouts.admin')
 
 @section('content')
@@ -55,10 +56,11 @@
                                         </div>
 
                                         <div class="row g-2">
-                                            @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                            @foreach(PWHelperService::resources() as $resource)
                                                 <div class="col-md-3 col-sm-4 col-6">
                                                     <label class="form-label">{{ ucfirst($resource) }}</label>
-                                                    <input type="number" name="{{ $resource }}" class="form-control form-control-sm"
+                                                    <input type="number" name="{{ $resource }}"
+                                                           class="form-control form-control-sm"
                                                            min="0" value="{{ $req->$resource }}">
                                                     <small class="text-muted">
                                                         Has: {{ number_format(($req->nation->resources->$resource ?? 0) + $req->nation->accounts->sum($resource)) }}
@@ -105,7 +107,8 @@
                             @forelse ($history as $req)
                                 <tr>
                                     <td>
-                                        <a href="https://politicsandwar.com/nation/id={{ $req->nation->id }}" target="_blank">
+                                        <a href="https://politicsandwar.com/nation/id={{ $req->nation->id }}"
+                                           target="_blank">
                                             {{ $req->nation->leader_name }}
                                         </a>
                                     </td>
@@ -122,7 +125,7 @@
                                     </td>
                                     <td>{{ number_format($req->money) }}</td>
                                     <td>
-                                        @foreach(\App\Services\PWHelperService::resources(false, false, true) as $res)
+                                        @foreach(PWHelperService::resources(false, false, true) as $res)
                                             @if($req->$res > 0)
                                                 <span class="badge bg-secondary">{{ ucfirst($res) }}: {{ $req->$res }}</span>
                                             @endif
@@ -131,7 +134,9 @@
                                     <td>{{ $req->created_at->format('M d, Y H:i') }}</td>
                                 </tr>
                             @empty
-                                <tr><td colspan="7" class="text-center text-muted">No previous requests.</td></tr>
+                                <tr>
+                                    <td colspan="7" class="text-center text-muted">No previous requests.</td>
+                                </tr>
                             @endforelse
                             </tbody>
                         </table>

--- a/resources/views/admin/grants/grants.blade.php
+++ b/resources/views/admin/grants/grants.blade.php
@@ -1,3 +1,4 @@
+@php use App\Services\PWHelperService; @endphp
 @extends('layouts.admin')
 
 @section("content")
@@ -115,7 +116,7 @@
                     <tr class="collapse" id="resources-{{ $grant->id }}">
                         <td colspan="6">
                             <div class="d-flex flex-wrap gap-2">
-                                @foreach (\App\Services\PWHelperService::resources() as $res)
+                                @foreach (PWHelperService::resources() as $res)
                                     @if ($grant->$res > 0)
                                         <span class="badge text-bg-light border">
                             <strong>{{ ucfirst($res) }}:</strong> {{ number_format($grant->$res) }}
@@ -168,7 +169,7 @@
 
                         {{-- Resources --}}
                         <div class="row">
-                            @foreach (\App\Services\PWHelperService::resources(false) as $resource)
+                            @foreach (PWHelperService::resources(false) as $resource)
                                 <div class="col-md-4 mb-3">
                                     <label class="form-label text-capitalize">{{ $resource }}</label>
                                     <input type="number" class="form-control" name="{{ $resource }}"

--- a/resources/views/admin/wars.blade.php
+++ b/resources/views/admin/wars.blade.php
@@ -142,7 +142,8 @@
                                 {{ $war->attacker->leader_name ?? 'Unknown' }}
                             </a>
                             @if($war->attacker && $war->attacker->alliance)
-                                (<a href="https://politicsandwar.com/alliance/id={{ $war->attacker->alliance->id }}" target="_blank">
+                                (<a href="https://politicsandwar.com/alliance/id={{ $war->attacker->alliance->id }}"
+                                    target="_blank">
                                     {{ $war->attacker->alliance->name }}
                                 </a>)
                             @endif
@@ -152,7 +153,8 @@
                                 {{ $war->defender->leader_name ?? 'Unknown' }}
                             </a>
                             @if($war->defender && $war->defender->alliance)
-                                (<a href="https://politicsandwar.com/alliance/id={{ $war->defender->alliance->id }}" target="_blank">
+                                (<a href="https://politicsandwar.com/alliance/id={{ $war->defender->alliance->id }}"
+                                    target="_blank">
                                     {{ $war->defender->alliance->name }}
                                 </a>)
                             @endif
@@ -226,7 +228,7 @@
             options: {
                 responsive: true,
                 scales: {
-                    y: { beginAtZero: true }
+                    y: {beginAtZero: true}
                 }
             }
         });
@@ -256,7 +258,7 @@
             },
             options: {
                 scales: {
-                    y: { beginAtZero: true }
+                    y: {beginAtZero: true}
                 }
             }
         });
@@ -276,7 +278,7 @@
             options: {
                 indexAxis: 'y',
                 scales: {
-                    x: { beginAtZero: true }
+                    x: {beginAtZero: true}
                 }
             }
         });

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,3 +1,4 @@
+@php use Carbon\Carbon; @endphp
 <footer class="bg-neutral text-neutral-content px-6 py-10">
     <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
         <!-- Brand / Logo Section -->
@@ -42,7 +43,7 @@
 
         <!-- Right: Time -->
         <div class="text-sm opacity-60 text-right">
-            <p>Server time: {{ \Carbon\Carbon::now()->toDayDateTimeString() }}</p>
+            <p>Server time: {{ Carbon::now()->toDayDateTimeString() }}</p>
         </div>
     </div>
 </footer>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -42,6 +42,7 @@
                             <ul class="p-2">
                                 <li><a href="{{ route("defense.counters") }}">Counter Finder</a></li>
                                 <li><a href="{{ route("defense.war-aid") }}">War Aid</a></li>
+                                <li><a href="{{ route("defense.raid-finder") }}">Raid Finder</a></li>
                             </ul>
                         </li>
                     </ul>
@@ -87,6 +88,7 @@
                             <ul class="absolute left-0 mt-2 w-64 menu bg-base-100 p-2 shadow rounded-box z-[1]">
                                 <li><a href="{{ route("defense.counters") }}">Counter Finder</a></li>
                                 <li><a href="{{ route("defense.war-aid") }}">War Aid</a></li>
+                                <li><a href="{{ route("defense.raid-finder") }}">Raid Finder</a></li>
                             </ul>
                         </details>
                     </li>

--- a/resources/views/defense/counters.blade.php
+++ b/resources/views/defense/counters.blade.php
@@ -47,9 +47,11 @@
             <div class="card bg-base-100 shadow-md border border-base-300">
                 <div class="card-body">
                     <h2 class="card-title items-center gap-3">
-                        <img src="{{ $target->flag }}" alt="Flag of {{ $target->leader_name }}" class="w-8 h-5 rounded border border-base-300" />
+                        <img src="{{ $target->flag }}" alt="Flag of {{ $target->leader_name }}"
+                             class="w-8 h-5 rounded border border-base-300"/>
                         <div>
-                            <a href="https://politicsandwar.com/nation/id={{ $target->id }}" target="_blank" class="link link-hover text-info font-semibold">
+                            <a href="https://politicsandwar.com/nation/id={{ $target->id }}" target="_blank"
+                               class="link link-hover text-info font-semibold">
                                 {{ $target->leader_name }} of {{ $target->nation_name }}
                             </a>
                             <span class="badge badge-outline badge-info text-xs ml-2">ID: {{ $target->id }}</span>
@@ -135,7 +137,8 @@
                     @forelse($nations as $nation)
                         <tr class="{{ $target && !$nation->in_range ? 'opacity-40' : (strtolower($nation->color) === 'beige' ? 'bg-warning/30' : '') }}">
                             <td>
-                                <a href="https://politicsandwar.com/nation/id={{ $nation->id }}" target="_blank" class="link link-hover text-info font-semibold">
+                                <a href="https://politicsandwar.com/nation/id={{ $nation->id }}" target="_blank"
+                                   class="link link-hover text-info font-semibold">
                                     {{ $nation->leader_name }}
                                 </a>
                             </td>
@@ -151,7 +154,8 @@
                                 <td>
                                     @if($nation->in_range)
                                         <div class="flex items-center gap-2">
-                                            <progress class="progress progress-primary w-24" value="{{ $nation->match_score }}" max="100"></progress>
+                                            <progress class="progress progress-primary w-24"
+                                                      value="{{ $nation->match_score }}" max="100"></progress>
                                             <span class="text-sm font-semibold">{{ $nation->match_score }}</span>
                                         </div>
                                     @else

--- a/resources/views/defense/raid-finder.blade.php
+++ b/resources/views/defense/raid-finder.blade.php
@@ -9,7 +9,7 @@
 
         <div class="mb-4">
             <label for="nationId" class="label">Enter Nation ID</label>
-            <input id="nationId" type="number" class="input input-bordered w-full max-w-xs" x-model="nationId" />
+            <input id="nationId" type="number" class="input input-bordered w-full max-w-xs" x-model="nationId"/>
             <button class="btn btn-primary ml-2" @click="loadRaids()">Refresh</button>
         </div>
 

--- a/resources/views/defense/raid-finder.blade.php
+++ b/resources/views/defense/raid-finder.blade.php
@@ -1,11 +1,13 @@
 @extends('layouts.main')
 
 @section('content')
+    <div class="prose w-full max-w-none mb-5">
+        <h1 class="text-center flex items-center justify-center gap-2">
+            Raid Finder
+        </h1>
+    </div>
+
     <div class="max-w-7xl mx-auto px-4 py-6" x-data="raidFinder()" x-init="loadRaids()">
-        <div class="mb-6">
-            <h1 class="text-3xl font-bold">Raid Finder</h1>
-            <p class="text-sm text-gray-500">Scanning for juicy targets... 💸</p>
-        </div>
 
         <div class="mb-4">
             <label for="nationId" class="label">Enter Nation ID</label>

--- a/resources/views/defense/raid-finder.blade.php
+++ b/resources/views/defense/raid-finder.blade.php
@@ -1,0 +1,106 @@
+@extends('layouts.main')
+
+@section('content')
+    <div class="max-w-7xl mx-auto px-4 py-6" x-data="raidFinder()" x-init="loadRaids()">
+        <div class="mb-6">
+            <h1 class="text-3xl font-bold">Raid Finder</h1>
+            <p class="text-sm text-gray-500">Scanning for juicy targets... 💸</p>
+        </div>
+
+        <div class="mb-4">
+            <label for="nationId" class="label">Enter Nation ID</label>
+            <input id="nationId" type="number" class="input input-bordered w-full max-w-xs" x-model="nationId" />
+            <button class="btn btn-primary ml-2" @click="loadRaids()">Refresh</button>
+        </div>
+
+        <!-- Loading spinner -->
+        <div x-show="loading" class="flex justify-center items-center py-10">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+        </div>
+
+        <!-- Table -->
+        <div x-show="!loading" x-cloak>
+            <div class="overflow-x-auto">
+                <table class="table table-zebra w-full text-sm">
+                    <thead>
+                    <tr>
+                        <th>Leader</th>
+                        <th>Alliance</th>
+                        <th>Cities</th>
+                        <th>Last Active</th>
+                        <th>Score</th>
+                        <th>Wars</th>
+                        <th>War Policy</th>
+                        <th>Est. Loot</th>
+                        <th>Last Beige</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <template x-for="target in targets" :key="target.nation.id">
+                        <tr>
+                            <td>
+                                <a :href="`https://politicsandwar.com/nation/id=${target.nation.id}`"
+                                   class="link link-hover text-primary font-semibold"
+                                   x-text="target.nation.leader_name"></a>
+                            </td>
+                            <td x-text="target.nation.alliance?.name ?? 'None'"></td>
+                            <td x-text="target.nation.num_cities"></td>
+                            <td x-text="target.nation.last_active"></td>
+                            <td x-text="target.nation.score.toFixed(2)"></td>
+                            <td x-text="target.defensive_wars"></td>
+                            <td x-text="target.nation.war_policy"></td>
+                            <td x-text="formatMoney(target.value)"></td>
+                            <td x-text="formatMoney(target.last_beige ?? 0)"></td>
+                        </tr>
+                    </template>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function raidFinder() {
+            return {
+                nationId: Number('{{ $nationId }}'),
+                loading: true,
+                targets: [],
+
+                loadRaids() {
+                    this.loading = true;
+
+                    // Step 1: CSRF for Sanctum
+                    fetch('/sanctum/csrf-cookie', {
+                        method: 'GET',
+                        credentials: 'include'
+                    }).then(() => {
+                        // Step 2: fetch raid targets
+                        return fetch(`/api/v1/defense/raid-finder/${this.nationId}`, {
+                            method: 'GET',
+                            credentials: 'include',
+                            headers: {
+                                'Accept': 'application/json'
+                            }
+                        });
+                    })
+                        .then(res => {
+                            if (!res.ok) throw new Error('Failed to load raid targets');
+                            return res.json();
+                        })
+                        .then(data => {
+                            this.targets = data;
+                        })
+                        .catch(err => {
+                            alert('Failed to fetch raid targets');
+                            console.error(err);
+                        })
+                        .finally(() => this.loading = false);
+                },
+
+                formatMoney(value) {
+                    return `$${Number(value).toLocaleString()}`;
+                }
+            }
+        }
+    </script>
+@endsection

--- a/resources/views/defense/raid-finder.blade.php
+++ b/resources/views/defense/raid-finder.blade.php
@@ -30,7 +30,6 @@
                         <th>Last Active</th>
                         <th>Score</th>
                         <th>Wars</th>
-                        <th>War Policy</th>
                         <th>Est. Loot</th>
                         <th>Last Beige</th>
                     </tr>
@@ -48,7 +47,6 @@
                             <td x-text="target.nation.last_active"></td>
                             <td x-text="target.nation.score.toFixed(2)"></td>
                             <td x-text="target.defensive_wars"></td>
-                            <td x-text="target.nation.war_policy"></td>
                             <td x-text="formatMoney(target.value)"></td>
                             <td x-text="formatMoney(target.last_beige ?? 0)"></td>
                         </tr>

--- a/resources/views/defense/war-aid.blade.php
+++ b/resources/views/defense/war-aid.blade.php
@@ -1,3 +1,4 @@
+@php use App\Services\PWHelperService; @endphp
 @extends('layouts.main')
 
 @inject('settings', 'App\Services\SettingService')
@@ -32,19 +33,19 @@
                     <table class="table w-full">
                         <thead>
                         <tr>
-                            <th>Attacker</th>
-                            <th>Defender</th>
+                            <th>Enemy</th>
                             <th>Type</th>
                             <th>Status</th>
+                            <th>Start</th>
                         </tr>
                         </thead>
                         <tbody>
                         @foreach ($wars as $war)
                             <tr>
-                                <td><a class="link-primary" href="https://politicsandwar.com/nation/id={{ $war->attacker->id }}" target="_blank">{{ $war->attacker->leader_name ?? "N/A" }}</td>
-                                <td><a class="link-primary" href="https://politicsandwar.com/nation/id={{ $war->defender->id }}" target="_blank">{{ $war->defender->leader_name ?? "N/A" }}</td>
-                                <td>{{ $war->war_type }}</td>
-                                <td>{{ $war->date }}</td>
+                                <td>{{ $war->opponent_name }}</td>
+                                <td>{{ ucfirst($war->war_type) }}</td>
+                                <td>{{ $war->status }}</td>
+                                <td>{{ $war->start_date->format('M d, Y H:i') }}</td>
                             </tr>
                         @endforeach
                         </tbody>
@@ -76,7 +77,7 @@
                             </td>
                             <td>{{ number_format($req->money) }}</td>
                             <td>
-                                @foreach(\App\Services\PWHelperService::resources(false, false, true) as $resource)
+                                @foreach(PWHelperService::resources(false, false, true) as $resource)
                                     @if($req->$resource > 0)
                                         <span class="badge badge-outline">{{ ucfirst($resource) }}: {{ $req->$resource }}</span>
                                     @endif
@@ -84,7 +85,9 @@
                             </td>
                         </tr>
                     @empty
-                        <tr><td colspan="5" class="text-center text-gray-500">No previous requests.</td></tr>
+                        <tr>
+                            <td colspan="5" class="text-center text-gray-500">No previous requests.</td>
+                        </tr>
                     @endforelse
                     </tbody>
                 </table>
@@ -115,17 +118,20 @@
                     </div>
 
                     <div class="grid grid-cols-2 gap-2 mt-4">
-                        @foreach(\App\Services\PWHelperService::resources() as $resource)
+                        @foreach(PWHelperService::resources() as $resource)
                             <div>
                                 <label class="label">{{ ucfirst($resource) }}</label>
-                                <input type="number" name="{{ $resource }}" class="input input-bordered w-full" min="0" value="0">
+                                <input type="number" name="{{ $resource }}" class="input input-bordered w-full" min="0"
+                                       value="0">
                             </div>
                         @endforeach
                     </div>
 
                     <div class="modal-action">
                         <button type="submit" class="btn btn-primary">Submit</button>
-                        <button type="button" class="btn" onclick="document.getElementById('aid-request-modal').close()">Cancel</button>
+                        <button type="button" class="btn"
+                                onclick="document.getElementById('aid-request-modal').close()">Cancel
+                        </button>
                     </div>
                 </form>
             </div>

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -49,5 +49,7 @@
     });
 </script>
 
+<script src="//unpkg.com/alpinejs" defer></script>
+
 </body>
 </html>

--- a/resources/views/vendor/pulse/dashboard.blade.php
+++ b/resources/views/vendor/pulse/dashboard.blade.php
@@ -1,19 +1,19 @@
 <x-pulse>
-    <livewire:pulse.servers cols="full" />
+    <livewire:pulse.servers cols="full"/>
 
-    <livewire:pulse.usage cols="4" rows="2" />
+    <livewire:pulse.usage cols="4" rows="2"/>
 
-    <livewire:pulse.queues cols="4" />
+    <livewire:pulse.queues cols="4"/>
 
-    <livewire:pulse.cache cols="4" />
+    <livewire:pulse.cache cols="4"/>
 
-    <livewire:pulse.slow-queries cols="8" />
+    <livewire:pulse.slow-queries cols="8"/>
 
-    <livewire:pulse.exceptions cols="6" />
+    <livewire:pulse.exceptions cols="6"/>
 
-    <livewire:pulse.slow-requests cols="6" />
+    <livewire:pulse.slow-requests cols="6"/>
 
-    <livewire:pulse.slow-jobs cols="6" />
+    <livewire:pulse.slow-jobs cols="6"/>
 
-    <livewire:pulse.slow-outgoing-requests cols="6" />
+    <livewire:pulse.slow-outgoing-requests cols="6"/>
 </x-pulse>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\API\AccountController;
+use App\Http\Controllers\API\RaidFinderController;
 use App\Http\Controllers\API\SubController;
 use App\Http\Middleware\ValidateNexusAPI;
 use Illuminate\Http\Request;
@@ -13,7 +14,7 @@ Route::prefix('v1')->middleware("auth:sanctum")->group(function () {
 
     Route::get('/accounts', [AccountController::class, 'getUserAccounts']);
     Route::post('/accounts/{account}/deposit-request', [AccountController::class, 'createDepositRequest']);
-    Route::get('/defense/raid-finder/{nation_id?}', [\App\Http\Controllers\API\RaidFinderController::class, 'show']);
+    Route::get('/defense/raid-finder/{nation_id?}', [RaidFinderController::class, 'show']);
 });
 
 Route::prefix('v1/subs')->middleware(ValidateNexusAPI::class)->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ Route::prefix('v1')->middleware("auth:sanctum")->group(function () {
 
     Route::get('/accounts', [AccountController::class, 'getUserAccounts']);
     Route::post('/accounts/{account}/deposit-request', [AccountController::class, 'createDepositRequest']);
+    Route::get('/defense/raid-finder/{nation_id?}', [\App\Http\Controllers\API\RaidFinderController::class, 'show']);
 });
 
 Route::prefix('v1/subs')->middleware(ValidateNexusAPI::class)->group(function () {

--- a/routes/console.php
+++ b/routes/console.php
@@ -25,3 +25,7 @@ Schedule::command('taxes:collect')->hourlyAt("15");
 
 // Military sign in
 Schedule::command("military:sign-in")->dailyAt("12:10");
+
+// Treaty sync
+Schedule::command("sync:treaties")->hourlyAt("10");
+

--- a/routes/console.php
+++ b/routes/console.php
@@ -28,4 +28,5 @@ Schedule::command("military:sign-in")->dailyAt("12:10");
 
 // Treaty sync
 Schedule::command("sync:treaties")->hourlyAt("10");
+Schedule::command("trades:update")->hourlyAt("10");
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,9 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
         // War aid
         Route::get('/waraid', [\App\Http\Controllers\WarAidController::class, 'index'])->name('defense.war-aid');
         Route::post('/waraid', [\App\Http\Controllers\WarAidController::class, 'store'])->name('defense.war-aid.store');
+
+        Route::get('/raid-finder', [\App\Http\Controllers\RaidFinderController::class, 'index'])->name('defense.raid-finder');
+
     });
     // Counters
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,10 +11,13 @@ use App\Http\Controllers\Admin\TaxesController as AdminTaxesController;
 use App\Http\Controllers\Admin\WarAidController as AdminWarAidControllerAlias;
 use App\Http\Controllers\Admin\WarController as AdminWarController;
 use App\Http\Controllers\CityGrantController as UserCityGrantController;
+use App\Http\Controllers\CounterFinderController;
 use App\Http\Controllers\GrantController as UserGrantController;
 use App\Http\Controllers\LoansController as UserLoansController;
+use App\Http\Controllers\RaidFinderController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\VerificationController;
+use App\Http\Controllers\WarAidController;
 use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\EnsureUserIsVerified;
 use Illuminate\Support\Facades\Route;
@@ -59,15 +62,16 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
     /***** Defense Routes *****/
     Route::prefix('defense')->middleware(['auth'])->group(function () {
         // Counters
-        Route::get('/counters/{nation?}', [\App\Http\Controllers\CounterFinderController::class, 'index'])
+        Route::get('/counters/{nation?}', [CounterFinderController::class, 'index'])
             ->name('defense.counters');
 
         // War aid
-        Route::get('/waraid', [\App\Http\Controllers\WarAidController::class, 'index'])->name('defense.war-aid');
-        Route::post('/waraid', [\App\Http\Controllers\WarAidController::class, 'store'])->name('defense.war-aid.store');
+        Route::get('/waraid', [WarAidController::class, 'index'])->name('defense.war-aid');
+        Route::post('/waraid', [WarAidController::class, 'store'])->name('defense.war-aid.store');
 
-        Route::get('/raid-finder', [\App\Http\Controllers\RaidFinderController::class, 'index'])->name('defense.raid-finder');
-
+        Route::get('/raid-finder', [RaidFinderController::class, 'index'])->name(
+            'defense.raid-finder'
+        );
     });
     // Counters
 
@@ -120,11 +124,19 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
         // Grants
         Route::get("/grants", [AdminGrantController::class, 'grants'])->name("admin.grants");
         Route::post("/grants/create", [AdminGrantController::class, 'createGrant'])->name("admin.grants.create");
-        Route::post("/grants/{grant}/update", [AdminGrantController::class, 'updateGrant'])->name("admin.grants.update");
-        Route::post("/grants/{grant}/toggle", [AdminGrantController::class, 'toggleGrant'])->name("admin.grants.toggle");
+        Route::post("/grants/{grant}/update", [AdminGrantController::class, 'updateGrant'])->name(
+            "admin.grants.update"
+        );
+        Route::post("/grants/{grant}/toggle", [AdminGrantController::class, 'toggleGrant'])->name(
+            "admin.grants.toggle"
+        );
 
-        Route::post("/grants/approve/{application}", [AdminGrantController::class, 'approveApplication'])->name("admin.grants.approve");
-        Route::post("/grants/deny/{application}", [AdminGrantController::class, 'denyApplication'])->name("admin.grants.deny");
+        Route::post("/grants/approve/{application}", [AdminGrantController::class, 'approveApplication'])->name(
+            "admin.grants.approve"
+        );
+        Route::post("/grants/deny/{application}", [AdminGrantController::class, 'denyApplication'])->name(
+            "admin.grants.deny"
+        );
 
         // Loan
         Route::get("/loans", [LoansController::class, 'index'])->name("admin.loans");

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\GrantController as AdminGrantController;
 use App\Http\Controllers\Admin\LoansController;
 use App\Http\Controllers\Admin\MembersController as AdminMembersController;
+use App\Http\Controllers\Admin\RaidController;
 use App\Http\Controllers\Admin\TaxesController as AdminTaxesController;
 use App\Http\Controllers\Admin\WarAidController as AdminWarAidControllerAlias;
 use App\Http\Controllers\Admin\WarController as AdminWarController;
@@ -182,4 +183,10 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
         Route::post('/defense/waraid/toggle', [AdminWarAidControllerAlias::class, 'toggle'])->name(
             'admin.war-aid.toggle'
         );
+
+        Route::get('/defense/raids', [RaidController::class, 'index'])->name('admin.raids.index');
+        Route::post('/defense/raids/no-raid', [RaidController::class, 'storeNoRaid'])->name('admin.raids.no-raid.store');
+        Route::delete('/defense/raids/no-raid/{id}', [RaidController::class, 'destroyNoRaid'])->name('admin.raids.no-raid.destroy');
+        Route::post('/defense/raids/top-cap', [RaidController::class, 'updateTopCap'])->name('admin.raids.top-cap.update');
+
     });


### PR DESCRIPTION
Raid finder system. Resolves #15 

- Added Raid Finder page for members to find high-value raid targets
- Automatically calculates estimated loot based on recent war history and 24h average trade prices
- Admins can manage a No-Raid List of alliance IDs to exclude from targeting
- Added Top Alliance Cap setting to exclude top-ranked alliances from raid queries
- Integrated hourly trade price syncing via scheduled command
- Integrated treaty syncing to exclude alliances with active treaties to top alliances
- Built fully asynchronous UI using Alpine.js + AJAX
- Supports nation ID input, defaulting to the logged-in user’s nation