### PR TITLE
Implement Direct Deposit System

### DIFF
--- a/app/GraphQL/Models/Nation.php
+++ b/app/GraphQL/Models/Nation.php
@@ -287,6 +287,9 @@ class Nation
         $this->wars_won = isset($json->wars_won) ? (int)$json->wars_won : null;
         $this->wars_lost = isset($json->wars_lost) ? (int)$json->wars_lost : null;
 
+        // Tax ID
+        $this->tax_id = isset($json->tax_id) ? (int)$json->tax_id : null;
+
         // Economy
         $this->gross_national_income = isset($json->gross_national_income) ? (float)$json->gross_national_income : null;
         $this->gross_domestic_product = isset($json->gross_domestic_product) ? (float)$json->gross_domestic_product : null;

--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Exceptions\UserErrorException;
 use App\Models\Account;
 use App\Models\DirectDepositEnrollment;
+use App\Models\DirectDepositLog;
 use App\Models\Loan;
 use App\Services\AccountService;
 use App\Services\DirectDepositService;
@@ -238,12 +239,18 @@ class AccountsController extends Controller
 
         $accounts->load("nation");
 
-        // Get related transactions where they are to or from
         $transactions = AccountService::getRelatedTransactions($accounts);
+
+        $ddLogs = DirectDepositLog::where('account_id', $accounts->id)
+            ->latest()
+            ->limit(50)
+            ->orderBy('created_at', 'DESC')
+            ->get();
 
         return view("accounts.view", [
             "account" => $accounts,
-            "transactions" => $transactions
+            "transactions" => $transactions,
+            "ddLogs" => $ddLogs,
         ]);
     }
 

--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\UserErrorException;
 use App\Models\Account;
+use App\Models\DirectDepositEnrollment;
 use App\Models\Loan;
 use App\Services\AccountService;
+use App\Services\DirectDepositService;
 use App\Services\LoanService;
 use App\Services\PWHelperService;
 use Closure;
@@ -41,9 +43,13 @@ class AccountsController extends Controller
             ->where('remaining_balance', '>', 0)
             ->get();
 
+        $ddService = app(DirectDepositService::class);
+
         return view("accounts.index", [
             "accounts" => $accounts,
             "activeLoans" => $activeLoans,
+            'enrollment' => DirectDepositEnrollment::with('account')->where('nation_id', Auth::user()->nation_id)->first(),
+            'bracket' => $ddService->getApplicableBracket(Auth::user()->nation),
         ]);
     }
 

