### PR TITLE
Fix trade price gasoline column reference

### DIFF
--- a/app/Console/Commands/UpdateTradePrices.php
+++ b/app/Console/Commands/UpdateTradePrices.php
@@ -39,7 +39,7 @@ class UpdateTradePrices extends Command
                 'iron' => (int)$graphqlPrice->iron,
                 'bauxite' => (int)$graphqlPrice->bauxite,
                 'lead' => (int)$graphqlPrice->lead,
-                'gas' => (int)$graphqlPrice->gasoline,
+                'gasoline' => (int)$graphqlPrice->gasoline,
                 'munitions' => (int)$graphqlPrice->munitions,
                 'steel' => (int)$graphqlPrice->steel,
                 'aluminum' => (int)$graphqlPrice->aluminum,

--- a/app/Models/TradePrice.php
+++ b/app/Models/TradePrice.php
@@ -19,7 +19,7 @@ class TradePrice extends Model
         'iron',
         'bauxite',
         'lead',
-        'gas',
+        'gasoline',
         'munitions',
         'steel',
         'aluminum',


### PR DESCRIPTION
## Summary
- update the trade price update command to persist the gasoline column name
- adjust the TradePrice model fillable list to reference gasoline instead of gas

## Testing
- ./vendor/bin/pint *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fe9f8bcb9883238877d72ae5dcb530