### PR TITLE
Allow blank offshore credential inputs to preserve stored keys

### DIFF
--- a/app/Http/Requests/Admin/OffshoreRequest.php
+++ b/app/Http/Requests/Admin/OffshoreRequest.php
@@ -26,8 +26,12 @@ abstract class OffshoreRequest extends FormRequest
     {
         $nameRule = $this->isUpdate() ? ['sometimes', 'string', 'max:255'] : ['required', 'string', 'max:255'];
         $allianceRule = $this->isUpdate() ? ['sometimes', 'integer', 'exists:alliances,id'] : ['required', 'integer', 'exists:alliances,id'];
-        $apiKeyRule = $this->isUpdate() ? ['sometimes', 'string', 'max:255'] : ['required', 'string', 'max:255'];
-        $mutationKeyRule = $this->isUpdate() ? ['sometimes', 'string', 'max:255'] : ['required', 'string', 'max:255'];
+        $apiKeyRule = $this->isUpdate()
+            ? ['sometimes', 'nullable', 'string', 'max:255']
+            : ['required', 'string', 'max:255'];
+        $mutationKeyRule = $this->isUpdate()
+            ? ['sometimes', 'nullable', 'string', 'max:255']
+            : ['required', 'string', 'max:255'];
 
         return [
             'name' => $nameRule,
@@ -46,8 +50,8 @@ abstract class OffshoreRequest extends FormRequest
     {
         return collect($this->safe()->except(['guardrails']))
             ->reject(function ($value, string $key) {
-                // Avoid overwriting credentials with empty strings during updates.
-                return in_array($key, ['api_key', 'mutation_key'], true) && $value === '';
+                // Avoid overwriting credentials with empty or null values during updates.
+                return in_array($key, ['api_key', 'mutation_key'], true) && blank($value);
             })
             ->all();
     }


### PR DESCRIPTION
## Summary
- allow update requests to accept nullable API and mutation keys so empty form fields do not trigger validation errors
- skip updating stored credentials when the submitted value is blank or null to keep existing keys intact

## Testing
- unable to run `./vendor/bin/pint` (requires composer install, which failed due to GitHub 403 while downloading dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68fe74174dd88323b1d5b77923aea18f