### PR TITLE
Add PW API health check and restrict actions when down. Resolves #113

### DIFF
--- a/app/Console/Commands/PWHealthCheckCommand.php
+++ b/app/Console/Commands/PWHealthCheckCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\PWHealthService;
+use Illuminate\Console\Command;
+
+class PWHealthCheckCommand extends Command
+{
+    protected $signature = 'pw:health-check {--ttl=600 : TTL for cache in seconds}';
+    protected $description = 'Checks the Politics & War API health and caches the result.';
+
+    /**
+     * @param PWHealthService $service
+     * @return int
+     */
+    public function handle(PWHealthService $service): int
+    {
+        $ok = $service->checkAndCache((int)$this->option('ttl'));
+        $this->info($ok ? 'PW API is UP' : 'PW API appears DOWN');
+
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Http/Middleware/BlockWhenPWDown.php
+++ b/app/Http/Middleware/BlockWhenPWDown.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\PWHealthService;
+use Closure;
+use Illuminate\Http\Request;
+
+readonly class BlockWhenPWDown
+{
+    public function __construct(private PWHealthService $status) {}
+
+    /**
+     * @param Request $request
+     * @param Closure $next
+     * @return \Illuminate\Http\RedirectResponse|mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($this->status->isDown()) {
+            return redirect()
+                ->back()
+                ->with([
+                    'alert-message' => 'This action is currently restricted due to PW API issues. Please try again soon.',
+                    'alert-type'    => 'error',
+                ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,10 +8,13 @@ use App\Models\Loan;
 use App\Models\Nation;
 use App\Models\User;
 use App\Models\WarAidRequest;
+use App\Services\PWHealthService;
 use App\Services\PWMessageService;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -45,5 +48,10 @@ class AppServiceProvider extends ServiceProvider
         foreach (config('permissions', []) as $permission) {
             Gate::define($permission, fn(User $user) => $user->hasPermission($permission));
         }
+
+        View::composer('*', function ($view) {
+            $view->with('pwApiDown', Cache::get(PWHealthService::CACHE_KEY_STATUS) === false);
+            $view->with('pwApiLastChecked', Cache::get(PWHealthService::CACHE_KEY_CHECKED_AT));
+        });
     }
 }

--- a/app/Services/GraphQLQueryBuilder.php
+++ b/app/Services/GraphQLQueryBuilder.php
@@ -159,6 +159,11 @@ class GraphQLQueryBuilder
     public function addFields(array|string $fields): self
     {
         if (is_array($fields)) {
+            foreach ($fields as $f) {
+                if (!is_string($f)) {
+                    throw new \InvalidArgumentException('addFields() expects strings only.');
+                }
+            }
             $this->fields = array_merge($this->fields, $fields);
         } else {
             $this->fields[] = $fields;

--- a/app/Services/PWHealthService.php
+++ b/app/Services/PWHealthService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final class PWHealthService
+{
+    public const CACHE_KEY_STATUS = 'pw:health:status';       // bool: true=up, false=down
+    public const CACHE_KEY_CHECKED_AT = 'pw:health:checked_at';
+    public const CACHE_KEY_LAST_ERROR = 'pw:health:last_error';
+
+    /**
+     * @param QueryService $query
+     */
+    public function __construct(
+        private readonly QueryService $query,
+    ) {}
+
+    /**
+     * Run the actual health check using the exact 'me' query and cache the result.
+     * @param int $ttlSeconds
+     * @return bool
+     */
+    public function checkAndCache(int $ttlSeconds = 600): bool
+    {
+        try {
+            $builder = (new \App\Services\GraphQLQueryBuilder())
+                ->setRootField('me')
+                ->addFields([
+                    'requests',
+                    'max_requests',
+                    'key',
+                    'permission_bits',
+                ])
+                ->addNestedField('nation', function (\App\Services\GraphQLQueryBuilder $b) {
+                    $b->addFields(['leader_name']);
+                });
+
+            // No pagination, no special headers needed
+            $data = $this->query->sendQuery($builder, headers: false, handlePagination: false);
+
+            // Basic sanity: we expect certain keys to exist
+            $ok = isset($data->requests, $data->max_requests, $data->key, $data->permission_bits);
+
+            Cache::put(self::CACHE_KEY_STATUS, $ok, $ttlSeconds);
+            Cache::put(self::CACHE_KEY_CHECKED_AT, now()->toIso8601String(), $ttlSeconds);
+            Cache::forget(self::CACHE_KEY_LAST_ERROR);
+
+            return $ok;
+        } catch (Throwable $e) {
+            Log::warning('PW API health check FAILED: ' . $e->getMessage());
+            Cache::put(self::CACHE_KEY_STATUS, false, $ttlSeconds);
+            Cache::put(self::CACHE_KEY_CHECKED_AT, now()->toIso8601String(), $ttlSeconds);
+            Cache::put(self::CACHE_KEY_LAST_ERROR, $e->getMessage(), $ttlSeconds);
+
+            return false;
+        }
+    }
+
+    /**
+     * Read-only fast path from cache. If missing, do a quick check.
+     * @param int $fallbackCheckTtl
+     * @param bool $checkIfEmpty
+     * @return bool
+     */
+    public function isUp(int $fallbackCheckTtl = 600, bool $checkIfEmpty = false): bool
+    {
+        $cached = Cache::get(self::CACHE_KEY_STATUS);
+
+        if (is_bool($cached)) {
+            return $cached;
+        }
+
+        return $checkIfEmpty
+            ? $this->checkAndCache($fallbackCheckTtl)
+            : true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDown(): bool
+    {
+        return ! $this->isUp();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function lastCheckedAt(): ?string
+    {
+        return Cache::get(self::CACHE_KEY_CHECKED_AT);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function lastError(): ?string
+    {
+        return Cache::get(self::CACHE_KEY_LAST_ERROR);
+    }
+}

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -10,6 +10,17 @@
 </head>
 <body class="flex flex-col min-h-screen">
 
+@if($pwApiDown)
+    <div class="bg-warning text-warning-content text-sm py-1 text-center w-full">
+        Nexus has detected PW API issues. Functionality will be limited.
+        @if(!empty($pwApiLastChecked))
+            <span class="opacity-75 ml-2">
+                (Last checked {{ \Carbon\Carbon::parse($pwApiLastChecked)->diffForHumans() }})
+            </span>
+        @endif
+    </div>
+@endif
+
 <x-header/>
 
 <div class="container mx-auto py-8 flex-grow">

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,18 +1,27 @@
 <?php
 
 use App\Console\Commands\ProcessDeposits;
+use App\Services\PWHealthService;
 use Illuminate\Support\Facades\Schedule;
+
+
+$whenPWUp = fn() => app(PWHealthService::class)->isUp();
+
+Schedule::command('pw:health-check')->everyMinute();
 
 // Syncing
 Schedule::command('sync:nations')->twiceDailyAt(0, 12, 15)->runInBackground()
-    ->withoutOverlapping(10);
+    ->withoutOverlapping(10)
+    ->when($whenPWUp);
 Schedule::command('sync:alliances')->twiceDailyAt(0, 12, 15)->runInBackground()
-    ->withoutOverlapping(10);
+    ->withoutOverlapping(10)
+    ->when($whenPWUp);
 Schedule::command('sync:wars')->hourlyAt(10)->runInBackground()
-    ->withoutOverlapping(10);
+    ->withoutOverlapping(10)
+    ->when($whenPWUp);
 
 // Deposits
-Schedule::command(ProcessDeposits::class)->everyMinute()->runInBackground();
+Schedule::command(ProcessDeposits::class)->everyMinute()->runInBackground()->when($whenPWUp);
 
 // Loan
 Schedule::command('loans:process-payments')->dailyAt('00:15');
@@ -21,12 +30,12 @@ Schedule::command('loans:process-payments')->dailyAt('00:15');
 Schedule::command('telescope:prune --hours=72')->dailyAt("23:45");
 
 // Taxes
-Schedule::command('taxes:collect')->hourlyAt("15");
+Schedule::command('taxes:collect')->hourlyAt("15")->when($whenPWUp);
 
 // Military sign in
-Schedule::command("military:sign-in")->dailyAt("12:10");
+Schedule::command("military:sign-in")->dailyAt("12:10")->when($whenPWUp);
 
 // Treaty sync
-Schedule::command("sync:treaties")->hourlyAt("10");
-Schedule::command("trades:update")->hourlyAt("10");
+Schedule::command("sync:treaties")->hourlyAt("10")->when($whenPWUp);
+Schedule::command("trades:update")->hourlyAt("10")->when($whenPWUp);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\UserController;
 use App\Http\Controllers\VerificationController;
 use App\Http\Controllers\WarAidController;
 use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\BlockWhenPWDown;
 use App\Http\Middleware\EnsureUserIsVerified;
 use Illuminate\Support\Facades\Route;
 
@@ -55,7 +56,8 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
     // Account Routes
     Route::get("/accounts", [AccountsController::class, 'index'])->name("accounts");
     Route::post('accounts/transfer', [AccountsController::class, 'transfer'])
-        ->name('accounts.transfer');
+        ->name('accounts.transfer')
+        ->middleware(BlockWhenPWDown::class);
 
     Route::get("/accounts/create", [AccountsController::class, "createView"])->name("accounts.create");
     Route::post("/accounts/create", [AccountsController::class, "create"])->name("accounts.create.post");
@@ -65,8 +67,10 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
     Route::get("/accounts/{accounts}", [AccountsController::class, 'viewAccount'])->name("accounts.view");
 
     // Direct Deposit
-    Route::post('/direct-deposit/enroll', [DirectDepositController::class, 'enroll'])->name('dd.enroll');
-    Route::post('/direct-deposit/disenroll', [DirectDepositController::class, 'disenroll'])->name('dd.disenroll');
+    Route::post('/direct-deposit/enroll', [DirectDepositController::class, 'enroll'])->name('dd.enroll')
+        ->middleware(BlockWhenPWDown::class);
+    Route::post('/direct-deposit/disenroll', [DirectDepositController::class, 'disenroll'])->name('dd.disenroll')
+        ->middleware(BlockWhenPWDown::class);
 
     // MMR Assistant
     Route::post('/mmr-assistant/update', [DirectDepositController::class, 'updateMMRA'])
@@ -74,8 +78,10 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
 
     // Loan
     Route::get("/loans", [UserLoansController::class, 'index'])->name("loans.index");
-    Route::post('/loans/apply', [UserLoansController::class, 'apply'])->name('loans.apply');
-    Route::post('/loans/repay', [UserLoansController::class, 'repay'])->name('loans.repay');
+    Route::post('/loans/apply', [UserLoansController::class, 'apply'])->name('loans.apply')
+        ->middleware(BlockWhenPWDown::class);
+    Route::post('/loans/repay', [UserLoansController::class, 'repay'])->name('loans.repay')
+        ->middleware(BlockWhenPWDown::class);
 
     /***** Defense Routes *****/
     Route::prefix('defense')->middleware(['auth'])->group(function () {
@@ -85,11 +91,12 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
 
         // War aid
         Route::get('/waraid', [WarAidController::class, 'index'])->name('defense.war-aid');
-        Route::post('/waraid', [WarAidController::class, 'store'])->name('defense.war-aid.store');
+        Route::post('/waraid', [WarAidController::class, 'store'])->name('defense.war-aid.store')
+            ->middleware(BlockWhenPWDown::class);
 
         Route::get('/raid-finder', [RaidFinderController::class, 'index'])->name(
             'defense.raid-finder'
-        );
+        )->middleware(BlockWhenPWDown::class);
     });
     // Counters
 
@@ -100,10 +107,12 @@ Route::middleware(['auth', EnsureUserIsVerified::class,])->group(callback: funct
         Route::get("/city", [UserCityGrantController::class, 'index'])->name("grants.city");
         Route::post("/city", [UserCityGrantController::class, 'request'])->name(
             "grants.city.request"
-        );
+        )
+            ->middleware(BlockWhenPWDown::class);
 
         Route::get('{grant:slug}', [UserGrantController::class, 'show'])->name('grants.show_grants');
-        Route::post('{grant:slug}/apply', [UserGrantController::class, 'apply'])->name('grants.apply');
+        Route::post('{grant:slug}/apply', [UserGrantController::class, 'apply'])->name('grants.apply')
+            ->middleware(BlockWhenPWDown::class);
     });
 });
 
