### PR TITLE
Harden offshore management flows

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,14 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests;
+    use DispatchesJobs;
+    use ValidatesRequests;
 }

--- a/app/Http/Requests/Admin/OffshoreRequest.php
+++ b/app/Http/Requests/Admin/OffshoreRequest.php
@@ -58,7 +58,14 @@ abstract class OffshoreRequest extends FormRequest
             return null;
         }
 
-        return collect($this->input('guardrails', []))
+        $rawGuardrails = $this->input('guardrails', []);
+
+        if (! is_array($rawGuardrails)) {
+            return [];
+        }
+
+        return collect($rawGuardrails)
+            ->filter(fn($guardrail) => is_array($guardrail))
             ->map(fn(array $guardrail) => [
                 'resource' => $guardrail['resource'],
                 'minimum_amount' => (float) $guardrail['minimum_amount'],

--- a/app/Services/OffshoreFulfillmentService.php
+++ b/app/Services/OffshoreFulfillmentService.php
@@ -323,9 +323,23 @@ class OffshoreFulfillmentService
      */
     protected function sendOffshoreWithdrawal(Offshore $offshore, Transaction $transaction, array $payload): void
     {
+        $apiKey = $offshore->api_key_decrypted;
+        $mutationKey = $offshore->mutation_key_decrypted;
+
+        if (! $apiKey || ! $mutationKey) {
+            Log::error('Missing offshore credentials for fulfillment withdrawal', [
+                'transaction_id' => $transaction->id,
+                'offshore_id' => $offshore->id,
+                'missing_api_key' => empty($apiKey),
+                'missing_mutation_key' => empty($mutationKey),
+            ]);
+
+            throw new PWQueryFailedException('Offshore credentials are missing or invalid.');
+        }
+
         $parameters = [
-            'apiKey' => $offshore->api_key_decrypted,
-            'mutationKey' => $offshore->mutation_key_decrypted,
+            'apiKey' => $apiKey,
+            'mutationKey' => $mutationKey,
         ];
 
         /** @var QueryService $client */

--- a/resources/views/admin/offshores/index.blade.php
+++ b/resources/views/admin/offshores/index.blade.php
@@ -339,6 +339,7 @@
                                 </button>
                             </div>
                             @php($createGuardrails = $modalContext === 'create' ? old('guardrails', []) : [])
+                            <input type="hidden" name="guardrails" value="">
                             <div id="create-guardrail-container" class="guardrail-container" data-next-index="{{ count($createGuardrails) }}">
                                 @foreach($createGuardrails as $index => $guardrail)
                                     @include('admin.offshores.partials.guardrail-row', ['index' => $index, 'guardrail' => $guardrail, 'resources' => $guardrailResources])
@@ -418,6 +419,7 @@
                                             'minimum_amount' => $guardrail->minimum_amount,
                                         ])->all();
                                 @endphp
+                                <input type="hidden" name="guardrails" value="">
                                 <div id="edit-guardrail-container-{{ $offshore->id }}" class="guardrail-container"
                                      data-next-index="{{ count($editGuardrails) }}">
                                     @foreach($editGuardrails as $index => $guardrail)


### PR DESCRIPTION
## Summary
- extend the base controller with Laravel's authorization helpers so admin controllers can call authorize()
- guard manual and automated offshore transfers by requiring decrypted credentials and logging missing keys before hitting the PW API
- ensure guardrail forms always submit predictable payloads so validation can clear or update guardrails safely

## Testing
- ./vendor/bin/pint *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fe6dc02ed88323ab29eea58d8a12ba