### PR TITLE
Fix offshore sweep payload and layout

### DIFF
--- a/app/Http/Controllers/Admin/OffshoreController.php
+++ b/app/Http/Controllers/Admin/OffshoreController.php
@@ -227,7 +227,7 @@ class OffshoreController extends Controller
 
         $balances = $this->mainBankService->refreshBalances();
 
-        $payload = collect(PWHelperService::resources())
+        $payload = collect(PWHelperService::resources(includeCredits: true))
             ->mapWithKeys(fn(string $resource) => [
                 $resource => (float) ($balances[$resource] ?? 0),
             ])

--- a/resources/views/admin/offshores/index.blade.php
+++ b/resources/views/admin/offshores/index.blade.php
@@ -231,8 +231,6 @@
                 </div>
             </div>
         </div>
-    </div>
-
         <div class="col-12 col-xl-4">
             <div class="card shadow-sm h-100">
                 <div class="card-header d-flex justify-content-between align-items-center">
@@ -268,9 +266,11 @@
                 </div>
             </div>
         </div>
+    </div>
 
+    <div class="row g-4 mt-0">
         @if($canManageOffshores)
-            <div class="col-lg-5">
+            <div class="col-12 col-lg-5 col-xl-4">
                 <div class="card shadow-sm h-100">
                     <div class="card-header">
                         <h5 class="mb-0">Manual Transfer</h5>
@@ -283,96 +283,76 @@
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div class="col-12 col-xl-8">
-            <div class="row g-4 h-100">
-                @if($canManageOffshores)
-                    <div class="col-12 col-lg-5 col-xl-6">
-                        <div class="card shadow-sm h-100">
-                            <div class="card-header">
-                                <h5 class="mb-0">Manual Transfer</h5>
-                            </div>
-                            <div class="card-body">
-                                <p class="text-muted small">Bridge funds between the main bank and offshores. Transfers are executed instantly using the configured API keys.</p>
-                                <button class="btn btn-outline-primary w-100" data-bs-toggle="modal" data-bs-target="#manualTransferModal">
-                                    <i class="bi bi-cash-coin me-1"></i> Start Transfer
-                                </button>
-                            </div>
+            <div class="col-12 col-lg-7 col-xl-8">
+        @else
+            <div class="col-12">
+        @endif
+                <div class="card shadow-sm h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">Recent Manual Transfers</h5>
+                        <span class="text-muted small">Last {{ $transfers->count() }} records</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-striped align-middle mb-0">
+                                <thead>
+                                <tr>
+                                    <th>When</th>
+                                    <th>Initiated By</th>
+                                    <th>Route</th>
+                                    <th>Payload</th>
+                                    <th>Status</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @forelse($transfers as $transfer)
+                                    <tr>
+                                        <td>{{ $transfer->created_at?->format('M d, Y H:i') ?? 'Unknown' }}</td>
+                                        <td>{{ $transfer->user?->name ?? 'Unknown User' }}</td>
+                                        <td>
+                                            {{ $transfer->source_type === \App\Models\OffshoreTransfer::TYPE_MAIN ? 'Main Bank' : ($transfer->sourceOffshore?->name ?? 'Offshore') }}
+                                            <i class="bi bi-arrow-right-short"></i>
+                                            {{ $transfer->destination_type === \App\Models\OffshoreTransfer::TYPE_MAIN ? 'Main Bank' : ($transfer->destinationOffshore?->name ?? 'Offshore') }}
+                                        </td>
+                                        <td>
+                                            <ul class="list-inline mb-0 small">
+                                                @foreach($transfer->payload as $resource => $amount)
+                                                    <li class="list-inline-item text-capitalize">
+                                                        <span class="badge text-bg-light">
+                                                            {{ $resource }}:
+                                                            {{ $resource === 'money' ? '$' . number_format($amount, 2) : number_format($amount, 2) }}
+                                                        </span>
+                                                    </li>
+                                                @endforeach
+                                            </ul>
+                                            @if($transfer->message)
+                                                <div class="small text-muted mt-1">{{ $transfer->message }}</div>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            @switch($transfer->status)
+                                                @case(\App\Models\OffshoreTransfer::STATUS_COMPLETED)
+                                                    <span class="badge text-bg-success">Completed</span>
+                                                    @break
+                                                @case(\App\Models\OffshoreTransfer::STATUS_FAILED)
+                                                    <span class="badge text-bg-danger">Failed</span>
+                                                    @break
+                                                @default
+                                                    <span class="badge text-bg-secondary">Pending</span>
+                                            @endswitch
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="text-center text-muted py-4">No transfers recorded yet.</td>
+                                    </tr>
+                                @endforelse
+                                </tbody>
+                            </table>
                         </div>
                     </div>