--- a/app/Http/Controllers/DirectDepositController.php
+++ b/app/Http/Controllers/DirectDepositController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Account;
+use App\Services\DirectDepositService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class DirectDepositController extends Controller
+{
+    /**
+     * @var DirectDepositService
+     */
+    public DirectDepositService $directDepositService;
+
+    /**
+     *
+     */
+    public function __construct()
+    {
+        $this->directDepositService = app(DirectDepositService::class);
+    }
+
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function enroll(Request $request)
+    {
+        $request->validate(['account_id' => 'required|exists:accounts,id']);
+
+        $nation = Auth::user()->nation;
+        $account = Account::findOrFail($request->account_id);
+
+        $this->directDepositService->enroll($nation, $account);
+
+        return back()->with([
+            'alert-message' => 'You have been enrolled in Direct Deposit.',
+            'alert-type' => 'success'
+        ]);
+    }
+
+    /**
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function disenroll()
+    {
+        $nation = Auth::user()->nation;
+
+        $this->directDepositService->disenroll($nation);
+
+        return back()->with([
+            'alert-message' => 'You have been disenrolled from Direct Deposit.',
+            'alert-type' => 'success'
+        ]);
+    }
+}

--- a/app/Jobs/AssignTaxBracket.php
+++ b/app/Jobs/AssignTaxBracket.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\TaxBracketService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class AssignTaxBracket implements ShouldQueue
+{
+    use Queueable, InteractsWithQueue, SerializesModels;
+
+    protected TaxBracketService $taxBracketService;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(TaxBracketService $taxBracketService)
+    {
+        $this->taxBracketService = $taxBracketService;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->taxBracketService->sendAssign();
+    }
+}

--- a/app/Models/DirectDepositEnrollment.php
+++ b/app/Models/DirectDepositEnrollment.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DirectDepositEnrollment extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'nation_id',
+        'account_id',
+        'previous_tax_id',
+        'enrolled_at',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected $dates = ['enrolled_at'];
+
+    /**
+     * @return BelongsTo
+     */
+    public function nation(): BelongsTo
+    {
+        return $this->belongsTo(Nation::class);
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+}

--- a/app/Models/DirectDepositEnrollment.php
+++ b/app/Models/DirectDepositEnrollment.php
@@ -26,6 +26,13 @@ class DirectDepositEnrollment extends Model
     protected $dates = ['enrolled_at'];
 
     /**
+     * @var string[]
+     */
+    protected $casts = [
+        'enrolled_at' => 'datetime',
+    ];
+
+    /**
      * @return BelongsTo
      */
     public function nation(): BelongsTo

--- a/app/Models/DirectDepositLog.php
+++ b/app/Models/DirectDepositLog.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DirectDepositLog extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = [
+        'nation_id',
+        'account_id',
+        'bank_record_id',
+        'money',
+        'coal',
+        'oil',
+        'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'gasoline',
+        'munitions',
+        'steel',
+        'aluminum',
+        'food',
+    ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function nation(): BelongsTo
+    {
+        return $this->belongsTo(Nation::class);
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function bankRecord(): BelongsTo
+    {
+        return $this->belongsTo(BankRecord::class);
+    }
+}

--- a/app/Models/DirectDepositTaxBracket.php
+++ b/app/Models/DirectDepositTaxBracket.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DirectDepositTaxBracket extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'city_number',
+        'money',
+        'coal',
+        'oil',
+        'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'gasoline',
+        'munitions',
+        'steel',
+        'aluminum',
+        'food',
+    ];
+}

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -404,21 +404,17 @@ class AccountService
      */
     public function createDefaultForNation(Nation $nation): Account
     {
-        return Account::create([
-            'nation_id' => $nation->id,
-            'name' => 'System Created Account',
-            'money' => 0,
-            'coal' => 0,
-            'oil' => 0,
-            'uranium' => 0,
-            'iron' => 0,
-            'bauxite' => 0,
-            'lead' => 0,
-            'gasoline' => 0,
-            'munitions' => 0,
-            'steel' => 0,
-            'aluminum' => 0,
-            'food' => 0,
-        ]);
+        $account = new Account();
+
+        $account->nation_id = $nation->id;
+        $account->name = 'System Created Account';
+
+        foreach (PWHelperService::resources() as $resource) {
+            $account->$resource = 0;
+        }
+
+        $account->save();
+
+        return $account;
     }
 }

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -8,6 +8,7 @@ use App\GraphQL\Models\BankRecord;
 use App\Models\Account;
 use App\Models\DepositRequest;
 use App\Models\ManualTransaction;
+use App\Models\Nation;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Notifications\DepositCreated;
@@ -396,4 +397,28 @@ class AccountService
         ]);
     }
 
+    /**
+     * If for some reason (DD) we need an account but they don't have one, we're gonna create one for them
+     * @param Nation $nation
+     * @return Account
+     */
+    public function createDefaultForNation(Nation $nation): Account
+    {
+        return Account::create([
+            'nation_id' => $nation->id,
+            'name' => 'System Created Account',
+            'money' => 0,
+            'coal' => 0,
+            'oil' => 0,
+            'uranium' => 0,
+            'iron' => 0,
+            'bauxite' => 0,
+            'lead' => 0,
+            'gasoline' => 0,
+            'munitions' => 0,
+            'steel' => 0,
+            'aluminum' => 0,
+            'food' => 0,
+        ]);
+    }
 }