@@ -133,7 +142,8 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
             'admin.accounts.adjust'
         );
         Route::post('/accounts/transactions/{transaction}/refund', [AccountController::class, 'refundTransaction'])
-            ->name('admin.accounts.transactions.refund');
+            ->name('admin.accounts.transactions.refund')
+            ->middleware(BlockWhenPWDown::class);
 
         Route::post('/admin/direct-deposit/settings', [AccountController::class, 'saveDirectDepositSettings'])
             ->name('admin.dd.settings');
@@ -178,19 +188,21 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
 
         Route::post("/grants/approve/{application}", [AdminGrantController::class, 'approveApplication'])->name(
             "admin.grants.approve"
-        );
+        )
+            ->middleware(BlockWhenPWDown::class);
         Route::post("/grants/deny/{application}", [AdminGrantController::class, 'denyApplication'])->name(
             "admin.grants.deny"
-        );
+        )
+            ->middleware(BlockWhenPWDown::class);
 
         // Loan
         Route::get("/loans", [LoansController::class, 'index'])->name("admin.loans");
         Route::post("/loans/{Loan}/approve", [LoansController::class, 'approve'])->name(
             "admin.loans.approve"
-        );
+        )->middleware(BlockWhenPWDown::class);
         Route::post("/loans/{Loan}/deny", [LoansController::class, 'deny'])->name(
             "admin.loans.deny"
-        );
+        )->middleware(BlockWhenPWDown::class);
         Route::get("/loans/{Loan}/view", [LoansController::class, 'view'])->name(
             "admin.loans.view"
         );