-                    <div class="col-12 col-lg-7 col-xl-6">
-                @else
-                    <div class="col-12">
-                @endif
-                        <div class="card shadow-sm h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h5 class="mb-0">Recent Manual Transfers</h5>
-                                <span class="text-muted small">Last {{ $transfers->count() }} records</span>
-                            </div>
-                            <div class="card-body">
-                                <div class="table-responsive">
-                                    <table class="table table-striped align-middle mb-0">
-                                        <thead>
-                                        <tr>
-                                            <th>When</th>
-                                            <th>Initiated By</th>
-                                            <th>Route</th>
-                                            <th>Payload</th>
-                                            <th>Status</th>
-                                        </tr>
-                                        </thead>
-                                        <tbody>
-                                        @forelse($transfers as $transfer)
-                                            <tr>
-                                                <td>{{ $transfer->created_at?->format('M d, Y H:i') ?? 'Unknown' }}</td>
-                                                <td>{{ $transfer->user?->name ?? 'Unknown User' }}</td>
-                                                <td>
-                                                    {{ $transfer->source_type === \App\Models\OffshoreTransfer::TYPE_MAIN ? 'Main Bank' : ($transfer->sourceOffshore?->name ?? 'Offshore') }}
-                                                    <i class="bi bi-arrow-right-short"></i>
-                                                    {{ $transfer->destination_type === \App\Models\OffshoreTransfer::TYPE_MAIN ? 'Main Bank' : ($transfer->destinationOffshore?->name ?? 'Offshore') }}
-                                                </td>
-                                                <td>
-                                                    <ul class="list-inline mb-0 small">
-                                                        @foreach($transfer->payload as $resource => $amount)
-                                                            <li class="list-inline-item text-capitalize">
-                                                                <span class="badge text-bg-light">
-                                                                    {{ $resource }}:
-                                                                    {{ $resource === 'money' ? '$' . number_format($amount, 2) : number_format($amount, 2) }}
-                                                                </span>
-                                                            </li>
-                                                        @endforeach
-                                                    </ul>
-                                                    @if($transfer->message)
-                                                        <div class="small text-muted mt-1">{{ $transfer->message }}</div>
-                                                    @endif
-                                                </td>
-                                                <td>
-                                                    @switch($transfer->status)
-                                                        @case(\App\Models\OffshoreTransfer::STATUS_COMPLETED)
-                                                            <span class="badge text-bg-success">Completed</span>
-                                                            @break
-                                                        @case(\App\Models\OffshoreTransfer::STATUS_FAILED)
-                                                            <span class="badge text-bg-danger">Failed</span>
-                                                            @break
-                                                        @default
-                                                            <span class="badge text-bg-secondary">Pending</span>
-                                                    @endswitch
-                                                </td>
-                                            </tr>
-                                        @empty
-                                            <tr>
-                                                <td colspan="5" class="text-center text-muted py-4">No transfers recorded yet.</td>
-                                            </tr>
-                                        @endforelse
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                </div>
             </div>
-        </div>
     </div>
 
     @if($canManageOffshores)


### PR DESCRIPTION
## Summary
- include credits when building the main bank sweep payload so sweeps fire when only credits are cached
- repair the admin offshore dashboard markup so the manual transfer card renders correctly and closes Blade directives

## Testing
- not run (per project policy)


------
https://chatgpt.com/codex/tasks/task_e_68fe79c0f08883238a000656074f1fb9