--- a/app/Services/DirectDepositService.php
+++ b/app/Services/DirectDepositService.php
@@ -36,7 +36,7 @@ class DirectDepositService
      */
     public function process(BankRecord $record): BankRecord
     {
-        if ($record->tax_id !== $this->ddTaxId) {
+        if ($record->tax_id != $this->ddTaxId) {
             return $record; // Not a DD tax record
         }
 

--- a/app/Services/DirectDepositService.php
+++ b/app/Services/DirectDepositService.php
@@ -161,7 +161,7 @@ class DirectDepositService
         }
 
         $targetTaxId = $enrollment->previous_tax_id;
-        $fallbackTaxId = (int)$this->settings->get('direct_deposit_fallback_tax_id');
+        $fallbackTaxId = SettingService::getDirectDepositFallbackId();
 
         // Attempt to assign the previous tax bracket
         try {

--- a/app/Services/DirectDepositService.php
+++ b/app/Services/DirectDepositService.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace App\Services;
+
+use App\GraphQL\Models\BankRecord;
+use App\Models\Account;
+use App\Models\DirectDepositEnrollment;
+use App\Models\DirectDepositLog;
+use App\Models\DirectDepositTaxBracket;
+use App\Models\Nation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class DirectDepositService
+{
+    public function __construct(
+        protected SettingService $settings,
+        protected AccountService $accountService,
+    ) {
+    }
+
+    /**
+     * Process a BankRecord using Direct Deposit.
+     * Adjusts retained taxes and deposits remaining balance.
+     */
+    public function process(BankRecord $record): BankRecord
+    {
+        // TODO: implement tax split and deposit logic
+        return $record;
+    }
+
+    /**
+     * Enroll a nation in Direct Deposit and update their in-game tax bracket.
+     */
+    public function enroll(Nation $nation, Account $account): void
+    {
+        // TODO: implement mutation to set DD tax ID and persist enrollment
+    }
+
+    /**
+     * Disenroll a nation from Direct Deposit and revert their tax bracket.
+     */
+    public function disenroll(Nation $nation): void
+    {
+        // TODO: lookup previous tax ID and revert tax bracket
+    }
+
+    /**
+     * Determine which tax bracket applies to a nation by city count.
+     */
+    public function getApplicableBracket(Nation $nation): ?DirectDepositTaxBracket
+    {
+        return DirectDepositTaxBracket::where('city_number', $nation->num_cities)->first()
+            ?? DirectDepositTaxBracket::where('city_number', 0)->first();
+    }
+
+    /**
+     * Get the account used for DD deposits or fallback/create a new one.
+     */
+    public function getDepositAccount(Nation $nation): Account
+    {
+        $enrollment = DirectDepositEnrollment::where('nation_id', $nation->id)->first();
+
+        if ($enrollment) {
+            return $enrollment->account;
+        }
+
+        $fallback = $nation->accounts()->first();
+
+        if ($fallback) {
+            return $fallback;
+        }
+
+        return $this->accountService->createDefaultForNation($nation);
+    }
+}

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -133,4 +133,29 @@ class SettingService
         self::setValue("dd_tax_id", $DDTaxID);
     }
 
+    /**
+     * @return int
+     */
+    public static function getDirectDepositFallbackId(): int
+    {
+        $value = self::getValue("dd_fallback_tax_id");
+
+        if (is_null($value)) {
+            self::setDirectDepositFallbackId(0); // Default to 0
+
+            return 0;
+        }
+
+        return (int)$value;
+    }
+
+    /**
+     * @param int $DDTaxID
+     * @return void
+     */
+    public static function setDirectDepositFallbackId(int $DDTaxID): void
+    {
+        self::setValue("dd_fallback_tax_id", $DDTaxID);
+    }
+
 }

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -108,4 +108,29 @@ class SettingService
         self::setValue("raid_top_alliance_cap", $topN);
     }
 
+    /**
+     * @return int
+     */
+    public static function getDirectDepositId(): int
+    {
+        $value = self::getValue("dd_tax_id");
+
+        if (is_null($value)) {
+            self::setDirectDepositId(0); // Default to 0
+
+            return 0;
+        }
+
+        return (int)$value;
+    }
+
+    /**
+     * @param int $DDTaxID
+     * @return void
+     */
+    public static function setDirectDepositId(int $DDTaxID): void
+    {
+        self::setValue("dd_tax_id", $DDTaxID);
+    }
+
 }

--- a/app/Services/TaxBracketService.php
+++ b/app/Services/TaxBracketService.php
@@ -34,8 +34,8 @@ class TaxBracketService
             ->setMutation()
             ->addArgument('id', $this->id)
             ->addArgument('target_id', $this->target_id)
-            ->addFields(['id', 'name', 'rate']);
+            ->addFields(['id', 'tax_rate', 'resource_tax_rate']);
 
-        $client->sendQuery($builder);
+        $client->sendQuery($builder, headers: true);
     }
 }

