### PR TITLE
Track last scanned taxes per alliance

### DIFF
--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -28,7 +28,7 @@ class TaxService
         Cache::forget('tax_daily_totals');
 
         $taxes = self::getAllianceTaxes($alliance_id, $client);
-        $lastTaxId = self::getLastScannedTaxRecordId();
+        $lastTaxId = self::getLastScannedTaxRecordId($alliance_id);
         $newLastId = $lastTaxId;
 
         $ddService = app(DirectDepositService::class);
@@ -99,9 +99,15 @@ class TaxService
     /**
      * @return int
      */
-    public static function getLastScannedTaxRecordId(): int
+    public static function getLastScannedTaxRecordId(?int $allianceId = null): int
     {
-        return Taxes::value(DB::raw('MAX(id)')) ?: 0;
+        $query = Taxes::query();
+
+        if ($allianceId !== null) {
+            $query->where('receiver_id', $allianceId);
+        }
+
+        return (int)($query->max('id') ?? 0);
     }
 
     /**


### PR DESCRIPTION
## Summary
- scope the last scanned tax ID lookup to the current alliance to avoid skipping offshore records

## Testing
- ./vendor/bin/pint *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fe8b02722c83238c47946c8bf5acfc