### PR TITLE
Display zero balances in main bank snapshot

### DIFF
--- a/resources/views/admin/offshores/index.blade.php
+++ b/resources/views/admin/offshores/index.blade.php
@@ -249,7 +249,8 @@
                 </div>
                 <div class="card-body">
                     @php
-                        $visibleMainBalances = collect($mainBankSnapshot['balances'] ?? [])->filter(fn($amount) => $amount > 0);
+                        $visibleMainBalances = collect($mainBankSnapshot['balances'] ?? [])
+                            ->filter(fn($amount) => $amount !== null);
                     @endphp
                     @if($visibleMainBalances->isNotEmpty())
                         <div class="text-muted small">


### PR DESCRIPTION
## Summary
- ensure the main bank snapshot on the offshore dashboard keeps zero-value balances visible so users can see empty resources

## Testing
- not run (per project policy)


------
https://chatgpt.com/codex/tasks/task_e_68fe7fd046008323aa38fff85a5a0786