### PR TITLE
Add Withdrawal Limits

### DIFF
--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -239,11 +239,18 @@ class AccountsController extends Controller
                     $transfer
                 );
             } else {
-                AccountService::transferToNation(
+                $transaction = AccountService::transferToNation(
                     $request->input("from"),
                     Auth::user()->nation_id,
                     $transfer
                 );
+
+                if ($transaction->requires_admin_approval) {
+                    return redirect()->back()->with([
+                        'alert-message' => 'Withdrawal submitted for review. An admin will approve it soon.',
+                        'alert-type' => 'info',
+                    ]);
+                }
             }
 
             return redirect()->back()->with([

--- a/app/Http/Controllers/Admin/WithdrawalController.php
+++ b/app/Http/Controllers/Admin/WithdrawalController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Transaction;
+use App\Models\WithdrawLimit;
+use App\Notifications\WithdrawalDeniedNotification;
+use App\Services\AccountService;
+use App\Services\PWHelperService;
+use App\Services\SettingService;
+use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Http\RedirectResponse;
+
+class WithdrawalController extends Controller
+{
+    /**
+     * @return RedirectResponse
+     * @throws AuthorizationException
+     */
+    public function index(): RedirectResponse
+    {
+        Gate::authorize('manage-accounts');
+
+        return redirect()->route('admin.accounts.dashboard');
+    }
+
+    /**
+     * @param Request $request
+     * @return RedirectResponse
+     * @throws AuthorizationException
+     */
+    public function updateLimits(Request $request): RedirectResponse
+    {
+        Gate::authorize('manage-accounts');
+
+        $resources = PWHelperService::resources();
+        $rules = [
+            'limits' => ['required', 'array'],
+            'max_daily_withdrawals' => ['required', 'integer', 'min:0'],
+        ];
+
+        foreach ($resources as $resource) {
+            $rules["limits.$resource"] = ['nullable', 'numeric', 'min:0'];
+        }
+
+        $validated = $request->validate($rules);
+
+        foreach ($resources as $resource) {
+            $value = $validated['limits'][$resource] ?? 0;
+
+            WithdrawLimit::updateOrCreate(
+                ['resource' => $resource],
+                ['daily_limit' => $value ?? 0]
+            );
+        }
+
+        SettingService::setWithdrawMaxDailyCount($validated['max_daily_withdrawals']);
+
+        return redirect()->route('admin.accounts.dashboard')->with([
+            'alert-message' => 'Withdrawal limits updated successfully.',
+            'alert-type' => 'success',
+        ]);
+    }
+
+    /**
+     * @param Transaction $transaction
+     * @return RedirectResponse
+     * @throws AuthorizationException
+     */
+    public function approve(Transaction $transaction): RedirectResponse
+    {
+        Gate::authorize('manage-accounts');
+
+        if (!$transaction->requires_admin_approval || $transaction->approved_at || $transaction->denied_at) {
+            return redirect()->route('admin.accounts.dashboard')->with([
+                'alert-message' => 'This withdrawal request is no longer pending.',
+                'alert-type' => 'error',
+            ]);
+        }
+
+        DB::transaction(function () use ($transaction) {
+            $transaction->requires_admin_approval = false;
+            $transaction->approved_at = now();
+            $transaction->approved_by = auth()->id();
+            $transaction->save();
+        });
+
+        AccountService::dispatchWithdrawal($transaction);
+
+        return redirect()->route('admin.accounts.dashboard')->with([
+            'alert-message' => 'Withdrawal approved and queued for processing.',
+            'alert-type' => 'success',
+        ]);
+    }
+
+    /**
+     * @param Request $request
+     * @param Transaction $transaction
+     * @return RedirectResponse
+     * @throws AuthorizationException
+     * @throws Exception
+     */
+    public function deny(Request $request, Transaction $transaction): RedirectResponse
+    {
+        Gate::authorize('manage-accounts');
+
+        if (!$transaction->requires_admin_approval || $transaction->approved_at || $transaction->denied_at) {
+            return redirect()->route('admin.accounts.dashboard')->with([
+                'alert-message' => 'This withdrawal request is no longer pending.',
+                'alert-type' => 'error',
+            ]);
+        }
+
+        $validated = $request->validate([
+            'reason' => ['required', 'string', 'max:500'],
+        ]);
+
+        $accountName = null;
+
+        DB::transaction(function () use ($transaction, $validated, &$accountName) {
+            $account = AccountService::getAccountById($transaction->from_account_id);
+
+            $accountName = $account->name;
+
+            foreach (PWHelperService::resources() as $resource) {
+                $account->{$resource} += $transaction->{$resource};
+            }
+
+            $account->save();
+
+            $transaction->is_pending = false;
+            $transaction->requires_admin_approval = false;
+            $transaction->denied_at = now();
+            $transaction->denied_by = auth()->id();
+            $transaction->denial_reason = $validated['reason'];
+            $transaction->save();
+        });
+
+        $transaction->refresh();
+        $transaction->loadMissing('nation', 'fromAccount');
+
+        if ($transaction->nation) {
+            $transaction->nation->notify(new WithdrawalDeniedNotification(
+                nationId: $transaction->nation_id,
+                transaction: $transaction,
+                accountName: $accountName ?? $transaction->fromAccount?->name,
+            ));
+        }
+
+        return redirect()->route('admin.accounts.dashboard')->with([
+            'alert-message' => 'Withdrawal request denied and funds returned to the account.',
+            'alert-type' => 'success',
+        ]);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -10,6 +10,14 @@ class Transaction extends Model
 
     public $table = "transactions";
 
+    protected $casts = [
+        'is_pending' => 'bool',
+        'requires_admin_approval' => 'bool',
+        'approved_at' => 'datetime',
+        'denied_at' => 'datetime',
+        'refunded_at' => 'datetime',
+    ];
+
     /**
      * @return BelongsTo
      */
@@ -32,6 +40,22 @@ class Transaction extends Model
     public function nation()
     {
         return $this->belongsTo(Nation::class, "nation_id", "id");
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function approvedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'approved_by');
+    }
+
+    /**
+     * @return BelongsTo
+     */
+    public function deniedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'denied_by');
     }
 
     /**

--- a/app/Models/WithdrawLimit.php
+++ b/app/Models/WithdrawLimit.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WithdrawLimit extends Model
+{
+    protected $fillable = [
+        'resource',
+        'daily_limit',
+    ];
+}

--- a/app/Notifications/WithdrawalDeniedNotification.php
+++ b/app/Notifications/WithdrawalDeniedNotification.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Transaction;
+use App\Services\PWHelperService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class WithdrawalDeniedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public int $nationId;
+
+    public Transaction $transaction;
+
+    public ?string $accountName;
+
+    /**
+     * @param int $nationId
+     * @param Transaction $transaction
+     * @param string|null $accountName
+     */
+    public function __construct(int $nationId, Transaction $transaction, ?string $accountName = null)
+    {
+        $this->nationId = $nationId;
+        $this->transaction = $transaction;
+        $this->accountName = $accountName;
+    }
+
+    /**
+     * @param object $notifiable
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['pnw'];
+    }
+
+    /**
+     * @param object $notifiable
+     * @return array<string, string>
+     */
+    public function toPNW(object $notifiable): array
+    {
+        $accountLabel = $this->accountName ?? 'your alliance bank account';
+        $submittedAt = $this->transaction->created_at
+            ? $this->transaction->created_at->timezone('UTC')->format('M d, Y H:i') . ' UTC'
+            : null;
+
+        $resourceLines = collect(PWHelperService::resources())
+            ->filter(function (string $resource) {
+                return (float) $this->transaction->{$resource} > 0;
+            })
+            ->map(function (string $resource) {
+                $amount = (float) $this->transaction->{$resource};
+                $formattedAmount = number_format($amount, 2);
+                $label = $resource === 'money' ? 'Money' : ucfirst($resource);
+
+                return $resource === 'money'
+                    ? "- {$label}: $" . $formattedAmount
+                    : "- {$label}: {$formattedAmount}";
+            });
+
+        $messageParts = [
+            "Your withdrawal request from [b]{$accountLabel}[/b] has been denied. ❌",
+        ];
+
+        if ($submittedAt) {
+            $messageParts[] = "[b]Submitted:[/b] {$submittedAt}";
+        }
+
+        if ($resourceLines->isNotEmpty()) {
+            $messageParts[] = "[b]Requested resources:[/b]\n" . $resourceLines->implode("\n");
+        }
+
+        if (!empty($this->transaction->denial_reason)) {
+            $messageParts[] = "[b]Reason provided:[/b]\n" . $this->transaction->denial_reason;
+        }
+
+        $messageParts[] = 'The funds have been returned to the source account. Please reach out to leadership if you have questions.';
+
+        return [
+            'nation_id' => $this->nationId,
+            'subject' => 'Withdrawal Denied',
+            'message' => implode("\n\n", $messageParts),
+        ];
+    }
+}

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -258,4 +258,29 @@ class SettingService
         self::setValue("mmr_assistant_enabled", (int)$enabled);
     }
 
