### PR TITLE
Refresh admin role and user management pages

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -24,10 +24,19 @@ class UserController extends Controller
     {
         $this->authorize('view-users');
 
-        $users = User::with('nation')
+        $statsQuery = User::query();
+
+        $stats = [
+            'total_users' => (clone $statsQuery)->count(),
+            'admins' => (clone $statsQuery)->where('is_admin', true)->count(),
+            'active_today' => (clone $statsQuery)->whereNotNull('last_active_at')->where('last_active_at', '>=', now()->subDay())->count(),
+        ];
+
+        $users = User::with(['nation', 'roles'])
+            ->latest('last_active_at')
             ->paginate(25);
 
-        return view('admin.users.index', compact('users'));
+        return view('admin.users.index', compact('users', 'stats'));
     }
 
     /**

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -28,7 +28,7 @@ class Role extends Model
      */
     public function permissions(): HasMany
     {
-        return $this->hasMany(RolePermission::class);
+        return $this->hasMany(RolePermission::class)->orderBy('permission');
     }
 
     /**

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -1,71 +1,137 @@
 @extends('layouts.admin')
 
 @section('content')
+    @php use Illuminate\Support\Str; @endphp
+
     <div class="app-content-header">
         <div class="container-fluid">
             <div class="row">
-                <div class="col-sm-6">
-                    <h3 class="mb-0">Manage Roles</h3>
+                <div class="col">
+                    <h3 class="mb-1">Manage Roles</h3>
+                    <p class="text-muted mb-0">Review role coverage, update permissions, and keep your access model organized.</p>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="card mt-3 shadow-sm">
-        <div class="card-header d-flex justify-content-between align-items-center">
-            <span>All Roles</span>
-            <a href="{{ route('admin.roles.create') }}" class="btn btn-sm btn-success">
-                <i class="bi bi-plus-circle me-1"></i> New Role
-            </a>
+    <div class="container-fluid">
+        <div class="row g-3 mt-1">
+            <div class="col-12 col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <span class="text-uppercase text-muted small fw-semibold">Total roles</span>
+                                <div class="display-6 fw-bold mt-1">{{ $stats['total_roles'] }}</div>
+                            </div>
+                            <span class="text-primary fs-3"><i class="bi bi-people"></i></span>
+                        </div>
+                        <p class="text-muted small mb-0 mt-3">All roles currently available to assign.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <span class="text-uppercase text-muted small fw-semibold">Protected roles</span>
+                                <div class="display-6 fw-bold mt-1">{{ $stats['protected_roles'] }}</div>
+                            </div>
+                            <span class="text-warning fs-3"><i class="bi bi-shield-lock"></i></span>
+                        </div>
+                        <p class="text-muted small mb-0 mt-3">Locked roles that cannot be edited or removed.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <span class="text-uppercase text-muted small fw-semibold">Unique permissions</span>
+                                <div class="display-6 fw-bold mt-1">{{ $stats['unique_permissions'] }}</div>
+                            </div>
+                            <span class="text-success fs-3"><i class="bi bi-key"></i></span>
+                        </div>
+                        <p class="text-muted small mb-0 mt-3">Distinct capabilities currently in use across roles.</p>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="card-body table-responsive">
-            <table class="table align-middle">
-                <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Protected</th>
-                    <th>Permissions</th>
-                    <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                @foreach($roles as $role)
-                    <tr>
-                        <td>{{ ucfirst($role->name) }}</td>
-                        <td>
-                            @if($role->protected)
-                                <span class="badge bg-secondary">Yes</span>
-                            @else
-                                <span class="badge bg-light text-muted">No</span>
-                            @endif
-                        </td>
-                        <td>
-                            @foreach($role->permissions() as $perm)
-                                <span class="badge bg-info text-dark me-1">{{ $perm }}</span>
-                            @endforeach
-                        </td>
-                        <td class="text-end">
-                            @if(!$role->protected)
-                                <a href="{{ route('admin.roles.edit', $role) }}" class="btn btn-sm btn-outline-primary">
-                                    <i class="bi bi-pencil"></i> Edit
-                                </a>
 
-                                <form method="POST" action="{{ route('admin.roles.destroy', $role) }}" class="d-inline"
-                                      onsubmit="return confirm('Are you sure you want to delete this role?')">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-sm btn-outline-danger">
-                                        <i class="bi bi-trash"></i> Delete
-                                    </button>
-                                </form>
-                            @else
-                                <span class="text-muted">Locked</span>
-                            @endif
-                        </td>
+        <div class="card border-0 shadow-sm mt-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <div>
+                    <h5 class="mb-0">Role directory</h5>
+                    <span class="text-muted small">Assign, edit, or retire roles as your governance evolves.</span>
+                </div>
+                <a href="{{ route('admin.roles.create') }}" class="btn btn-success">
+                    <i class="bi bi-plus-circle me-1"></i>
+                    New Role
+                </a>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">Role</th>
+                        <th scope="col">Permissions</th>
+                        <th scope="col" class="text-center">Members</th>
+                        <th scope="col" class="text-center">Status</th>
+                        <th scope="col" class="text-end">Actions</th>
                     </tr>
-                @endforeach
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                    @foreach($roles as $role)
+                        <tr>
+                            <td class="fw-semibold text-capitalize">{{ $role->name }}</td>
+                            <td>
+                                <div class="d-flex flex-wrap gap-2">
+                                    @forelse($role->permissions as $permission)
+                                        <span class="badge rounded-pill bg-info text-dark">
+                                            {{ Str::headline($permission->permission) }}
+                                        </span>
+                                    @empty
+                                        <span class="text-muted">No permissions assigned</span>
+                                    @endforelse
+                                </div>
+                            </td>
+                            <td class="text-center">
+                                <span class="badge bg-light text-dark border">{{ $role->users_count }}</span>
+                            </td>
+                            <td class="text-center">
+                                @if($role->protected)
+                                    <span class="badge bg-secondary"><i class="bi bi-lock-fill me-1"></i>Protected</span>
+                                @else
+                                    <span class="badge bg-success"><i class="bi bi-unlock me-1"></i>Editable</span>
+                                @endif
+                            </td>
+                            <td class="text-end">
+                                @if(!$role->protected)
+                                    <div class="btn-group" role="group">
+                                        <a href="{{ route('admin.roles.edit', $role) }}" class="btn btn-sm btn-outline-primary">
+                                            <i class="bi bi-pencil"></i> Edit
+                                        </a>
+                                        <form method="POST" action="{{ route('admin.roles.destroy', $role) }}" class="d-inline"
+                                              onsubmit="return confirm('Are you sure you want to delete this role?')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                <i class="bi bi-trash"></i> Delete
+                                            </button>
+                                        </form>
+                                    </div>
+                                @else
+                                    <span class="text-muted">Locked</span>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 @endsection
+

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,73 +1,150 @@
 @extends('layouts.admin')
 
 @section('content')
+    @php use Illuminate\Support\Str; @endphp
+
     <div class="app-content-header">
         <div class="container-fluid">
             <div class="row align-items-center">
-                <div class="col-sm-6">
-                    <h3 class="mb-0">Users</h3>
+                <div class="col">
+                    <h3 class="mb-1">Users</h3>
+                    <p class="text-muted mb-0">Monitor activity, spot administrators, and jump quickly into user management.</p>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="card mt-4">
-        <div class="card-header">All Users</div>
-        <div class="card-body table-responsive">
-            <table class="table table-hover align-middle">
-                <thead>
-                <tr>
-                    <th>Username</th>
-                    <th>Discord</th>
-                    <th>Nation ID</th>
-                    <th>In Alliance</th>
-                    <th>Is Admin</th>
-                    <th>Last Active</th>
-                    <th>Actions</th>
-                </tr>
-                </thead>
-                <tbody>
-                @php $membershipService = app(\App\Services\AllianceMembershipService::class) @endphp
-                @foreach($users as $user)
-                    <tr>
-                        <td>
-                            {{ $user->name }}
-                            @if($user->last_active_at && now()->diffInMinutes($user->last_active_at) <= 5)
-                                <span class="badge bg-success ms-1">Online</span>
-                            @endif
-                        </td>
-                        <td>{{ $user->nation->discord ?? '—' }}</td>
-                        <td><a href="https://politicsandwar.com/nation/id={{ $user->nation_id }}" target="_blank">{{ $user->nation_id }}</a></td>
-                        <td>
-                            @if($user->nation && $membershipService->contains($user->nation->alliance_id))
-                                <span class="badge bg-primary">Yes</span>
-                            @else
-                                <span class="badge bg-secondary">No</span>
-                            @endif
-                        </td>
-                        <td>
-                            @if($user->is_admin)
-                                <i class="bi bi-check-circle-fill text-success"></i>
-                            @else
-                                <i class="bi bi-x-circle-fill text-danger"></i>
-                            @endif
-                        </td>
-                        <td>
-                            {{ $user->last_active_at ? $user->last_active_at->diffForHumans() : 'Never' }}
-                        </td>
-                        <td>
-                            <a href="{{ route('admin.users.edit', $user->id) }}" class="btn btn-sm btn-outline-primary">
-                                Edit
-                            </a>
-                        </td>
-                    </tr>
-                @endforeach
-                </tbody>
-            </table>
+    <div class="container-fluid">
+        <div class="row g-3 mt-1">
+            <div class="col-12 col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <span class="text-uppercase text-muted small fw-semibold">Total users</span>
+                                <div class="display-6 fw-bold mt-1">{{ $stats['total_users'] }}</div>
+                            </div>
+                            <span class="text-primary fs-3"><i class="bi bi-people"></i></span>
+                        </div>
+                        <p class="text-muted small mb-0 mt-3">All accounts that have access to Nexus.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <span class="text-uppercase text-muted small fw-semibold">Admins</span>
+                                <div class="display-6 fw-bold mt-1">{{ $stats['admins'] }}</div>
+                            </div>
+                            <span class="text-danger fs-3"><i class="bi bi-shield-check"></i></span>
+                        </div>
+                        <p class="text-muted small mb-0 mt-3">Users with elevated platform access.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-md-4">
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <span class="text-uppercase text-muted small fw-semibold">Active today</span>
+                                <div class="display-6 fw-bold mt-1">{{ $stats['active_today'] }}</div>
+                            </div>
+                            <span class="text-success fs-3"><i class="bi bi-activity"></i></span>
+                        </div>
+                        <p class="text-muted small mb-0 mt-3">Members seen within the last 24 hours.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-            <div class="mt-3">
+        <div class="card border-0 shadow-sm mt-4">
+            <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2">
+                <div>
+                    <h5 class="mb-0">Member directory</h5>
+                    <span class="text-muted small">Browse user details and jump into edits without leaving the page.</span>
+                </div>
+                <a href="{{ route('admin.roles.index') }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-shield-lock me-1"></i>
+                    Manage roles
+                </a>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">User</th>
+                        <th scope="col">Discord</th>
+                        <th scope="col">Nation</th>
+                        <th scope="col" class="text-center">Alliance</th>
+                        <th scope="col">Roles</th>
+                        <th scope="col">Last active</th>
+                        <th scope="col" class="text-end">Actions</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @php $membershipService = app(\App\Services\AllianceMembershipService::class); @endphp
+                    @foreach($users as $user)
+                        <tr>
+                            <td>
+                                <div class="fw-semibold">{{ $user->name }}</div>
+                                <div class="text-muted small">{{ $user->email }}</div>
+                                <div class="d-flex flex-wrap gap-2 mt-2">
+                                    @if($user->is_admin)
+                                        <span class="badge bg-danger">Admin</span>
+                                    @endif
+                                    @if($user->last_active_at && now()->diffInMinutes($user->last_active_at) <= 5)
+                                        <span class="badge bg-success">Online</span>
+                                    @endif
+                                </div>
+                            </td>
+                            <td>{{ $user->nation->discord ?? '—' }}</td>
+                            <td>
+                                @if($user->nation_id)
+                                    <a href="https://politicsandwar.com/nation/id={{ $user->nation_id }}" target="_blank" class="text-decoration-none">
+                                        {{ $user->nation_id }}
+                                    </a>
+                                @else
+                                    <span class="text-muted">—</span>
+                                @endif
+                            </td>
+                            <td class="text-center">
+                                @if($user->nation && $membershipService->contains($user->nation->alliance_id))
+                                    <span class="badge bg-primary">Member</span>
+                                @else
+                                    <span class="badge bg-secondary">No</span>
+                                @endif
+                            </td>
+                            <td>
+                                <div class="d-flex flex-wrap gap-2">
+                                    @forelse($user->roles as $role)
+                                        <span class="badge rounded-pill bg-primary">{{ Str::title($role->name) }}</span>
+                                    @empty
+                                        <span class="text-muted">No roles assigned</span>
+                                    @endforelse
+                                </div>
+                            </td>
+                            <td>
+                                {{ $user->last_active_at ? $user->last_active_at->diffForHumans() : 'Never' }}
+                            </td>
+                            <td class="text-end">
+                                <a href="{{ route('admin.users.edit', $user->id) }}" class="btn btn-sm btn-primary">
+                                    <i class="bi bi-pencil-square me-1"></i>
+                                    Edit
+                                </a>
+                            </td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="card-footer bg-white">
                 {{ $users->links() }}
             </div>
         </div>
     </div>
 @endsection
+


### PR DESCRIPTION
## Summary
- eager load role permissions and compute quick stats for the roles dashboard
- restyle the roles index to surface assigned permissions, membership counts, and clearer actions
- refresh the admin users list with at-a-glance metrics and inline role badges

## Testing
- `./vendor/bin/pint` *(fails: file not found in repository snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_68fea94b4b3483239e1b2bd92d19e3ca