### PR TITLE
Switch login to username authentication

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -22,7 +22,12 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique(User::class, 'name'),
+            ],
             'email' => [
                 'required',
                 'string',

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -18,7 +18,12 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     public function update(User $user, array $input): void
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('users', 'name')->ignore($user->id),
+            ],
 
             'email' => [
                 'required',

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -10,6 +10,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 class UserController extends Controller
@@ -106,8 +107,8 @@ class UserController extends Controller
         $this->authorize('edit-users');
 
         $validated = $request->validate([
-            'name' => ['required', 'string'],
-            'email' => ['required', 'email'],
+            'name' => ['required', 'string', Rule::unique('users', 'name')->ignore($user->id)],
+            'email' => ['required', 'email', Rule::unique('users', 'email')->ignore($user->id)],
             'is_admin' => ['required', 'boolean'],
             'disabled' => ['required', 'boolean'],
             'password' => ['nullable', 'confirmed', 'min:8'],

--- a/app/Http/Middleware/PreventDisabledUsers.php
+++ b/app/Http/Middleware/PreventDisabledUsers.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Fortify;
 use Symfony\Component\HttpFoundation\Response;
 
 class PreventDisabledUsers
@@ -20,7 +21,7 @@ class PreventDisabledUsers
             Auth::logout();
 
             return redirect()->route('login')->withErrors([
-                'email' => 'Your account has been disabled.',
+                Fortify::username() => 'Your account has been disabled.',
             ]);
         }
 

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -45,7 +45,7 @@ return [
     |
     */
 
-    'username' => 'email',
+    'username' => 'name',
 
     'email' => 'email',
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,12 +6,13 @@
             @csrf
             <div class="items-center mt-2">
                 <label class="input input-bordered flex items-center gap-2 mb-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
                          class="w-4 h-4 opacity-70">
-                        <path d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z"/>
-                        <path d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z"/>
+                        <path fill-rule="evenodd"
+                              d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z"
+                              clip-rule="evenodd"/>
                     </svg>
-                    <input type="email" class="grow" name="email" placeholder="Email"/>
+                    <input type="text" class="grow" name="name" placeholder="Username"/>
                 </label>
                 <label class="input input-bordered flex items-center gap-2 mb-2">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"


### PR DESCRIPTION
## Summary
- configure Fortify to authenticate users by their username instead of email
- update login UI and disabled-user messaging to use the username field
- enforce unique usernames during registration, profile updates, and admin edits

## Testing
- composer install --no-interaction --no-progress *(fails: GitHub 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_6904f54e0fdc832380bbe37cfa98b59a