+    /**
+     * @return int
+     */
+    public static function getWithdrawMaxDailyCount(): int
+    {
+        $value = self::getValue('withdraw_max_daily_count');
+
+        if (is_null($value)) {
+            self::setWithdrawMaxDailyCount(0);
+
+            return 0;
+        }
+
+        return (int)$value;
+    }
+
+    /**
+     * @param int $count
+     * @return void
+     */
+    public static function setWithdrawMaxDailyCount(int $count): void
+    {
+        self::setValue('withdraw_max_daily_count', max(0, $count));
+    }
+
 }

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -25,19 +25,25 @@ class TransactionService
         int $fromAccountId,
         string $transactionType,
         int|null $toAccountId = null,
-        bool $isPending = true
+        bool $isPending = true,
+        ?string $note = null,
+        bool $requiresAdminApproval = false,
+        ?string $pendingReason = null
     ): Transaction {
         $transaction = new Transaction();
         $transaction->from_account_id = $fromAccountId;
         $transaction->to_account_id = $toAccountId ?? null;
         $transaction->nation_id = $nation_id;
         $transaction->transaction_type = $transactionType;
+        $transaction->note = $note;
 
         foreach ($resources as $res => $value) {
             $transaction->$res = $value;
         }
 
         $transaction->is_pending = $isPending;
+        $transaction->requires_admin_approval = $requiresAdminApproval;
+        $transaction->pending_reason = $pendingReason;
 
         $transaction->save();
 

--- a/app/Services/WithdrawalLimitService.php
+++ b/app/Services/WithdrawalLimitService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Transaction;
+use App\Models\WithdrawLimit;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class WithdrawalLimitService
+{
+    public static function limits(): Collection
+    {
+        return WithdrawLimit::query()->get()->keyBy('resource');
+    }
+
+    public static function evaluate(int $nationId, array $requestedResources): array
+    {
+        $limits = self::limits();
+        $transactions = Transaction::query()
+            ->where('nation_id', $nationId)
+            ->where('transaction_type', 'withdrawal')
+            ->where('created_at', '>=', Carbon::now()->subDay())
+            ->where('requires_admin_approval', false)
+            ->get();
+
+        $exceededResources = [];
+        foreach (PWHelperService::resources() as $resource) {
+            $limitValue = $limits[$resource]->daily_limit ?? null;
+            $requested = (float)($requestedResources[$resource] ?? 0);
+            if (is_null($limitValue) || $limitValue <= 0 || $requested <= 0) {
+                continue;
+            }
+
+            $currentTotal = (float)$transactions->sum($resource);
+            if (($currentTotal + $requested) > $limitValue + 0.00001) {
+                $exceededResources[] = $resource;
+            }
+        }
+
+        $maxDailyWithdrawals = SettingService::getWithdrawMaxDailyCount();
+        $dailyCount = $transactions->count();
+        $countLimitReached = $maxDailyWithdrawals > 0 && $dailyCount >= $maxDailyWithdrawals;
+
+        $requiresApproval = $countLimitReached || !empty($exceededResources);
+
+        $pendingReason = null;
+        if ($requiresApproval) {
+            $messages = [];
+            if (!empty($exceededResources)) {
+                $messages[] = 'Exceeded daily limit for ' . collect($exceededResources)
+                        ->map(fn(string $resource) => ucfirst($resource))
+                        ->implode(', ');
+            }
+
+            if ($countLimitReached) {
+                $messages[] = 'Reached the maximum automatic withdrawals for the day';
+            }
+
+            $pendingReason = implode(' and ', $messages);
+        }
+
+        return [
+            'requires_approval' => $requiresApproval,
+            'exceeded_resources' => $exceededResources,
+            'count_limit_reached' => $countLimitReached,
+            'pending_reason' => $pendingReason,
+        ];
+    }
+}

--- a/database/migrations/2025_07_20_120000_create_withdraw_limits_table.php
+++ b/database/migrations/2025_07_20_120000_create_withdraw_limits_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('withdraw_limits', function (Blueprint $table) {
+            $table->id();
+            $table->string('resource')->unique();
+            $table->decimal('daily_limit', 18, 2)->default(0);
+            $table->timestamps();
+        });
+
+        $now = now();
+        $resources = [
+            'money',
+            'coal',
+            'oil',
+            'uranium',
+            'iron',
+            'bauxite',
+            'lead',
+            'gasoline',
+            'munitions',
+            'steel',
+            'aluminum',
+            'food',
+        ];
+
+        DB::table('withdraw_limits')->insert(array_map(static function (string $resource) use ($now) {
+            return [
+                'resource' => $resource,
+                'daily_limit' => 0,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }, $resources));
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('withdraw_limits');
+    }
+};

