### PR TITLE
Persist custom page media

### DIFF
--- a/app/Http/Controllers/Admin/CustomizationImageController.php
+++ b/app/Http/Controllers/Admin/CustomizationImageController.php
@@ -38,9 +38,10 @@ class CustomizationImageController extends Controller
         return response()->json([
             'success' => 1,
             'file' => [
-                'url' => $publicUrl,
+                'url' => $signedUrl,
                 'path' => $path,
                 'preview_url' => $signedUrl,
+                'public_url' => $publicUrl,
             ],
         ], 201);
     }

--- a/app/Services/PagePublisher.php
+++ b/app/Services/PagePublisher.php
@@ -256,6 +256,8 @@ class PagePublisher
 
         $data['path'] = $path;
         $data['url'] = $publicUrl;
+        $data['public_url'] = $publicUrl;
+        unset($data['preview_url']);
 
         $file = Arr::get($data, 'file', []);
         if (! is_array($file)) {
@@ -264,6 +266,8 @@ class PagePublisher
 
         $file['path'] = $path;
         $file['url'] = $publicUrl;
+        $file['public_url'] = $publicUrl;
+        unset($file['preview_url']);
         $data['file'] = $file;
 
         return $data;

--- a/resources/js/customization/editor.js
+++ b/resources/js/customization/editor.js
@@ -349,6 +349,29 @@ function disableWhileRunning(button, callback) {
     });
 }
 
+/**
+ * Build default block payloads for quick insert shortcuts.
+ *
+ * @param {string} type
+ * @param {DOMStringMap} dataset
+ * @returns {object}
+ */
+function presetBlockData(type, dataset) {
+    if (type === 'embed') {
+        const service = dataset && dataset.customizationService ? dataset.customizationService : 'youtube';
+
+        return {
+            service: service,
+            source: '',
+            embed: '',
+            url: '',
+            caption: '',
+        };
+    }
+
+    return {};
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const holder = document.getElementById('customization-editor');
 
@@ -440,6 +463,42 @@ document.addEventListener('DOMContentLoaded', () => {
             },
         },
     });
+
+    editor.isReady
+        .then(() => {
+            const quickInsertButtons = document.querySelectorAll('[data-customization-block]');
+
+            quickInsertButtons.forEach((button) => {
+                button.addEventListener('click', (event) => {
+                    event.preventDefault();
+
+                    if (!(button instanceof HTMLButtonElement)) {
+                        return;
+                    }
+
+                    const blockType = button.dataset.customizationBlock;
+
+                    if (!blockType) {
+                        return;
+                    }
+
+                    try {
+                        editor.blocks.insert(
+                            blockType,
+                            presetBlockData(blockType, button.dataset),
+                            undefined,
+                            undefined,
+                            true,
+                        );
+                    } catch (error) {
+                        console.error('Failed to insert block', error);
+                    }
+                });
+            });
+        })
+        .catch((error) => {
+            console.error('Editor failed to initialize', error);
+        });
 
     async function refreshActivity() {
         if (!endpoints.versions) {

--- a/resources/views/admin/customization/edit.blade.php
+++ b/resources/views/admin/customization/edit.blade.php
@@ -71,6 +71,18 @@
                     </div>
                 </div>
                 <div class="card-body">
+                    <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+                        <span class="text-muted small">Quick insert:</span>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" data-customization-block="image">
+                            <i class="bi bi-image me-1"></i> Image
+                        </button>
+                        <button type="button"
+                                class="btn btn-outline-secondary btn-sm"
+                                data-customization-block="embed"
+                                data-customization-service="youtube">
+                            <i class="bi bi-youtube me-1"></i> YouTube Embed
+                        </button>
+                    </div>
                     <div id="customization-editor"
                          class="bg-body-secondary rounded border p-3"
                          data-endpoints='@json($endpoints)'


### PR DESCRIPTION
## Summary
- return permanent public URLs for custom page image uploads while keeping signed preview links for the editor
- normalize stored page blocks to retain stable image paths and hydrate legacy signed URLs
- surface the YouTube embed block explicitly in the customization editor toolbox

## Testing
- Not run (pint binary missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68febd62893c8323860d5dfc12df5a97