@@ -200,7 +212,7 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
 
         Route::post('/loans/{Loan}/mark-paid', [LoansController::class, 'markAsPaid'])->name(
             'admin.loans.markPaid'
-        );
+        )->middleware(BlockWhenPWDown::class);
 
         // Taxes
         Route::get('/taxes', [AdminTaxesController::class, 'index'])->name('admin.taxes');
@@ -219,11 +231,11 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
         Route::patch(
             '/defense/waraid/{WarAidRequest}/approve',
             [AdminWarAidControllerAlias::class, 'approve']
-        )->name('admin.war-aid.approve');
+        )->name('admin.war-aid.approve')->middleware(BlockWhenPWDown::class);
         Route::patch(
             '/defense/waraid/{WarAidRequest}/deny',
             [AdminWarAidControllerAlias::class, 'deny']
-        )->name('admin.war-aid.deny');
+        )->name('admin.war-aid.deny')->middleware(BlockWhenPWDown::class);
         Route::post('/defense/waraid/toggle', [AdminWarAidControllerAlias::class, 'toggle'])->name(
             'admin.war-aid.toggle'
         );
@@ -242,14 +254,14 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
         Route::get('/settings', [SettingsController::class, 'index'])->name('admin.settings');
         Route::post('/settings/sync/nations', [SettingsController::class, 'runSyncNation'])->name(
             'admin.settings.sync.run'
-        );
+        )->middleware(BlockWhenPWDown::class);
         Route::post('/settings/sync/alliances', [SettingsController::class, 'runSyncAlliance'])->name(
             'admin.settings.sync.alliances'
-        );
+        )->middleware(BlockWhenPWDown::class);
 
         Route::post('/settings/sync/wars', [SettingsController::class, 'runSyncWar'])->name(
             'admin.settings.sync.wars'
-        );
+        )->middleware(BlockWhenPWDown::class);
         Route::post('/settings/sync/cancel', [SettingsController::class, 'cancelSync'])->name(
             'admin.settings.sync.cancel'
         );


### PR DESCRIPTION
Introduces PWHealthService for monitoring the Politics & War API status, a console command for health checks, and middleware to block sensitive actions when the API is down. Updates scheduled tasks and web routes to respect API health, and adds a UI warning when the API is unavailable. Also improves GraphQLQueryBuilder field validation.