### PR TITLE
Add offshore models and service layer

### DIFF
--- a/app/Http/Requests/Admin/OffshoreRequest.php
+++ b/app/Http/Requests/Admin/OffshoreRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\OffshoreGuardrail;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+abstract class OffshoreRequest extends FormRequest
+{
+    /**
+     * Ensure sensitive fields are never flashed back to the session on validation errors.
+     *
+     * @var string[]
+     */
+    protected $dontFlash = ['api_key', 'mutation_key'];
+
+    abstract protected function isUpdate(): bool;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $nameRule = $this->isUpdate() ? ['sometimes', 'string', 'max:255'] : ['required', 'string', 'max:255'];
+        $allianceRule = $this->isUpdate() ? ['sometimes', 'integer', 'exists:alliances,id'] : ['required', 'integer', 'exists:alliances,id'];
+        $apiKeyRule = $this->isUpdate() ? ['sometimes', 'string', 'max:255'] : ['required', 'string', 'max:255'];
+        $mutationKeyRule = $this->isUpdate() ? ['sometimes', 'string', 'max:255'] : ['required', 'string', 'max:255'];
+
+        return [
+            'name' => $nameRule,
+            'alliance_id' => $allianceRule,
+            'enabled' => ['sometimes', 'boolean'],
+            'priority' => ['sometimes', 'integer', 'min:0'],
+            'api_key' => $apiKeyRule,
+            'mutation_key' => $mutationKeyRule,
+            'guardrails' => ['sometimes', 'array'],
+            'guardrails.*.resource' => ['required_with:guardrails', 'string', Rule::in(OffshoreGuardrail::RESOURCES)],
+            'guardrails.*.minimum_amount' => ['required_with:guardrails', 'numeric', 'min:0'],
+        ];
+    }
+
+    public function payload(): array
+    {
+        return $this->safe()->except(['guardrails']);
+    }
+
+    public function guardrails(): ?array
+    {
+        if (! $this->has('guardrails')) {
+            return null;
+        }
+
+        return collect($this->input('guardrails', []))
+            ->map(fn(array $guardrail) => [
+                'resource' => $guardrail['resource'],
+                'minimum_amount' => (float) $guardrail['minimum_amount'],
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Requests/Admin/StoreOffshoreRequest.php
+++ b/app/Http/Requests/Admin/StoreOffshoreRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+class StoreOffshoreRequest extends OffshoreRequest
+{
+    protected function isUpdate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Http/Requests/Admin/UpdateOffshoreRequest.php
+++ b/app/Http/Requests/Admin/UpdateOffshoreRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+class UpdateOffshoreRequest extends OffshoreRequest
+{
+    protected function isUpdate(): bool
+    {
+        return true;
+    }
+}

--- a/app/Models/Offshore.php
+++ b/app/Models/Offshore.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
+
+class Offshore extends Model
+{
+    protected $fillable = [
+        'name',
+        'alliance_id',
+        'enabled',
+        'priority',
+        'api_key',
+        'mutation_key',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'priority' => 'integer',
+        'api_key' => 'encrypted',
+        'mutation_key' => 'encrypted',
+    ];
+
+    protected $hidden = [
+        'api_key',
+        'mutation_key',
+    ];
+
+    /**
+     * @return HasMany<OffshoreGuardrail>
+     */
+    public function guardrails(): HasMany
+    {
+        return $this->hasMany(OffshoreGuardrail::class);
+    }
+
+    public function scopeEnabled(Builder $query): Builder
+    {
+        return $query->where('enabled', true);
+    }
+
+    public function getApiKeyDecryptedAttribute(): ?string
+    {
+        $value = $this->getRawOriginal('api_key');
+
+        if (! $value) {
+            return null;
+        }
+
+        try {
+            return Crypt::decryptString($value);
+        } catch (DecryptException $exception) {
+            Log::warning('Failed to decrypt offshore api key', [
+                'offshore_id' => $this->id,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    public function getMutationKeyDecryptedAttribute(): ?string
+    {
+        $value = $this->getRawOriginal('mutation_key');
+
+        if (! $value) {
+            return null;
+        }
+
+        try {
+            return Crypt::decryptString($value);
+        } catch (DecryptException $exception) {
+            Log::warning('Failed to decrypt offshore mutation key', [
+                'offshore_id' => $this->id,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    public function guardrailFor(string $resource): ?OffshoreGuardrail
+    {
+        if ($this->relationLoaded('guardrails')) {
+            /** @var Collection<int, OffshoreGuardrail> $guardrails */
+            $guardrails = $this->getRelation('guardrails');
+
+            return $guardrails->firstWhere('resource', $resource);
+        }
+
+        return $this->guardrails()->where('resource', $resource)->first();
+    }
+}

--- a/app/Models/OffshoreGuardrail.php
+++ b/app/Models/OffshoreGuardrail.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OffshoreGuardrail extends Model
+{
+    public const RESOURCES = [
+        'money',
+        'coal',
+        'oil',
+        'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'gasoline',
+        'munitions',
+        'steel',
+        'aluminum',
+        'food',
+        'credits',
+    ];
+
+    protected $fillable = [
+        'offshore_id',
+        'resource',
+        'minimum_amount',
+    ];
+
+    protected $casts = [
+        'minimum_amount' => 'decimal:2',
+    ];
+
+    /**
+     * @return BelongsTo<Offshore, self>
+     */
+    public function offshore(): BelongsTo
+    {
+        return $this->belongsTo(Offshore::class);
+    }
+
+    public function appliesTo(string $resource): bool
+    {
+        return $this->resource === $resource;
+    }
+}

--- a/app/Observers/OffshoreGuardrailObserver.php
+++ b/app/Observers/OffshoreGuardrailObserver.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Offshore;
+use App\Models\OffshoreGuardrail;
+use App\Services\OffshoreService;
+use Illuminate\Support\Facades\Log;
+
+class OffshoreGuardrailObserver
+{
+    public function __construct(private readonly OffshoreService $offshoreService)
+    {
+    }
+
+    public function created(OffshoreGuardrail $guardrail): void
+    {
+        $this->flushCache($guardrail);
+        $this->log('created', $guardrail);
+    }
+
+    public function updated(OffshoreGuardrail $guardrail): void
+    {
+        $this->flushCache($guardrail);
+        $this->log('updated', $guardrail);
+    }
+
+    public function deleted(OffshoreGuardrail $guardrail): void
+    {
+        $this->flushCache($guardrail);
+        $this->log('deleted', $guardrail);
+    }
+
+    public function forceDeleted(OffshoreGuardrail $guardrail): void
+    {
+        $this->flushCache($guardrail);
+        $this->log('force-deleted', $guardrail);
+    }
+
+    protected function flushCache(OffshoreGuardrail $guardrail): void
+    {
+        $offshore = $this->resolveOffshore($guardrail);
+
+        if ($offshore) {
+            $this->offshoreService->clearCaches($offshore);
+        }
+    }
+
+    protected function resolveOffshore(OffshoreGuardrail $guardrail): ?Offshore
+    {
+        if ($guardrail->relationLoaded('offshore')) {
+            return $guardrail->getRelation('offshore');
+        }
+
+        return $guardrail->offshore()->first();
+    }
+
+    protected function log(string $action, OffshoreGuardrail $guardrail): void
+    {
+        Log::info("Offshore guardrail {$action}", [
+            'guardrail_id' => $guardrail->id,
+            'offshore_id' => $guardrail->offshore_id,
+            'resource' => $guardrail->resource,
+            'minimum_amount' => $guardrail->minimum_amount,
+        ]);
+    }
+}

--- a/app/Observers/OffshoreObserver.php
+++ b/app/Observers/OffshoreObserver.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Offshore;
+use App\Services\OffshoreService;
+use Illuminate\Support\Facades\Log;
+
+class OffshoreObserver
+{
+    public function __construct(private readonly OffshoreService $offshoreService)
+    {
+    }
+
+    public function created(Offshore $offshore): void
+    {
+        $this->offshoreService->clearCaches($offshore);
+        $this->log('created', $offshore);
+    }
+
+    public function updated(Offshore $offshore): void
+    {
+        $this->offshoreService->clearCaches($offshore);
+        $this->log('updated', $offshore);
+    }
+
+    public function deleted(Offshore $offshore): void
+    {
+        $this->offshoreService->clearCaches($offshore);
+        $this->log('deleted', $offshore);
+    }
+
+    public function restored(Offshore $offshore): void
+    {
+        $this->offshoreService->clearCaches($offshore);
+        $this->log('restored', $offshore);
+    }
+
+    public function forceDeleted(Offshore $offshore): void
+    {
+        $this->offshoreService->clearCaches($offshore);
+        $this->log('force-deleted', $offshore);
+    }
+
+    protected function log(string $action, Offshore $offshore): void
+    {
+        Log::info("Offshore {$action}", [
+            'offshore_id' => $offshore->id,
+            'name' => $offshore->name,
+            'alliance_id' => $offshore->alliance_id,
+            'enabled' => $offshore->enabled,
+            'priority' => $offshore->priority,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,8 +6,12 @@ use App\Broadcasting\PWMessageChannel;
 use App\Models\CityGrantRequest;
 use App\Models\Loan;
 use App\Models\Nation;
+use App\Models\Offshore;
+use App\Models\OffshoreGuardrail;
 use App\Models\User;
 use App\Models\WarAidRequest;
+use App\Observers\OffshoreGuardrailObserver;
+use App\Observers\OffshoreObserver;
 use App\Services\PWHealthService;
 use App\Services\PWMessageService;
 use Illuminate\Support\Facades\Cache;
@@ -40,6 +44,9 @@ class AppServiceProvider extends ServiceProvider
         Route::model('Loan', Loan::class);
         Route::model('Nation', Nation::class);
         Route::model('WarAidRequest', WarAidRequest::class);
+
+        Offshore::observe(OffshoreObserver::class);
+        OffshoreGuardrail::observe(OffshoreGuardrailObserver::class);
 
         Gate::define('viewPulse', function (User $user) {
             return Gate::allows('view-diagnostic-info');

--- a/app/Services/OffshoreService.php
+++ b/app/Services/OffshoreService.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\PWQueryFailedException;
+use App\Models\Offshore;
+use App\Models\OffshoreGuardrail;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class OffshoreService
+{
+    private const CACHE_TTL_MINUTES = 30;
+
+    public function all(bool $includeDisabled = false): Collection
+    {
+        $query = Offshore::query()
+            ->with('guardrails')
+            ->orderByDesc('enabled')
+            ->orderBy('priority');
+
+        if (! $includeDisabled) {
+            $query->where('enabled', true);
+        }
+
+        return $query->get();
+    }
+
+    public function find(int $id): ?Offshore
+    {
+        return Offshore::with('guardrails')->find($id);
+    }
+
+    public function create(array $attributes, ?array $guardrails = null): Offshore
+    {
+        $offshore = new Offshore($attributes);
+        $offshore->save();
+
+        $this->syncGuardrails($offshore, $guardrails);
+        $this->clearCaches($offshore);
+
+        return $offshore->fresh('guardrails');
+    }
+
+    public function update(Offshore $offshore, array $attributes, ?array $guardrails = null): Offshore
+    {
+        $offshore->fill($attributes);
+        $offshore->save();
+
+        $this->syncGuardrails($offshore, $guardrails);
+        $this->clearCaches($offshore);
+
+        return $offshore->fresh('guardrails');
+    }
+
+    public function delete(Offshore $offshore): void
+    {
+        $offshore->delete();
+        $this->clearCaches($offshore);
+    }
+
+    public function guardrailFor(Offshore $offshore, string $resource): ?OffshoreGuardrail
+    {
+        return $offshore->guardrailFor($resource);
+    }
+
+    public function getBalances(Offshore $offshore, bool $force = false): array
+    {
+        $cacheKey = $this->balancesCacheKey($offshore);
+
+        if ($force) {
+            Cache::forget($cacheKey);
+        }
+
+        return Cache::remember($cacheKey, now()->addMinutes(self::CACHE_TTL_MINUTES), function () use ($offshore) {
+            return $this->fetchLiveBalances($offshore);
+        });
+    }
+
+    public function refreshBalances(Offshore $offshore, bool $force = false): array
+    {
+        $cacheKey = $this->balancesCacheKey($offshore);
+
+        Cache::forget($cacheKey);
+
+        if ($force) {
+            $offshore->refresh();
+        }
+
+        $balances = $this->fetchLiveBalances($offshore);
+
+        Cache::put($cacheKey, $balances, now()->addMinutes(self::CACHE_TTL_MINUTES));
+
+        Log::info('Offshore balances refreshed', [
+            'offshore_id' => $offshore->id,
+            'alliance_id' => $offshore->alliance_id,
+            'force' => $force,
+        ]);
+
+        return $balances;
+    }
+
+    public function clearCaches(Offshore $offshore): void
+    {
+        Cache::forget($this->balancesCacheKey($offshore));
+    }
+
+    protected function fetchLiveBalances(Offshore $offshore): array
+    {
+        $parameters = [];
+
+        $apiKey = $offshore->api_key_decrypted;
+        $mutationKey = $offshore->mutation_key_decrypted;
+
+        if ($apiKey) {
+            $parameters['apiKey'] = $apiKey;
+        }
+
+        if ($mutationKey) {
+            $parameters['mutationKey'] = $mutationKey;
+        }
+
+        /** @var QueryService $client */
+        $client = App::make(QueryService::class, $parameters);
+
+        $builder = (new GraphQLQueryBuilder())
+            ->setRootField('alliances')
+            ->addArgument('id', $offshore->alliance_id)
+            ->addNestedField('data', function (GraphQLQueryBuilder $builder) {
+                $builder->addFields(SelectionSetHelper::allianceSet());
+            });
+
+        try {
+            $response = $client->sendQuery($builder);
+        } catch (ConnectionException|PWQueryFailedException $exception) {
+            Log::warning('Failed to fetch offshore balances', [
+                'offshore_id' => $offshore->id,
+                'alliance_id' => $offshore->alliance_id,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return [];
+        } catch (Throwable $exception) {
+            Log::error('Unexpected error while fetching offshore balances', [
+                'offshore_id' => $offshore->id,
+                'alliance_id' => $offshore->alliance_id,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $result = (array)($response->{0} ?? []);
+        $resources = PWHelperService::resources(includeCredits: true);
+
+        return collect($resources)
+            ->mapWithKeys(fn(string $resource) => [
+                $resource => (float) Arr::get($result, $resource, 0),
+            ])
+            ->all();
+    }
+
+    protected function syncGuardrails(Offshore $offshore, ?array $guardrails): void
+    {
+        if (is_null($guardrails)) {
+            return;
+        }
+
+        $guardrailsCollection = collect($guardrails)
+            ->filter(fn($guardrail) => is_array($guardrail))
+            ->mapWithKeys(function (array $guardrail) {
+                $resource = $guardrail['resource'] ?? null;
+
+                if (! $resource) {
+                    return [];
+                }
+
+                return [
+                    $resource => [
+                        'minimum_amount' => (float) ($guardrail['minimum_amount'] ?? 0),
+                    ],
+                ];
+            });
+
+        $existingResources = $offshore->guardrails()->pluck('resource');
+
+        foreach ($guardrailsCollection as $resource => $payload) {
+            $offshore->guardrails()->updateOrCreate(
+                ['resource' => $resource],
+                ['minimum_amount' => $payload['minimum_amount']]
+            );
+        }
+
+        $resourcesToDelete = $existingResources->diff($guardrailsCollection->keys());
+
+        if ($resourcesToDelete->isNotEmpty()) {
+            $offshore->guardrails()->whereIn('resource', $resourcesToDelete)->delete();
+        }
+    }
+
+    protected function balancesCacheKey(Offshore $offshore): string
+    {
+        return sprintf('offshores:%d:balances', $offshore->id);
+    }
+}

--- a/app/Services/QueryService.php
+++ b/app/Services/QueryService.php
@@ -33,6 +33,10 @@ class QueryService
      */
     protected string $endpoint;
     /**
+     * @var string|null
+     */
+    protected ?string $mutationKey = null;
+    /**
      * @var int
      */
     protected int $maxConcurrency = 5;
@@ -40,9 +44,10 @@ class QueryService
     /**
      *
      */
-    public function __construct()
+    public function __construct(?string $apiKey = null, ?string $mutationKey = null)
     {
-        $this->apiKey = $this->getAPIKey();
+        $this->apiKey = $apiKey ?? $this->getAPIKey();
+        $this->mutationKey = $mutationKey ?? $this->getMutationKey();
         $this->endpoint = $this->buildEndpoint();
     }
 
@@ -58,7 +63,15 @@ class QueryService
             throw new Exception("Env value PW_API_KEY not set");
         }
 
-        return env("PW_API_KEY");
+        return $apiKey;
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getMutationKey(): ?string
+    {
+        return env('PW_API_MUTATION_KEY');
     }
 
     /**
@@ -150,10 +163,10 @@ class QueryService
      */
     protected function getHeaders(): array
     {
-        return [
-            'X-Bot-Key' => env("PW_API_MUTATION_KEY"),
-            'X-Api-Key' => env("PW_API_KEY"),
-        ];
+        return array_filter([
+            'X-Bot-Key' => $this->mutationKey,
+            'X-Api-Key' => $this->apiKey,
+        ], fn($value) => ! is_null($value));
     }
 
     /**

--- a/database/migrations/2025_07_21_000000_create_offshores_table.php
+++ b/database/migrations/2025_07_21_000000_create_offshores_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('offshores', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('alliance_id')->constrained('alliances');
+            $table->boolean('enabled')->default(true);
+            $table->unsignedInteger('priority')->default(0);
+            $table->text('api_key')->nullable();
+            $table->text('mutation_key')->nullable();
+            $table->timestamps();
+
+            $table->index(['enabled', 'priority']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('offshores');
+    }
+};

--- a/database/migrations/2025_07_21_000100_create_offshore_guardrails_table.php
+++ b/database/migrations/2025_07_21_000100_create_offshore_guardrails_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('offshore_guardrails', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('offshore_id')->constrained('offshores')->cascadeOnDelete();
+            $table->enum('resource', [
+                'money',
+                'coal',
+                'oil',
+                'uranium',
+                'iron',
+                'bauxite',
+                'lead',
+                'gasoline',
+                'munitions',
+                'steel',
+                'aluminum',
+                'food',
+                'credits',
+            ]);
+            $table->decimal('minimum_amount', 20, 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(['offshore_id', 'resource']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('offshore_guardrails');
+    }
+};


### PR DESCRIPTION
## Summary
- add migrations for offshores and guardrails with priority indexing and cascading cleanup
- introduce encrypted offshore models, admin form requests, and a service that manages guardrails plus cached balance refreshes via QueryService overrides
- update QueryService to accept runtime API credentials and register observers so offshore cache keys (`offshores:{id}:balances`) stay in sync while emitting audit logs

## Testing
- php -l app/Models/Offshore.php
- php -l app/Models/OffshoreGuardrail.php
- php -l app/Services/OffshoreService.php
- php -l app/Services/QueryService.php
- php -l app/Observers/OffshoreObserver.php
- php -l app/Observers/OffshoreGuardrailObserver.php
- php -l app/Http/Requests/Admin/OffshoreRequest.php
- php -l app/Http/Requests/Admin/StoreOffshoreRequest.php
- php -l app/Http/Requests/Admin/UpdateOffshoreRequest.php
- php -l database/migrations/2025_07_21_000000_create_offshores_table.php
- php -l database/migrations/2025_07_21_000100_create_offshore_guardrails_table.php

------
https://chatgpt.com/codex/tasks/task_e_68fe5e0a76f483238bfc0d1d80be6184