--- a/database/migrations/2025_07_20_121000_add_withdrawal_approval_columns_to_transactions.php
+++ b/database/migrations/2025_07_20_121000_add_withdrawal_approval_columns_to_transactions.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->string('note')->nullable()->after('transaction_type');
+            $table->boolean('requires_admin_approval')->default(false)->after('refunded_at');
+            $table->string('pending_reason')->nullable()->after('requires_admin_approval');
+            $table->timestamp('approved_at')->nullable()->after('pending_reason');
+            $table->foreignId('approved_by')->nullable()->after('approved_at')->constrained('users')->nullOnDelete();
+            $table->timestamp('denied_at')->nullable()->after('approved_by');
+            $table->foreignId('denied_by')->nullable()->after('denied_at')->constrained('users')->nullOnDelete();
+            $table->text('denial_reason')->nullable()->after('denied_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropForeign(['approved_by']);
+            $table->dropForeign(['denied_by']);
+            $table->dropColumn([
+                'note',
+                'requires_admin_approval',
+                'pending_reason',
+                'approved_at',
+                'approved_by',
+                'denied_at',
+                'denied_by',
+                'denial_reason',
+            ]);
+        });
+    }
+};

--- a/resources/views/admin/accounts/dashboard.blade.php
+++ b/resources/views/admin/accounts/dashboard.blade.php
@@ -1,4 +1,6 @@
-@php use App\Services\PWHelperService; @endphp
+@php
+    use App\Services\PWHelperService;
+@endphp
 @extends('layouts.admin')
 
 @section("content")
