### PR TITLE
Restore GraphQL helper references for offshore transfers

### DIFF
--- a/app/Services/OffshoreTransferService.php
+++ b/app/Services/OffshoreTransferService.php
@@ -111,7 +111,7 @@ class OffshoreTransferService
     protected function sendFromMainToOffshore(Offshore $offshore, array $payload, string $note): void
     {
         $this->executeTransfer(
-            fn(GraphQLQueryBuilder $builder) => $builder
+            fn(\App\Services\GraphQLQueryBuilder $builder) => $builder
                 ->addArgument('receiver', $offshore->alliance_id)
                 ->addArgument('receiver_type', 2)
                 ->addArgument('note', $note),
@@ -134,7 +134,7 @@ class OffshoreTransferService
         $credentials = $this->requireOffshoreCredentials($offshore);
 
         $this->executeTransfer(
-            fn(GraphQLQueryBuilder $builder) => $builder
+            fn(\App\Services\GraphQLQueryBuilder $builder) => $builder
                 ->addArgument('receiver', $this->mainAllianceId)
                 ->addArgument('receiver_type', 2)
                 ->addArgument('note', $note),
@@ -160,10 +160,10 @@ class OffshoreTransferService
         /** @var QueryService $client */
         $client = App::make(QueryService::class, $parameters);
 
-        $builder = (new GraphQLQueryBuilder())
+        $builder = (new \App\Services\GraphQLQueryBuilder())
             ->setRootField('bankWithdraw')
             ->setMutation()
-            ->addFields(SelectionSetHelper::bankRecordSet());
+            ->addFields(\App\Services\SelectionSetHelper::bankRecordSet());
 
         $builderCallback($builder);
 


### PR DESCRIPTION
## Summary
- reference the GraphQLQueryBuilder helper by its fully qualified name when constructing manual offshore transfer mutations
- call SelectionSetHelper via its fully qualified name so bank record fields load during transfers

## Testing
- not run (per project policy)

------
https://chatgpt.com/codex/tasks/task_e_68fe79fd7664832380f87fec6131e482