### PR TITLE
Fix active state for settings link in sidebar. Resolves #131

### DIFF
--- a/resources/views/admin/components/sidebar.blade.php
+++ b/resources/views/admin/components/sidebar.blade.php
@@ -144,7 +144,7 @@
                     <x-nav.link href="{{ route('admin.settings') }}"
                                 icon="bi bi-gear"
                                 permission="view-diagnostic-info"
-                                :active="request()->is('telescope')">
+                                :active="request()->routeIs('admin.settings')">
                         Settings
                     </x-nav.link>
                 </li>


### PR DESCRIPTION
Updated the sidebar settings link to use routeIs('admin.settings') for determining its active state instead of checking the request path. This ensures the active class is applied correctly when on the settings page.