### PR TITLE
Display manual adjustments on account view

### DIFF
--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -284,6 +284,7 @@ class AccountsController extends Controller
         $accounts->load("nation");
 
         $transactions = AccountService::getRelatedTransactions($accounts);
+        $manualTransactions = AccountService::getRelatedManualTransactions($accounts);
 
         $ddLogs = DirectDepositLog::where('account_id', $accounts->id)
             ->latest()
@@ -294,6 +295,7 @@ class AccountsController extends Controller
         return view("accounts.view", [
             "account" => $accounts,
             "transactions" => $transactions,
+            "manualTransactions" => $manualTransactions,
             "ddLogs" => $ddLogs,
         ]);
     }

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -407,9 +407,10 @@ class AccountService
      *
      * @return mixed
      */
-    public static function getRelatedManualTransactions(Account $account, int $perPage)
+    public static function getRelatedManualTransactions(Account $account, int $perPage = 50)
     {
         return ManualTransaction::where("account_id", $account->id)
+            ->with('admin')
             ->orderBy("created_at", "DESC")
             ->paginate($perPage);
     }

--- a/resources/views/accounts/view.blade.php
+++ b/resources/views/accounts/view.blade.php
@@ -135,6 +135,52 @@
         {{ $transactions->links() }}
     </x-utils.card>
 
+    <div class="divider"></div>
+
+    <x-utils.card title="Manual Adjustments" extraClasses="mb-2">
+        @if($manualTransactions->count())
+            <div class="overflow-x-auto">
+                <table class="table w-full table-zebra">
+                    <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Admin</th>
+                        <th>Money</th>
+                        @foreach(PWHelperService::resources(false) as $resource)
+                            <th>{{ ucfirst($resource) }}</th>
+                        @endforeach
+                        <th>Note</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach ($manualTransactions as $transaction)
+                        <tr class="hover">
+                            <td>{{ $transaction->created_at->format('Y-m-d H:i') }}</td>
+                            <td>
+                                @if($transaction->admin)
+                                    {{ $transaction->admin->name }}
+                                @elseif($transaction->admin_id)
+                                    Admin #{{ $transaction->admin_id }}
+                                @else
+                                    System
+                                @endif
+                            </td>
+                            <td>${{ number_format($transaction->money, 2) }}</td>
+                            @foreach(PWHelperService::resources(false) as $resource)
+                                <td>{{ number_format($transaction->$resource, 2) }}</td>
+                            @endforeach
+                            <td>{{ $transaction->note }}</td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+            {{ $manualTransactions->links() }}
+        @else
+            <p class="text-center py-4">No manual adjustments found.</p>
+        @endif
+    </x-utils.card>
+
     @if($ddLogs->count())
         <div class="divider"></div>
 


### PR DESCRIPTION
## Summary
- load manual transactions for the user account view via the accounts controller
- render a manual adjustments table with admin attribution, resources, and pagination
- eager-load manual transaction admins while keeping a default per-page limit

## Testing
- ./vendor/bin/pint *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68feaf068d308323bacf3a4fb5542b3d