### PR TITLE
Optimize Taxes Page

### DIFF
--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -70,6 +70,11 @@ class TaxService
             }
         }
 
+        // Pre-warm cache so users don't wait on page load
+        self::getSummaryStats();
+        self::getResourceChartData();
+        self::getDailyTotals();
+
         return $newLastId;
     }
 
@@ -102,7 +107,7 @@ class TaxService
         $resources = PWHelperService::resources(false);
         $baseQuery = Taxes::where('date', '>=', $start);
 
-        return Cache::remember('tax_summary_stats', now()->addMinutes(30), function () use ($resources, $baseQuery) {
+        return Cache::remember('tax_summary_stats', now()->addMinutes(60), function () use ($resources, $baseQuery) {
             $sums = (clone $baseQuery)->selectRaw(
                 collect($resources)->prepend('money')->map(fn($r) => "SUM(`$r`) as `$r`")->implode(', ')
             )->first();
@@ -133,7 +138,7 @@ class TaxService
      */
     public static function getResourceChartData(): array
     {
-        return Cache::remember('tax_resource_chart_data', now()->addMinutes(30), function () {
+        return Cache::remember('tax_resource_chart_data', now()->addMinutes(60), function () {
             return self::getAggregatedResourceData(true);
         });
     }
@@ -179,7 +184,7 @@ class TaxService
      */
     public static function getDailyTotals(): array
     {
-        return Cache::remember('tax_daily_totals', now()->addMinutes(30), function () {
+        return Cache::remember('tax_daily_totals', now()->addMinutes(60), function () {
             return self::getAggregatedResourceData(false);
         });
     }

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -109,7 +109,7 @@ class TaxService
 
             $transactionCount = (clone $baseQuery)->count();
             $dailyAvg = (clone $baseQuery)
-                ->selectRaw('DATE(date) as d, SUM(money) as total')
+                ->select('day as d', DB::raw('SUM(money) as total'))
                 ->groupBy('d')
                 ->get()
                 ->avg('total');
@@ -148,8 +148,8 @@ class TaxService
         $resources = PWHelperService::resources();
 
         $results = Taxes::where('date', '>=', $start)
-            ->selectRaw('DATE(`date`) as day')
-            ->selectRaw(collect($resources)->map(fn($r) => "SUM(`$r`) as `$r`")->implode(', '))
+            ->select('day')
+            ->addSelect(collect($resources)->map(fn($r) => DB::raw("SUM(`$r`) as `$r`"))->toArray())
             ->groupBy('day')
             ->orderBy('day')
             ->get();

--- a/database/migrations/2025_05_23_150507_optimize_taxes_table.php
+++ b/database/migrations/2025_05_23_150507_optimize_taxes_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('taxes', function (Blueprint $table) {
+            // Convert float to decimal
+            $table->decimal('money', 20, 2)->default(0)->change();
+            $table->decimal('coal', 20, 2)->default(0)->change();
+            $table->decimal('oil', 20, 2)->default(0)->change();
+            $table->decimal('uranium', 20, 2)->default(0)->change();
+            $table->decimal('iron', 20, 2)->default(0)->change();
+            $table->decimal('bauxite', 20, 2)->default(0)->change();
+            $table->decimal('lead', 20, 2)->default(0)->change();
+            $table->decimal('gasoline', 20, 2)->default(0)->change();
+            $table->decimal('munitions', 20, 2)->default(0)->change();
+            $table->decimal('steel', 20, 2)->default(0)->change();
+            $table->decimal('aluminum', 20, 2)->default(0)->change();
+            $table->decimal('food', 20, 2)->default(0)->change();
+
+            // Add index on date
+            $table->index('date');
+
+            // Add generated column for day
+            $table->date('day')->storedAs('DATE(`date`)');
+            $table->index('day');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('taxes', function (Blueprint $table) {
+            // Revert to float
+            $table->float('money')->default(0)->change();
+            $table->float('coal')->default(0)->change();
+            $table->float('oil')->default(0)->change();
+            $table->float('uranium')->default(0)->change();
+            $table->float('iron')->default(0)->change();
+            $table->float('bauxite')->default(0)->change();
+            $table->float('lead')->default(0)->change();
+            $table->float('gasoline')->default(0)->change();
+            $table->float('munitions')->default(0)->change();
+            $table->float('steel')->default(0)->change();
+            $table->float('aluminum')->default(0)->change();
+            $table->float('food')->default(0)->change();
+
+            $table->dropIndex(['date']);
+            $table->dropIndex(['day']);
+            $table->dropColumn('day');
+        });
+    }
+};

--- a/resources/views/admin/taxes/index.blade.php
+++ b/resources/views/admin/taxes/index.blade.php
@@ -70,8 +70,8 @@
                                 <tbody>
                                 @foreach ($daily as $entry)
                                     <tr>
-                                        <td>{{ Carbon::parse($entry->day)->toFormattedDateString() }}</td>
-                                        <td>{{ number_format($entry->total, 2) }}</td>
+                                        <td>{{ Carbon::parse($entry['day'])->toFormattedDateString() }}</td>
+                                        <td>{{ number_format($entry['total'], 2) }}</td>
                                     </tr>
                                 @endforeach
                                 </tbody>


### PR DESCRIPTION
## Changelog

### Performance Improvements
- Consolidated per-resource tax queries into a single grouped query using `day` column
- Added `day` as a generated column (`DATE(date)`) for efficient grouping
- Added indexes on `date` and `day` columns
- Converted all tax resource columns from `FLOAT` to `DECIMAL(20,2)` for accuracy and aggregation performance
- Rewrote `getSummaryStats` to use fewer queries and leverage grouped aggregates

### Caching Enhancements
- Cached `getSummaryStats`, `getResourceChartData`, and `getDailyTotals` results for 60 minutes
- Automatically re-caches all summary/chart/totals data during `updateAllianceTaxes` so users don’t experience page delays

### Code Improvements
- Updated all queries to use `select('day')` instead of `DATE(date)`
- Changed `getLastScannedTaxRecordId` to use `value(DB::raw('MAX(id)'))`
- Wrapped GraphQL tax response in `collect()` to ensure consistent return type
- Cleaned up chart and total formatting logic for consistency

### Migration
- Created a migration to apply:
  - Field type updates (`FLOAT` → `DECIMAL(20,2)`)
  - Addition of `day` column
  - Indexes on `date` and `day`