@@ -86,6 +88,145 @@
             </table>
         </div>
     </div>
+
+    @can('manage-accounts')
+        <div class="row mt-4">
+            <div class="col-md-4">
+                <x-admin.info-box icon="bi bi-hourglass-split" bgColor="text-bg-warning"
+                                  title="Pending Withdrawals" :value="$pendingWithdrawals->count()"/>
+            </div>
+            <div class="col-md-4">
+                <x-admin.info-box icon="bi bi-arrow-down-up" bgColor="text-bg-info"
+                                  title="Daily Auto Withdraw Limit"
+                                  :value="$maxDailyWithdrawals > 0 ? $maxDailyWithdrawals : 'Unlimited'"/>
+            </div>
+            <div class="col-md-4">
+                <x-admin.info-box icon="bi bi-shield-lock" bgColor="text-bg-success"
+                                  title="Resources with Limits"
+                                  :value="$withdrawalLimits->filter(fn($limit) => (float)$limit->daily_limit > 0)->count()"/>
+            </div>
+        </div>
+
+        <div class="card mt-4">
+            <div class="card-header">Automatic Withdrawal Limits</div>
+            <div class="card-body">
+                <form method="POST" action="{{ route('admin.withdrawals.limits') }}" class="row g-3">
+                    @csrf
+                    <div class="col-12">
+                        <label for="max_daily_withdrawals" class="form-label fw-semibold">Maximum Automatic Withdrawals Per Day</label>
+                        <input type="number" min="0" class="form-control" id="max_daily_withdrawals"
+                               name="max_daily_withdrawals" value="{{ old('max_daily_withdrawals', $maxDailyWithdrawals) }}"
+                               required>
+                        <div class="form-text">Set to 0 to allow unlimited automatic approvals.</div>
+                    </div>
+
+                    <div class="col-12">
+                        <div class="table-responsive">
+                            <table class="table table-striped align-middle">
+                                <thead>
+                                <tr>
+                                    <th>Resource</th>
+                                    <th>Daily Auto-Approval Limit</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach(PWHelperService::resources() as $resource)
+                                    @php($limit = optional($withdrawalLimits->get($resource))->daily_limit ?? 0)
+                                    <tr>
+                                        <td class="text-capitalize">{{ $resource }}</td>
+                                        <td>
+                                            <div class="input-group">
+                                                <span class="input-group-text">{{ $resource === 'money' ? '$' : '' }}</span>
+                                                <input type="number" step="0.01" min="0" class="form-control"
+                                                       name="limits[{{ $resource }}]"
+                                                       value="{{ old('limits.' . $resource, $limit) }}">
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="col-12 d-flex justify-content-end">
+                        <button type="submit" class="btn btn-primary">Save Limits</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        @if($pendingWithdrawals->isNotEmpty())
+            <div class="card mt-4">
+                <div class="card-header">Pending Withdrawal Approvals</div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-striped align-middle">
+                            <thead>
+                            <tr>
+                                <th>Requested</th>
+                                <th>Member</th>
+                                <th>From Account</th>
+                                <th>Nation</th>
+                                <th>Resources</th>
+                                <th>Reason</th>
+                                <th class="text-end">Actions</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($pendingWithdrawals as $transaction)
+                                <tr>
+                                    <td>{{ $transaction->created_at?->format('M d, Y H:i') }}</td>
+                                    <td>{{ $transaction->fromAccount?->user?->name ?? 'Unknown User' }}</td>
+                                    <td>{{ $transaction->fromAccount?->name ?? 'Unknown Account' }}</td>
+                                    <td>{{ $transaction->nation?->nation_name ?? 'Unknown Nation' }}</td>
+                                    <td>
+                                        <ul class="mb-0 ps-3">
+                                            @foreach(PWHelperService::resources() as $resource)
+                                                @php($amount = $transaction->{$resource})
+                                                @if($amount > 0)
+                                                    <li>
+                                                        {{ ucfirst($resource) }}:
+                                                        {{ $resource === 'money' ? '$' : '' }}{{ number_format($amount, 2) }}
+                                                    </li>
+                                                @endif
+                                            @endforeach
+                                        </ul>
+                                    </td>
+                                    <td>{{ $transaction->pending_reason ?? 'Manual approval required' }}</td>
+                                    <td class="text-end">
+                                        <form action="{{ route('admin.withdrawals.approve', $transaction) }}" method="POST"
+                                              class="d-inline">
+                                            @csrf
+                                            <button type="submit" class="btn btn-success btn-sm">Approve</button>
+                                        </form>
+                                        <button class="btn btn-outline-danger btn-sm" type="button"
+                                                data-bs-toggle="collapse"
+                                                data-bs-target="#deny-form-{{ $transaction->id }}"
+                                                aria-expanded="false" aria-controls="deny-form-{{ $transaction->id }}">
+                                            Deny
+                                        </button>
+                                        <div class="collapse mt-2" id="deny-form-{{ $transaction->id }}">
+                                            <form action="{{ route('admin.withdrawals.deny', $transaction) }}" method="POST">
+                                                @csrf
+                                                <div class="mb-2">
+                                                    <label for="deny-reason-{{ $transaction->id }}" class="form-label">Reason</label>
+                                                    <textarea class="form-control" name="reason" id="deny-reason-{{ $transaction->id }}"
+                                                              rows="2" maxlength="500" required></textarea>
+                                                </div>
+                                                <button type="submit" class="btn btn-danger btn-sm">Confirm Denial</button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        @endif
+    @endcan
 
     @include('admin.accounts.direct_deposit')
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Admin\SettingsController;
 use App\Http\Controllers\Admin\TaxesController as AdminTaxesController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Admin\WarAidController as AdminWarAidControllerAlias;
