### PR TITLE
Fix readonly main alliance id initialization

### DIFF
--- a/app/Services/OffshoreTransferService.php
+++ b/app/Services/OffshoreTransferService.php
@@ -17,13 +17,17 @@ use Throwable;
 
 class OffshoreTransferService
 {
+    private readonly int $mainAllianceId;
+
     public function __construct(
         private readonly OffshoreService $offshoreService,
-        private readonly int $mainAllianceId = 0
+        ?int $mainAllianceId = null
     ) {
-        $this->mainAllianceId = $this->mainAllianceId > 0
-            ? $this->mainAllianceId
+        $resolvedAllianceId = $mainAllianceId !== null && $mainAllianceId > 0
+            ? $mainAllianceId
             : (int) env('PW_ALLIANCE_ID', 0);
+
+        $this->mainAllianceId = $resolvedAllianceId;
     }
 
     /**


### PR DESCRIPTION
## Summary
- resolve the main alliance ID for offshore transfers during construction without mutating a readonly property

## Testing
- ./vendor/bin/pint *(fails: vendor binaries not installed and Composer install requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68fe6c70652c83238d0c6507a4040271