### PR TITLE
Fix MMR tier money reset on admin updates

### DIFF
--- a/app/Http/Controllers/Admin/MMRController.php
+++ b/app/Http/Controllers/Admin/MMRController.php
@@ -66,11 +66,13 @@ class MMRController extends Controller
             array_merge(
                 ['city_count' => $validated['city_count']],
                 array_fill_keys([
+                    'money',
                     'steel',
                     'aluminum',
                     'munitions',
                     'uranium',
                     'food',
+                    'gasoline',
                     'barracks',
                     'factories',
                     'hangars',
@@ -133,11 +135,13 @@ class MMRController extends Controller
     {
         $this->authorize('manage-mmr');
         $fields = [
+            'money',
             'steel',
             'aluminum',
             'munitions',
             'uranium',
             'food',
+            'gasoline',
             'barracks',
             'factories',
             'hangars',

--- a/app/Models/MMRTier.php
+++ b/app/Models/MMRTier.php
@@ -10,11 +10,13 @@ class MMRTier extends Model
 
     protected $fillable = [
         'city_count',
+        'money',
         'steel',
         'aluminum',
         'munitions',
         'uranium',
         'food',
+        'gasoline',
         'barracks',
         'factories',
         'hangars',
@@ -25,11 +27,13 @@ class MMRTier extends Model
     ];
 
     protected $casts = [
+        'money' => 'integer',
         'steel' => 'integer',
         'aluminum' => 'integer',
         'munitions' => 'integer',
         'uranium' => 'integer',
         'food' => 'integer',
+        'gasoline' => 'integer',
         'barracks' => 'integer',
         'factories' => 'integer',
         'hangars' => 'integer',


### PR DESCRIPTION
## Summary
- add the cash and gasoline columns to the MMR tier model so they can be mass assigned and cast correctly
- update the admin MMR controller to include cash and gasoline when seeding new tiers and when bulk-updating tier requirements

## Testing
- not run (environment cannot install dependencies to execute Pint)


------
https://chatgpt.com/codex/tasks/task_e_68fea1b93dac83239a2a99c51fe5b395