+use App\Http\Controllers\Admin\WithdrawalController;
 use App\Http\Controllers\Admin\WarController as AdminWarController;
 use App\Http\Controllers\CityGrantController as UserCityGrantController;
 use App\Http\Controllers\CounterFinderController;
@@ -156,6 +157,12 @@ Route::middleware(['auth', EnsureUserIsVerified::class, AdminMiddleware::class,]
 
         Route::post('/admin/direct-deposit/brackets/delete', [AccountController::class, 'deleteDirectDepositBrackets'])
             ->name('admin.dd.brackets.delete');
+
+        // Withdrawals
+        Route::get('/withdrawals', [WithdrawalController::class, 'index'])->name('admin.withdrawals.index');
+        Route::post('/withdrawals/limits', [WithdrawalController::class, 'updateLimits'])->name('admin.withdrawals.limits');
+        Route::post('/withdrawals/{transaction}/approve', [WithdrawalController::class, 'approve'])->name('admin.withdrawals.approve');
+        Route::post('/withdrawals/{transaction}/deny', [WithdrawalController::class, 'deny'])->name('admin.withdrawals.deny');
 
         // City Grants
         Route::get("/grants/city", [CityGrantController::class, 'cityGrants'])->name(


### PR DESCRIPTION
## Summary
- deliver in-game notifications to nations when a withdrawal request is denied, including submission details and the admin's reason
- reset the withdrawal record after denial and capture the source account name so the notification can reference it

## Testing
- ✅ `php -l app/Notifications/WithdrawalDeniedNotification.php`


------
https://chatgpt.com/codex/tasks/task_e_68fd3bcd362083239fe7e47594380a49