--- a/app/Services/TaxBracketService.php
+++ b/app/Services/TaxBracketService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\PWQueryFailedException;
+use App\Jobs\AssignTaxBracket;
+use Illuminate\Http\Client\ConnectionException;
+
+class TaxBracketService
+{
+    public int $id;         // Tax bracket ID to assign
+    public int $target_id;  // Nation ID
+
+    /**
+     * Dispatches the job to assign a tax bracket asynchronously.
+     */
+    public function send(): void
+    {
+        AssignTaxBracket::dispatch($this);
+    }
+
+    /**
+     * Sends the mutation to assign the tax bracket directly.
+     *
+     * @throws PWQueryFailedException
+     * @throws ConnectionException
+     */
+    public function sendAssign(): void
+    {
+        $client = new QueryService();
+
+        $builder = (new GraphQLQueryBuilder())
+            ->setRootField('assignTaxBracket')
+            ->setMutation()
+            ->addArgument('id', $this->id)
+            ->addArgument('target_id', $this->target_id)
+            ->addFields(['id', 'name', 'rate']);
+
+        $client->sendQuery($builder);
+    }
+}

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -30,10 +30,15 @@ class TaxService
         $lastTaxId = self::getLastScannedTaxRecordId();
         $newLastId = $lastTaxId;
 
