### PR TITLE
Restore primary alliance ID lookup

### DIFF
--- a/app/Services/AllianceMembershipService.php
+++ b/app/Services/AllianceMembershipService.php
@@ -40,7 +40,7 @@ class AllianceMembershipService
      */
     public function getPrimaryAllianceId(): int
     {
-        return $this->getAllianceIds()->first() ?? 0;
+        return (int) env('PW_ALLIANCE_ID', 0);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure AllianceMembershipService::getPrimaryAllianceId reads the PW_ALLIANCE_ID environment value directly so safeguards trigger when it is missing

## Testing
- ./vendor/bin/pint app/Services/AllianceMembershipService.php *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fe8d0a252c83238dcda79c80197f17