### PR TITLE
Prevent deleting accounts with pending activity

### DIFF
--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -7,10 +7,12 @@ use App\Exceptions\UserErrorException;
 use App\GraphQL\Models\BankRecord;
 use App\Models\Account;
 use App\Models\DepositRequest;
+use App\Models\GrantApplication;
 use App\Models\ManualTransaction;
 use App\Models\Nation;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Models\WarAidRequest;
 use App\Notifications\DepositCreated;
 use Exception;
 use Illuminate\Http\Client\ConnectionException;
@@ -87,6 +89,33 @@ class AccountService
         // Check if the account has pending or active loans
         if ($account->loans()->whereIn('status', ['pending', 'approved'])->exists()) {
             throw new UserErrorException("The account has pending or active loans.");
+        }
+
+        // Check if the account has pending grant applications
+        if (GrantApplication::where('account_id', $account->id)->where('status', 'pending')->exists()) {
+            throw new UserErrorException("The account has pending grant applications.");
+        }
+
+        // Check if the account has pending war aid requests
+        if (WarAidRequest::where('account_id', $account->id)->where('status', 'pending')->exists()) {
+            throw new UserErrorException("The account has pending war aid requests.");
+        }
+
+        // Check if the account has pending deposit requests
+        if (DepositRequest::where('account_id', $account->id)->where('status', 'pending')->exists()) {
+            throw new UserErrorException("The account has pending deposit requests.");
+        }
+
+        // Check if the account has pending transactions (withdrawals or transfers)
+        $hasPendingTransactions = Transaction::where('is_pending', true)
+            ->where(function ($query) use ($account) {
+                $query->where('from_account_id', $account->id)
+                    ->orWhere('to_account_id', $account->id);
+            })
+            ->exists();
+
+        if ($hasPendingTransactions) {
+            throw new UserErrorException("The account has pending transactions.");
         }
 
         // Check to ensure the account is empty


### PR DESCRIPTION
## Summary
- block account deletion whenever grant applications, war aid requests, or deposit requests are still pending
- stop removal when pending transactions reference the account so withdrawals and transfers must complete first

## Testing
- composer install --no-interaction --no-progress *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fea9b14fcc8323ab8bf2d61edb4a1c