+        $ddService = app(DirectDepositService::class);
+
         foreach ($taxes as $record) {
             if ($record->id <= $lastTaxId) {
                 continue;
             }
+
+            // Process DD. If the tax_id matches the DD tax ID, then it will process the DD and return what is left for taxes.
+            $record = $ddService->process($record);
 
             try {
                 DB::transaction(function () use ($record) {

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -21,4 +21,6 @@ return [
     'view-diagnostic-info',
     'view-war-aid',
     'manage-war-aid',
+    'view-dd',
+    'manage-dd',
 ];

--- a/database/migrations/2025_05_23_173849_create_direct_deposit_tax_brackets_table.php
+++ b/database/migrations/2025_05_23_173849_create_direct_deposit_tax_brackets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('direct_deposit_tax_brackets', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('city_number')->unique();
+            $table->decimal('money', 10, 2)->default(0);
+            $table->decimal('coal', 10, 2)->default(0);
+            $table->decimal('oil', 10, 2)->default(0);
+            $table->decimal('uranium', 10, 2)->default(0);
+            $table->decimal('iron', 10, 2)->default(0);
+            $table->decimal('bauxite', 10, 2)->default(0);
+            $table->decimal('lead', 10, 2)->default(0);
+            $table->decimal('gasoline', 10, 2)->default(0);
+            $table->decimal('munitions', 10, 2)->default(0);
+            $table->decimal('steel', 10, 2)->default(0);
+            $table->decimal('aluminum', 10, 2)->default(0);
+            $table->decimal('food', 10, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('direct_deposit_tax_brackets');
+    }
+};

--- a/database/migrations/2025_05_23_174026_create_direct_deposit_logs_table.php
+++ b/database/migrations/2025_05_23_174026_create_direct_deposit_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('direct_deposit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('nation_id');
+            $table->unsignedBigInteger('account_id');
+            $table->unsignedBigInteger('bank_record_id');
+            $table->decimal('money', 15, 2)->default(0);
+            $table->decimal('coal', 15, 2)->default(0);
+            $table->decimal('oil', 15, 2)->default(0);
+            $table->decimal('uranium', 15, 2)->default(0);
+            $table->decimal('iron', 15, 2)->default(0);
+            $table->decimal('bauxite', 15, 2)->default(0);
+            $table->decimal('lead', 15, 2)->default(0);
+            $table->decimal('gasoline', 15, 2)->default(0);
+            $table->decimal('munitions', 15, 2)->default(0);
+            $table->decimal('steel', 15, 2)->default(0);
+            $table->decimal('aluminum', 15, 2)->default(0);
+            $table->decimal('food', 15, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('direct_deposit_logs');
+    }
+};

--- a/database/migrations/2025_05_23_185121_add_direct_deposit_enrollment_table.php
+++ b/database/migrations/2025_05_23_185121_add_direct_deposit_enrollment_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('direct_deposit_enrollments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('nation_id')->unique();
+            $table->unsignedBigInteger('account_id');
+            $table->unsignedInteger('previous_tax_id');
+            $table->timestamp('enrolled_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('direct_deposit_enrollments');
+    }
+};

--- a/database/seeders/DirectDepositDefaultBracketSeeder.php
+++ b/database/seeders/DirectDepositDefaultBracketSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class DirectDepositDefaultBracketSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $exists = DB::table('direct_deposit_tax_brackets')->where('city_number', 0)->exists();
+
+        if (! $exists) {
+            DB::table('direct_deposit_tax_brackets')->insert([
+                'city_number' => 0,
+                'money' => 10,
+                'coal' => 10,
+                'oil' => 10,
+                'uranium' => 10,
+                'iron' => 10,
+                'bauxite' => 10,
+                'lead' => 10,
+                'gasoline' => 10,
+                'munitions' => 10,
+                'steel' => 10,
+                'aluminum' => 10,
+                'food' => 10,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/resources/views/accounts/components/direct_deposit.blade.php
+++ b/resources/views/accounts/components/direct_deposit.blade.php
@@ -1,0 +1,57 @@
+@php
+    use App\Services\PWHelperService;
+
+    $isEnrolled = isset($enrollment);
+    $resources = PWHelperService::resources();
+@endphp
+
+<x-utils.card title="Direct Deposit">
+    @if ($isEnrolled)
+        <div class="mb-4">
+            <p class="mb-2 text-success font-semibold">You are enrolled in Direct Deposit.</p>
+            <p>Your deposits are going to: <span class="font-bold">{{ $enrollment->account->name }}</span></p>
+        </div>
+
+        <div class="mb-4">
+            <h3 class="font-semibold mb-1">Your Current Tax Bracket ({{ $bracket->city_number }} Cities)</h3>
+            <div class="overflow-x-auto">
+                <table class="table table-sm w-full">
+                    <thead>
+                    <tr>
+                        @foreach($resources as $r)
+                            <th>{{ ucfirst($r) }}</th>
+                        @endforeach
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        @foreach($resources as $r)
+                            <td>{{ number_format($bracket->$r, 2) }}%</td>
+                        @endforeach
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <form method="POST" action="{{ route('dd.disenroll') }}">
+            @csrf
+            <button class="btn btn-error" type="submit">Disenroll from Direct Deposit</button>
+        </form>
+    @else
+        <p class="mb-2 text-warning font-semibold">You are not currently enrolled in Direct Deposit.</p>
+
+        <form method="POST" action="{{ route('dd.enroll') }}">
+            @csrf
+            <label class="label" for="account_id">
+                <span class="label-text">Choose an account for deposits:</span>
+            </label>
+            <select name="account_id" id="account_id" class="select select-bordered w-full mb-4" required>
+                @foreach($accounts as $account)
+                    <option value="{{ $account->id }}">{{ $account->name }}</option>
+                @endforeach
+            </select>
+            <button class="btn btn-primary" type="submit">Enroll in Direct Deposit</button>
+        </form>
+    @endif
+</x-utils.card>

--- a/resources/views/accounts/index.blade.php
+++ b/resources/views/accounts/index.blade.php
@@ -18,4 +18,8 @@
 
     @include("accounts.components.transfer")
     @include("accounts.components.deposit_js")
+
+    <div class="divider"></div>
+
+    @include("accounts.components.direct_deposit")
 @endsection

--- a/resources/views/accounts/view.blade.php
+++ b/resources/views/accounts/view.blade.php
@@ -135,5 +135,36 @@
         {{ $transactions->links() }}
     </x-utils.card>
 
+    @if($ddLogs->count())
+        <div class="divider"></div>
+
+        <x-utils.card title="Direct Deposit Activity" extraClasses="mb-2">
+            <div class="overflow-x-auto">
+                <table class="table w-full table-zebra">
+                    <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Money</th>
+                        @foreach(PWHelperService::resources(false) as $resource)
+                            <th>{{ ucfirst($resource) }}</th>
+                        @endforeach
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach ($ddLogs as $log)
+                        <tr class="hover">
+                            <td>{{ $log->created_at->format('Y-m-d H:i') }}</td>
+                            <td>${{ number_format($log->money, 2) }}</td>
+                            @foreach(PWHelperService::resources(false) as $resource)
+                                <td>{{ number_format($log->$resource, 2) }}</td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </x-utils.card>
+    @endif
+
     @include("accounts.components.deposit_js")
 @endsection

--- a/resources/views/admin/accounts/dashboard.blade.php
+++ b/resources/views/admin/accounts/dashboard.blade.php
@@ -86,6 +86,8 @@
             </table>
         </div>
     </div>
+
+    @include('admin.accounts.direct_deposit')
 @endsection
 
 @section("scripts")

--- a/resources/views/admin/accounts/direct_deposit.blade.php
+++ b/resources/views/admin/accounts/direct_deposit.blade.php
@@ -43,33 +43,110 @@
         </div>
 
         {{-- DD Brackets Table --}}
-        <div class="card shadow-sm mb-4">
-            <div class="card-header">
-                <h5 class="mb-0">Direct Deposit Brackets</h5>
+        @can('view-dd')
+            <div class="card shadow-sm mb-4">
+                <div class="card-header">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">Direct Deposit Brackets</h5>
+
+                        @can('manage-dd')
+                            <form method="POST" action="{{ route('admin.dd.brackets.create') }}" class="d-flex align-items-center gap-2">
+                                @csrf
+                                <input type="number" name="city_number" class="form-control form-control-sm w-auto"
+                                       min="0" required placeholder="City #" autofocus>
+                                <button type="submit" class="btn btn-sm btn-success">Create Bracket</button>
+                            </form>
+                        @endcan
+                    </div>
+                </div>
+
+                <div class="card-body">
+                    @can('manage-dd')
+                        <div class="alert alert-secondary small mb-3">
+                            <strong>Tip:</strong> Enter new tax rates below and click "Apply to Selected" to update all checked brackets. The default bracket (City 0) cannot be deleted but can be edited.
+                        </div>
+
+                        <form method="POST" action="" id="bracket-form">
+                            @csrf
+
+                            <div class="row g-2 mb-3">
+                                @foreach(array_chunk(\App\Services\PWHelperService::resources(), ceil(count(\App\Services\PWHelperService::resources()) / 2)) as $chunk)
+                                    <div class="col-md-6">
+                                        <div class="row g-2">
+                                            @foreach($chunk as $resource)
+                                                <div class="col-md-4">
+                                                    <label class="form-label">{{ ucfirst($resource) }} %</label>
+                                                    <input type="number" name="rates[{{ $resource }}]" class="form-control form-control-sm w-100"
+                                                           min="0" max="100" step="0.01" placeholder="e.g. 10">
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                @endforeach
+
+                                <div class="col-md-12 mt-2 d-flex gap-2">
+                                    <button type="submit"
+                                            formaction="{{ route('admin.dd.brackets.update') }}"
+                                            class="btn btn-primary btn-sm">
+                                        Apply to Selected
+                                    </button>
+
+                                    <button type="submit"
+                                            formaction="{{ route('admin.dd.brackets.delete') }}"
+                                            onclick="return confirm('Are you sure you want to delete the selected brackets?');"
+                                            class="btn btn-danger btn-sm">
+                                        Delete Selected
+                                    </button>
+                                </div>
+                            </div>
+                            @endcan
+
+                            <div class="table-responsive">
+                                <table class="table table-bordered align-middle">
+                                    <thead class="table-light">
+                                    <tr>
+                                        @can('manage-dd')
+                                            <th style="width: 30px;"><input type="checkbox" id="check-all"></th>
+                                        @endcan
+                                        <th>City Number</th>
+                                        @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                            <th>{{ ucfirst($resource) }} %</th>
+                                        @endforeach
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    @foreach($brackets as $bracket)
+                                        <tr @if($bracket->city_number === 0) class="table-info" @endif>
+                                            @can('manage-dd')
+                                                <td>
+                                                    <input type="checkbox"
+                                                           name="selected[]"
+                                                           value="{{ $bracket->id }}"
+                                                           class="bracket-checkbox"
+                                                           @if($bracket->city_number === 0) data-non-deletable @endif>
+                                                </td>
+                                            @endcan
+                                            <td>
+                                                {{ $bracket->city_number }}
+                                                @if ($bracket->city_number === 0)
+                                                    <span class="badge bg-primary ms-1">Default</span>
+                                                @endif
+                                            </td>
+                                            @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                                <td>{{ number_format($bracket->$resource, 2) }}</td>
+                                            @endforeach
+                                        </tr>
+                                    @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            @can('manage-dd')
+                        </form>
+                    @endcan
+                </div>
             </div>
-            <div class="card-body table-responsive">
-                <table class="table table-bordered table-striped mb-0">
-                    <thead>
-                    <tr>
-                        <th>City Number</th>
-                        @foreach (\App\Services\PWHelperService::resources() as $resource)
-                            <th>{{ ucfirst($resource) }} %</th>
-                        @endforeach
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach($brackets as $bracket)
-                        <tr>
-                            <td>{{ $bracket->city_number }}</td>
-                            @foreach(\App\Services\PWHelperService::resources() as $resource)
-                                <td>{{ number_format($bracket->$resource, 2) }}</td>
-                            @endforeach
-                        </tr>
-                    @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        @endcan
 
         {{-- Current Enrollments Table --}}
         <div class="card shadow-sm">
@@ -105,3 +182,16 @@
         </div>
     </div>
 @endcan
+
+@section("scripts")
+    <script>
+        document.getElementById('check-all')?.addEventListener('change', function (e) {
+            const checkboxes = document.querySelectorAll('.bracket-checkbox');
+            checkboxes.forEach(cb => {
+                if (!cb.hasAttribute('data-non-deletable')) {
+                    cb.checked = e.target.checked;
+                }
+            });
+        });
+    </script>
+@endsection

--- a/resources/views/admin/accounts/direct_deposit.blade.php
+++ b/resources/views/admin/accounts/direct_deposit.blade.php
@@ -1,0 +1,107 @@
+@can('view-dd')
+    <div class="mt-5">
+        {{-- DD Settings --}}
+        <div class="card shadow-sm mb-4">
+            <div class="card-header">
+                <h5 class="mb-0">Direct Deposit Settings</h5>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ route('admin.dd.settings') }}">
+                    @csrf
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Direct Deposit Tax ID</label>
+                            <input type="number" class="form-control"
+                                   name="direct_deposit_tax_id"
+                                   value="{{ old('direct_deposit_tax_id', $ddTaxId) }}"
+                                   @cannot('manage-dd') disabled @endcannot required>
+                            <div class="form-text">
+                                This is the <strong>in-game tax bracket ID</strong> that members must be assigned to for Direct Deposit.
+                                It must be created in-game with <strong>100% money</strong> and <strong>100% resource taxes</strong>.
+                            </div>
+                        </div>
+
+                        <div class="col-md-6">
+                            <label class="form-label">Fallback Tax ID</label>
+                            <input type="number" class="form-control"
+                                   name="direct_deposit_fallback_tax_id"
+                                   value="{{ old('direct_deposit_fallback_tax_id', $fallbackTaxId) }}"
+                                   @cannot('manage-dd') disabled @endcannot required>
+                            <div class="form-text">
+                                If a member unenrolls from Direct Deposit and their original in-game tax bracket cannot be restored,
+                                Nexus will assign them to this fallback bracket. It should be a valid in-game tax ID with standard rates.
+                            </div>
+                        </div>
+                    </div>
+
+                    <button type="submit" class="btn btn-primary mt-3"
+                            @cannot('manage-dd') disabled @endcannot>
+                        Save Settings
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        {{-- DD Brackets Table --}}
+        <div class="card shadow-sm mb-4">
+            <div class="card-header">
+                <h5 class="mb-0">Direct Deposit Brackets</h5>
+            </div>
+            <div class="card-body table-responsive">
+                <table class="table table-bordered table-striped mb-0">
+                    <thead>
+                    <tr>
+                        <th>City Number</th>
+                        @foreach (\App\Services\PWHelperService::resources() as $resource)
+                            <th>{{ ucfirst($resource) }} %</th>
+                        @endforeach
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach($brackets as $bracket)
+                        <tr>
+                            <td>{{ $bracket->city_number }}</td>
+                            @foreach(\App\Services\PWHelperService::resources() as $resource)
+                                <td>{{ number_format($bracket->$resource, 2) }}</td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        {{-- Current Enrollments Table --}}
+        <div class="card shadow-sm">
+            <div class="card-header">
+                <h5 class="mb-0">Current Enrollments</h5>
+            </div>
+            <div class="card-body table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                    <tr>
+                        <th>Nation ID</th>
+                        <th>Account</th>
+                        <th>User</th>
+                        <th>Enrolled At</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach($enrollments as $enrollment)
+                        <tr>
+                            <td>
+                                <a href="https://politicsandwar.com/nation/id={{ $enrollment->nation_id }}" target="_blank">
+                                    {{ $enrollment->nation_id }}
+                                </a>
+                            </td>
+                            <td>{{ $enrollment->account->name }}</td>
+                            <td>{{ optional($enrollment->account->user)->name ?? 'Deleted' }}</td>
+                            <td>{{ $enrollment->enrolled_at->format('M d, Y H:i') }}</td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+@endcan

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Admin\WarAidController as AdminWarAidControllerAlias;
 use App\Http\Controllers\Admin\WarController as AdminWarController;
 use App\Http\Controllers\CityGrantController as UserCityGrantController;
 use App\Http\Controllers\CounterFinderController;
+use App\Http\Controllers\DirectDepositController;
 use App\Http\Controllers\GrantController as UserGrantController;
 use App\Http\Controllers\LoansController as UserLoansController;
 use App\Http\Controllers\RaidFinderController;
@@ -60,6 +61,10 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
     Route::post("/accounts/delete", [AccountsController::class, "delete"])->name("accounts.delete.post");
 
     Route::get("/accounts/{accounts}", [AccountsController::class, 'viewAccount'])->name("accounts.view");
+
+    // Direct Deposit
+    Route::post('/direct-deposit/enroll', [DirectDepositController::class, 'enroll'])->name('dd.enroll');
+    Route::post('/direct-deposit/disenroll', [DirectDepositController::class, 'disenroll'])->name('dd.disenroll');
 
     // Loan
     Route::get("/loans", [UserLoansController::class, 'index'])->name("loans.index");

--- a/routes/web.php
+++ b/routes/web.php
@@ -130,6 +130,15 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
         Route::post('/admin/direct-deposit/settings', [AccountController::class, 'saveDirectDepositSettings'])
             ->name('admin.dd.settings');
 
+        Route::post('/admin/direct-deposit/brackets/create', [AccountController::class, 'createDirectDepositBracket'])
+            ->name('admin.dd.brackets.create');
+
+        Route::post('/admin/direct-deposit/brackets/update', [AccountController::class, 'updateDirectDepositBrackets'])
+            ->name('admin.dd.brackets.update');
+
+        Route::post('/admin/direct-deposit/brackets/delete', [AccountController::class, 'deleteDirectDepositBrackets'])
+            ->name('admin.dd.brackets.delete');
+
         // City Grants
         Route::get("/grants/city", [CityGrantController::class, 'cityGrants'])->name(
             "admin.grants.city"

--- a/routes/web.php
+++ b/routes/web.php
@@ -127,6 +127,9 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
             'admin.accounts.adjust'
         );
 
+        Route::post('/admin/direct-deposit/settings', [AccountController::class, 'saveDirectDepositSettings'])
+            ->name('admin.dd.settings');
+
         // City Grants
         Route::get("/grants/city", [CityGrantController::class, 'cityGrants'])->name(
             "admin.grants.city"


### PR DESCRIPTION
## Pull Request: Implement Direct Deposit System

### Summary

This PR introduces a complete Direct Deposit (DD) system within Nexus AMS, allowing members to enroll in a custom tax mechanism. Taxes collected in-game are rerouted via Nexus logic, and deposited directly into a member's account after a configurable tax is withheld. The system includes member enrollment, admin configuration, bracket management, and tax handling.

---

### Features

#### Core Functionality
- Implemented `DirectDepositService` with methods:
  - `process(BankRecord $record)` to handle in-game tax redirection
  - `enroll(Nation $nation, Account $account)` to enable DD and update tax bracket
  - `disenroll(Nation $nation)` to revert to the prior in-game tax bracket
- GraphQL mutation integration via `TaxBracketService` and `AssignTaxBracket` job

#### Member UI
- Added Direct Deposit enrollment and status view to `/accounts`
- Allows selection of deposit account and opt-out functionality
- Displays effective tax bracket based on city count

#### Admin UI
- Added full bracket management interface to `admin.accounts.dashboard`
- Admins can:
  - Create brackets per city number with default 10% rates
  - Edit rates via multi-select inputs
  - Delete multiple brackets (excluding city 0)
- Admins can configure:
  - `direct_deposit_tax_id` (required in-game bracket with 100% tax)
  - `direct_deposit_fallback_tax_id` (used if reverting fails)

#### Permissions
- `view-dd`: can view brackets and enrollment list
- `manage-dd`: can create, edit, delete, and configure settings

---

### Bug Fixes and Improvements
- Fixed where Tax ID was always null #119 
- Fixed mass assignment in `AccountService::createDefaultForNation()` to use direct property setting
- Fixed issues with checkbox behavior for bracket editing and deletion
- Resolved Blade logic preventing edits to bracket 0
- Improved bracket management UI:
  - Clean layout with Bootstrap consistency
  - Help text and tooltips for admins
  - Default badge for city 0
  - "Select All" support with city 0 protection

---

### Database Changes
- New tables:
  - `direct_deposit_tax_brackets`
  - `direct_deposit_enrollments`
  - `direct_deposit_logs`
- Seeder for default tax bracket (`city_number = 0` with 10% rates)

---

### Notes
- Unit testing not included in this release
- Follows existing service/job/policy structure
- Designed to scale with minimal additional configuration