### PR TITLE
Streamline sync batch persistence

### DIFF
--- a/app/Console/Commands/SyncAlliances.php
+++ b/app/Console/Commands/SyncAlliances.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Jobs\FinalizeAllianceSyncJob;
-use App\Jobs\FinalizeNationSyncJob;
 use App\Jobs\SyncAlliancesJob;
 use App\Services\GraphQLQueryBuilder;
 use App\Services\QueryService;
@@ -12,7 +11,6 @@ use App\Services\SettingService;
 use Illuminate\Bus\Batch;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Cache;
 
 class SyncAlliances extends Command
 {
@@ -63,8 +61,6 @@ class SyncAlliances extends Command
             ->then(fn(Batch $batch) => FinalizeAllianceSyncJob::dispatch($batch->id))
             ->allowFailures()
             ->dispatch();
-
-        Cache::put("sync_batch:{$batch->id}:pages", range(1, $lastPage), now()->addMinutes(60));
 
         SettingService::setLastAllianceSyncBatchId($batch->id);
 

--- a/app/Console/Commands/SyncNations.php
+++ b/app/Console/Commands/SyncNations.php
@@ -12,7 +12,6 @@ use Carbon\Carbon;
 use Illuminate\Bus\Batch;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Cache;
 
 class SyncNations extends Command
 {
@@ -64,8 +63,6 @@ class SyncNations extends Command
             ->then(fn(Batch $batch) => FinalizeNationSyncJob::dispatch($batch->id))
             ->allowFailures()
             ->dispatch();
-
-        Cache::put("sync_batch:{$batch->id}:pages", range(1, $lastPage), now()->addMinutes(60));
 
         SettingService::setLastNationSyncBatchId($batch->id);
 

--- a/app/Jobs/FinalizeAllianceSyncJob.php
+++ b/app/Jobs/FinalizeAllianceSyncJob.php
@@ -7,6 +7,7 @@ use App\Services\SettingService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class FinalizeAllianceSyncJob implements ShouldQueue
@@ -32,19 +33,54 @@ class FinalizeAllianceSyncJob implements ShouldQueue
     {
         $batch = Bus::findBatch($this->batchId);
 
-        if ($batch?->cancelled()) {
-            Log::warning("FinalizeAllianceSyncJob skipped — batch {$this->batchId} was cancelled.");
+        if (!$batch) {
+            Log::warning("FinalizeAllianceSyncJob skipped — batch {$this->batchId} could not be found.");
+            Cache::forget("sync_batch:{$this->batchId}:alliances_processed");
             SettingService::setLastAllianceSyncBatchId($this->batchId);
+
+            return;
+        }
+
+        if ($batch->cancelled()) {
+            Log::warning("FinalizeAllianceSyncJob skipped — batch {$this->batchId} was cancelled.");
+            Cache::forget("sync_batch:{$this->batchId}:alliances_processed");
+            SettingService::setLastAllianceSyncBatchId($this->batchId);
+
+            return;
+        }
+
+        if ($batch->failedJobs > 0) {
+            Log::warning("FinalizeAllianceSyncJob skipped — batch {$this->batchId} had {$batch->failedJobs} failure(s).");
+            Cache::forget("sync_batch:{$this->batchId}:alliances_processed");
+            SettingService::setLastAllianceSyncBatchId($this->batchId);
+
+            return;
+        }
+
+        $processedCount = Cache::pull("sync_batch:{$this->batchId}:alliances_processed", 0);
+
+        if ($processedCount === 0) {
+            Log::warning("FinalizeAllianceSyncJob skipped — no alliances were recorded as processed for batch {$this->batchId}.");
+            SettingService::setLastAllianceSyncBatchId($this->batchId);
+
             return;
         }
 
         $cutoff = now()->subDays(30);
 
         $staleCount = Alliance::where('updated_at', '<', $cutoff)->count();
+        $totalCount = Alliance::count();
+
+        if ($totalCount > 0 && $staleCount >= $totalCount) {
+            Log::error("FinalizeAllianceSyncJob aborted — stale alliance count ({$staleCount}) matched total alliances ({$totalCount}).");
+            SettingService::setLastAllianceSyncBatchId($this->batchId);
+
+            return;
+        }
 
         Alliance::where('updated_at', '<', $cutoff)->delete();
 
-        Log::info("🧹 FinalizeAllianceSyncJob: Soft-deleted {$staleCount} alliances not updated since {$cutoff->toDateTimeString()}.");
+        Log::info("🧹 FinalizeAllianceSyncJob: Soft-deleted {$staleCount} alliances not updated since {$cutoff->toDateTimeString()} (processed {$processedCount}).");
 
         SettingService::setLastAllianceSyncBatchId($this->batchId);
     }

--- a/app/Jobs/FinalizeNationSyncJob.php
+++ b/app/Jobs/FinalizeNationSyncJob.php
@@ -10,6 +10,7 @@ use App\Services\SettingService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class FinalizeNationSyncJob implements ShouldQueue
@@ -27,22 +28,57 @@ class FinalizeNationSyncJob implements ShouldQueue
     {
         $batch = Bus::findBatch($this->batchId);
 
-        if ($batch?->cancelled()) {
-            Log::warning("FinalizeNationSyncJob skipped — batch {$this->batchId} was cancelled.");
+        if (!$batch) {
+            Log::warning("FinalizeNationSyncJob skipped — batch {$this->batchId} could not be found.");
+            Cache::forget("sync_batch:{$this->batchId}:nations_processed");
             SettingService::setLastNationSyncBatchId($this->batchId);
+
+            return;
+        }
+
+        if ($batch->cancelled()) {
+            Log::warning("FinalizeNationSyncJob skipped — batch {$this->batchId} was cancelled.");
+            Cache::forget("sync_batch:{$this->batchId}:nations_processed");
+            SettingService::setLastNationSyncBatchId($this->batchId);
+
+            return;
+        }
+
+        if ($batch->failedJobs > 0) {
+            Log::warning("FinalizeNationSyncJob skipped — batch {$this->batchId} had {$batch->failedJobs} failure(s).");
+            Cache::forget("sync_batch:{$this->batchId}:nations_processed");
+            SettingService::setLastNationSyncBatchId($this->batchId);
+
+            return;
+        }
+
+        $processedCount = Cache::pull("sync_batch:{$this->batchId}:nations_processed", 0);
+
+        if ($processedCount === 0) {
+            Log::warning("FinalizeNationSyncJob skipped — no nations were recorded as processed for batch {$this->batchId}.");
+            SettingService::setLastNationSyncBatchId($this->batchId);
+
             return;
         }
 
         $cutoff = now()->subDays(30);
 
         $staleNationCount = Nation::where('updated_at', '<', $cutoff)->count();
+        $totalNationCount = Nation::count();
+
+        if ($totalNationCount > 0 && $staleNationCount >= $totalNationCount) {
+            Log::error("FinalizeNationSyncJob aborted — stale nation count ({$staleNationCount}) matched total nations ({$totalNationCount}).");
+            SettingService::setLastNationSyncBatchId($this->batchId);
+
+            return;
+        }
 
         Nation::where('updated_at', '<', $cutoff)->delete();
         NationResources::whereHas('nation', fn($q) => $q->where('updated_at', '<', $cutoff))->delete();
         NationMilitary::whereHas('nation', fn($q) => $q->where('updated_at', '<', $cutoff))->delete();
         City::whereHas('nation', fn($q) => $q->where('updated_at', '<', $cutoff))->delete();
 
-        Log::info("🧹 FinalizeNationSyncJob: Soft-deleted {$staleNationCount} nations not updated since {$cutoff->toDateTimeString()}.");
+        Log::info("🧹 FinalizeNationSyncJob: Soft-deleted {$staleNationCount} nations not updated since {$cutoff->toDateTimeString()} (processed {$processedCount}).");
 
         SettingService::setLastNationSyncBatchId($this->batchId);
     }

--- a/app/Jobs/SyncAlliancesJob.php
+++ b/app/Jobs/SyncAlliancesJob.php
@@ -2,21 +2,63 @@
 
 namespace App\Jobs;
 
-use App\Models\Alliance;
 use App\Services\AllianceQueryService;
+use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * Queue job that synchronises a page of alliance data into the local database.
+ */
 class SyncAlliancesJob implements ShouldQueue
 {
     use Queueable, Batchable;
 
     public int $page;
     public int $perPage;
+
+    private CarbonImmutable $syncTimestamp;
+    private string $syncTimestampString;
+
+    /**
+     * Chunk size for bulk upserts. Shared with the nation job to keep DB behaviour predictable.
+     */
+    private const UPSERT_CHUNK_SIZE = 1000;
+
+    private const ALLIANCE_COLUMNS = [
+        'id',
+        'name',
+        'acronym',
+        'score',
+        'color',
+        'average_score',
+        'accept_members',
+        'flag',
+        'forum_link',
+        'discord_link',
+        'wiki_link',
+        'rank',
+    ];
+
+    private const ALLIANCE_UPDATE_COLUMNS = [
+        'name',
+        'acronym',
+        'score',
+        'color',
+        'average_score',
+        'accept_members',
+        'flag',
+        'forum_link',
+        'discord_link',
+        'wiki_link',
+        'rank',
+        'updated_at',
+    ];
 
     public function __construct(int $page, int $perPage)
     {
@@ -25,7 +67,12 @@ class SyncAlliancesJob implements ShouldQueue
     }
 
     /**
-     * Create a new job instance.
+     * Execute the job for the requested page.
+     *
+     * We read once from the GraphQL gateway, normalise the payload, and then perform high-volume
+     * upserts using the query builder to avoid Eloquent model instantiation overhead.
+     *
+     * @return void
      */
     public function handle(): void
     {
@@ -35,21 +82,86 @@ class SyncAlliancesJob implements ShouldQueue
         }
 
         try {
+            $this->syncTimestamp = now()->toImmutable();
+            $this->syncTimestampString = $this->syncTimestamp->toDateTimeString();
+
             $alliances = AllianceQueryService::getMultipleAlliances([
                 "page" => $this->page
             ], $this->perPage, handlePagination: false);
 
-            $ids = [];
+            if (empty($alliances)) {
+                Log::warning("SyncAlliancesJob received no alliances for page {$this->page}.");
 
-            foreach ($alliances as $alliance) {
-                Alliance::updateFromAPI($alliance, false);
-                $ids[] = $alliance->id;
+                return;
             }
 
-            unset($alliances, $ids);
+            $records = [];
+
+            foreach ($alliances as $alliance) {
+                // Flatten the alliance payload exactly once so we can reuse the array for every table.
+                $records[] = $this->extractAllianceData(is_array($alliance) ? $alliance : (array) $alliance);
+            }
+
+            if (!empty($records)) {
+                foreach (array_chunk($records, self::UPSERT_CHUNK_SIZE) as $chunk) {
+                    // Raw query builder avoids Eloquent hydration and keeps CPU focused on SQL execution.
+                    DB::table('alliances')->upsert($chunk, ['id'], self::ALLIANCE_UPDATE_COLUMNS);
+                }
+            }
+
+            $this->recordProcessedCount(count($records));
+
+            unset($alliances, $records);
             gc_collect_cycles();
         } catch (Exception $e) {
             Log::error("Failed to fetch alliances (page {$this->page}): " . $e->getMessage());
         }
+    }
+
+    /**
+     * Build the persistence payload for a single alliance row.
+     */
+    private function extractAllianceData(array $alliance): array
+    {
+        $data = $this->mapValues($alliance, self::ALLIANCE_COLUMNS);
+        $data['updated_at'] = $this->syncTimestampString;
+        $data['created_at'] = $this->syncTimestampString;
+
+        return $data;
+    }
+
+    /**
+     * Project the requested columns from the source payload onto a cached null-filled template.
+     *
+     * @return array<string, mixed>
+     */
+    private function mapValues(array $source, array $columns): array
+    {
+        static $templates = [];
+
+        $key = md5(implode('|', $columns));
+
+        if (!isset($templates[$key])) {
+            $templates[$key] = array_fill_keys($columns, null);
+        }
+
+        $template = $templates[$key];
+
+        return array_replace($template, array_intersect_key($source, $template));
+    }
+
+    /**
+     * Track how many alliances were refreshed so the finalize step can validate progress.
+     */
+    private function recordProcessedCount(int $count): void
+    {
+        if (!isset($this->batchId) || $count === 0) {
+            return;
+        }
+
+        $cacheKey = "sync_batch:{$this->batchId}:alliances_processed";
+
+        Cache::add($cacheKey, 0, now()->addHours(6));
+        Cache::increment($cacheKey, $count);
     }
 }

--- a/app/Jobs/SyncNationsJob.php
+++ b/app/Jobs/SyncNationsJob.php
@@ -10,36 +10,310 @@
 
 namespace App\Jobs;
 
-use App\Models\City;
-use App\Models\Nation;
-use App\Models\NationMilitary;
-use App\Models\NationResources;
 use App\Services\NationQueryService;
-use App\Services\PWHelperService;
+use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
-// Job to synchronize nations data from external API and persist it to the database
+/**
+ * Queue job that synchronizes a slice of nation, resource, military, and city data.
+ *
+ * The GraphQL gateway provides each page sequentially, so the job focuses purely on
+ * transforming the payload into DB-ready shapes and performing high-volume upserts.
+ */
 class SyncNationsJob implements ShouldQueue
 {
     use Queueable, Batchable;
 
-    // Set a very high timeout to allow the job to complete even if it takes a long time
+    /**
+     * Allow the heavy nation sync to run to completion even on slow queues.
+     */
     public $timeout = 99999999;
 
-    // Pagination parameters: current page and number of items per page
+    /**
+     * Chunk size for bulk upsert statements. 1k rows keeps MySQL packets small while
+     * amortising query preparation overhead.
+     */
+    private const UPSERT_CHUNK_SIZE = 1000;
+
+    /**
+     * Pagination parameters passed in from the console command dispatcher.
+     */
     public int $page;
     public int $perPage;
+
+    private CarbonImmutable $syncTimestamp;
+    private string $syncTimestampString;
+
+    private const TABLE_NATIONS = 'nations';
+    private const TABLE_NATION_RESOURCES = 'nation_resources';
+    private const TABLE_NATION_MILITARY = 'nation_military';
+    private const TABLE_CITIES = 'cities';
+
+    private const NATION_COLUMNS = [
+        'id',
+        'alliance_id',
+        'alliance_position',
+        'alliance_position_id',
+        'nation_name',
+        'leader_name',
+        'continent',
+        'war_policy_turns',
+        'domestic_policy_turns',
+        'color',
+        'num_cities',
+        'score',
+        'update_tz',
+        'population',
+        'flag',
+        'vacation_mode_turns',
+        'beige_turns',
+        'espionage_available',
+        'discord',
+        'discord_id',
+        'turns_since_last_city',
+        'turns_since_last_project',
+        'projects',
+        'project_bits',
+        'wars_won',
+        'wars_lost',
+        'tax_id',
+        'alliance_seniority',
+        'gross_national_income',
+        'gross_domestic_product',
+        'vip',
+        'commendations',
+        'denouncements',
+        'offensive_wars_count',
+        'defensive_wars_count',
+        'money_looted',
+        'total_infrastructure_destroyed',
+        'total_infrastructure_lost',
+    ];
+
+    private const NATION_UPDATE_COLUMNS = [
+        'alliance_id',
+        'alliance_position',
+        'alliance_position_id',
+        'nation_name',
+        'leader_name',
+        'continent',
+        'war_policy_turns',
+        'domestic_policy_turns',
+        'color',
+        'num_cities',
+        'score',
+        'update_tz',
+        'population',
+        'flag',
+        'vacation_mode_turns',
+        'beige_turns',
+        'espionage_available',
+        'discord',
+        'discord_id',
+        'turns_since_last_city',
+        'turns_since_last_project',
+        'projects',
+        'project_bits',
+        'wars_won',
+        'wars_lost',
+        'tax_id',
+        'alliance_seniority',
+        'gross_national_income',
+        'gross_domestic_product',
+        'vip',
+        'commendations',
+        'denouncements',
+        'offensive_wars_count',
+        'defensive_wars_count',
+        'money_looted',
+        'total_infrastructure_destroyed',
+        'total_infrastructure_lost',
+        'updated_at',
+    ];
+
+    private const RESOURCE_COLUMNS = [
+        'money',
+        'coal',
+        'oil',
+        'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'gasoline',
+        'munitions',
+        'steel',
+        'aluminum',
+        'food',
+        'credits',
+    ];
+
+    private const RESOURCE_UPDATE_COLUMNS = [
+        'money',
+        'coal',
+        'oil',
+        'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'gasoline',
+        'munitions',
+        'steel',
+        'aluminum',
+        'food',
+        'credits',
+        'updated_at',
+    ];
+
+    private const MILITARY_COLUMNS = [
+        'soldiers',
+        'tanks',
+        'aircraft',
+        'ships',
+        'missiles',
+        'nukes',
+        'spies',
+        'soldiers_today',
+        'tanks_today',
+        'aircraft_today',
+        'ships_today',
+        'missiles_today',
+        'nukes_today',
+        'spies_today',
+        'soldier_casualties',
+        'soldier_kills',
+        'tank_casualties',
+        'tank_kills',
+        'aircraft_casualties',
+        'aircraft_kills',
+        'ship_casualties',
+        'ship_kills',
+        'missile_casualties',
+        'missile_kills',
+        'nuke_casualties',
+        'nuke_kills',
+        'spy_casualties',
+        'spy_kills',
+        'spy_attacks',
+    ];
+
+    private const MILITARY_UPDATE_COLUMNS = [
+        'soldiers',
+        'tanks',
+        'aircraft',
+        'ships',
+        'missiles',
+        'nukes',
+        'spies',
+        'soldiers_today',
+        'tanks_today',
+        'aircraft_today',
+        'ships_today',
+        'missiles_today',
+        'nukes_today',
+        'spies_today',
+        'soldier_casualties',
+        'soldier_kills',
+        'tank_casualties',
+        'tank_kills',
+        'aircraft_casualties',
+        'aircraft_kills',
+        'ship_casualties',
+        'ship_kills',
+        'missile_casualties',
+        'missile_kills',
+        'nuke_casualties',
+        'nuke_kills',
+        'spy_casualties',
+        'spy_kills',
+        'spy_attacks',
+        'updated_at',
+    ];
+
+    private const CITY_COLUMNS = [
+        'id',
+        'nation_id',
+        'name',
+        'date',
+        'infrastructure',
+        'land',
+        'powered',
+        'oil_power',
+        'wind_power',
+        'coal_power',
+        'nuclear_power',
+        'coal_mine',
+        'oil_well',
+        'uranium_mine',
+        'barracks',
+        'farm',
+        'police_station',
+        'hospital',
+        'recycling_center',
+        'subway',
+        'supermarket',
+        'bank',
+        'shopping_mall',
+        'stadium',
+        'lead_mine',
+        'iron_mine',
+        'bauxite_mine',
+        'oil_refinery',
+        'aluminum_refinery',
+        'steel_mill',
+        'munitions_factory',
+        'factory',
+        'hangar',
+        'drydock',
+    ];
+
+    private const CITY_UPDATE_COLUMNS = [
+        'nation_id',
+        'name',
+        'date',
+        'infrastructure',
+        'land',
+        'powered',
+        'oil_power',
+        'wind_power',
+        'coal_power',
+        'nuclear_power',
+        'coal_mine',
+        'oil_well',
+        'uranium_mine',
+        'barracks',
+        'farm',
+        'police_station',
+        'hospital',
+        'recycling_center',
+        'subway',
+        'supermarket',
+        'bank',
+        'shopping_mall',
+        'stadium',
+        'lead_mine',
+        'iron_mine',
+        'bauxite_mine',
+        'oil_refinery',
+        'aluminum_refinery',
+        'steel_mill',
+        'munitions_factory',
+        'factory',
+        'hangar',
+        'drydock',
+        'updated_at',
+    ];
 
     /**
      * Create a new job instance.
      *
-     * @param int $page The current page number to fetch from the API
-     * @param int $perPage The number of nations to fetch per page
+     * @param int $page    The current GraphQL page being synchronised.
+     * @param int $perPage The number of nations returned per page.
      */
     public function __construct(int $page, int $perPage)
     {
@@ -50,8 +324,11 @@ class SyncNationsJob implements ShouldQueue
     /**
      * Execute the job.
      *
-     * This method handles the full process of fetching, transforming, and upserting nation data into the database.
-     * It wraps the process in a try-catch block to log any errors that might occur during execution.
+     * The bulk of the CPU work here is transforming the nested GraphQL payload into flat tables.
+     * We keep the loop tight and reuse column templates so we only perform array bookkeeping once
+     * per chunk rather than per row.
+     *
+     * @return void
      */
     public function handle(): void
     {
@@ -61,6 +338,9 @@ class SyncNationsJob implements ShouldQueue
         }
 
         try {
+            $this->syncTimestamp = now()->toImmutable();
+            $this->syncTimestampString = $this->syncTimestamp->toDateTimeString();
+
             // Fetch nations from the API using the NationQueryService with pagination parameters
             $nations = NationQueryService::getMultipleNations(
                 ["page" => $this->page],
@@ -68,6 +348,12 @@ class SyncNationsJob implements ShouldQueue
                 true,
                 handlePagination: false
             );
+
+            if (empty($nations)) {
+                Log::warning("SyncNationsJob received no nations for page {$this->page}.");
+
+                return;
+            }
 
             // Initialize arrays to hold transformed data for nations, resources, military, and cities
             $nationData = [];
@@ -77,247 +363,119 @@ class SyncNationsJob implements ShouldQueue
 
             // Process each nation and extract necessary data
             foreach ($nations as $nation) {
+                // Convert objects coming back from GraphQL into arrays once to minimise property access costs.
+                $nationArray = is_array($nation) ? $nation : (array) $nation;
+
                 // Extract nation core data
-                $nationData[] = $this->extractNationData($nation);
+                $nationData[] = $this->extractNationData($nationArray);
 
                 // Extract resource data if available
-                $resourceData = $this->extractResourceData($nation);
+                $resourceData = $this->extractResourceData($nationArray);
                 if (!is_null($resourceData)) {
                     $resourcesData[] = $resourceData;
                 }
 
                 // Extract military data
-                $militaryDataArray = $this->extractMilitaryData($nation);
+                $militaryDataArray = $this->extractMilitaryData($nationArray);
                 if (!empty($militaryDataArray)) {
                     $militaryData[] = $militaryDataArray;
                 }
 
                 // Extract cities data
-                $citiesDataArray = $this->extractCitiesData($nation);
+                $citiesDataArray = $this->extractCitiesData($nationArray);
                 if (!empty($citiesDataArray)) {
-                    $citiesData = array_merge($citiesData, $citiesDataArray);
+                    foreach ($citiesDataArray as $cityData) {
+                        $citiesData[] = $cityData;
+                    }
                 }
             }
 
             // Perform bulk upsert operations in a single transaction for improved performance and atomicity
             $this->bulkUpsert($nationData, $resourcesData, $militaryData, $citiesData);
 
+            $this->recordProcessedCount(count($nationData));
+
             // Clean up variables and force garbage collection to free memory
             unset($nations, $nationData, $resourcesData, $militaryData, $citiesData);
             gc_collect_cycles();
         } catch (Exception $e) {
             // Log any exceptions encountered during the synchronization process
-            Log::error("Failed to fetch nations: " . $e->getMessage());
+            Log::error('Failed to fetch nations batch', [
+                'page' => $this->page,
+                'per_page' => $this->perPage,
+                'exception' => $e,
+            ]);
         }
 
     }
 
     /**
-     * Extract nation core data from a nation object.
+     * Extract nation core data from a nation payload.
      *
-     * @param mixed $nation
-     * @return array
+     * @return array<string, mixed>
      */
-    private function extractNationData($nation): array
+    private function extractNationData(array $nation): array
     {
-        $keys = $this->getNationKeys();
-        $keysFlipped = array_flip($keys);
-        return array_intersect_key((array)$nation, $keysFlipped);
+        $data = $this->mapValues($nation, self::NATION_COLUMNS);
+        $data['updated_at'] = $this->syncTimestampString;
+        $data['created_at'] = $this->syncTimestampString;
+
+        return $data;
     }
 
     /**
-     * Get the list of keys for nation data extraction.
+     * Extract resource data from a nation payload.
      *
-     * @return array
+     * @return array<string, mixed>|null
      */
-    private function getNationKeys(): array
+    private function extractResourceData(array $nation): ?array
     {
-        return [
-            'id',
-            'alliance_id',
-            'alliance_position',
-            'alliance_position_id',
-            'nation_name',
-            'leader_name',
-            'continent',
-            'war_policy_turns',
-            'domestic_policy_turns',
-            'color',
-            'num_cities',
-            'score',
-            'update_tz',
-            'population',
-            'flag',
-            'vacation_mode_turns',
-            'beige_turns',
-            'espionage_available',
-            'discord',
-            'discord_id',
-            'turns_since_last_city',
-            'turns_since_last_project',
-            'projects',
-            'project_bits',
-            'wars_won',
-            'wars_lost',
-            'tax_id',
-            'alliance_seniority',
-            'gross_national_income',
-            'gross_domestic_product',
-            'vip',
-            'commendations',
-            'denouncements',
-            'offensive_wars_count',
-            'defensive_wars_count',
-            'money_looted',
-            'total_infrastructure_destroyed',
-            'total_infrastructure_lost'
-        ];
-    }
-
-    /**
-     * Extract resource data from a nation object.
-     *
-     * @param mixed $nation
-     * @return array|null Returns null if no monetary data is available.
-     */
-    private function extractResourceData($nation): ?array
-    {
-        if (is_null($nation->money)) {
+        if (!array_key_exists('money', $nation) || $nation['money'] === null) {
             return null;
         }
-        $keys = $this->getResourceKeys();
-        $keysFlipped = array_flip($keys);
-        $data = array_intersect_key((array)$nation, $keysFlipped);
-        return array_merge($data, ['nation_id' => $nation->id]);
+        $data = $this->mapValues($nation, self::RESOURCE_COLUMNS);
+        $data['nation_id'] = $nation['id'];
+        $data['updated_at'] = $this->syncTimestampString;
+        $data['created_at'] = $this->syncTimestampString;
+
+        return $data;
     }
 
     /**
-     * Get the list of keys for resource data extraction.
+     * Extract military data from a nation payload.
      *
-     * @return array
+     * @return array<string, mixed>
      */
-    private function getResourceKeys(): array
+    private function extractMilitaryData(array $nation): array
     {
-        return PWHelperService::resources(includeCredits: true);
+        $data = $this->mapValues($nation, self::MILITARY_COLUMNS);
+        $data['nation_id'] = $nation['id'];
+        $data['updated_at'] = $this->syncTimestampString;
+        $data['created_at'] = $this->syncTimestampString;
+
+        return $data;
     }
 
     /**
-     * Extract military data from a nation object.
+     * Extract cities data from a nation payload.
      *
-     * @param mixed $nation
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
-    private function extractMilitaryData($nation): array
-    {
-        $keys = $this->getMilitaryKeys();
-        $keysFlipped = array_flip($keys);
-        $data = array_intersect_key((array)$nation, $keysFlipped);
-        return array_merge($data, ['nation_id' => $nation->id]);
-    }
-
-    /**
-     * Get the list of keys for military data extraction.
-     *
-     * @return array
-     */
-    private function getMilitaryKeys(): array
-    {
-        return [
-            'soldiers',
-            'tanks',
-            'aircraft',
-            'ships',
-            'missiles',
-            'nukes',
-            'spies',
-            'soldiers_today',
-            'tanks_today',
-            'aircraft_today',
-            'ships_today',
-            'missiles_today',
-            'nukes_today',
-            'spies_today',
-            'soldier_casualties',
-            'soldier_kills',
-            'tank_casualties',
-            'tank_kills',
-            'aircraft_casualties',
-            'aircraft_kills',
-            'ship_casualties',
-            'ship_kills',
-            'missile_casualties',
-            'missile_kills',
-            'nuke_casualties',
-            'nuke_kills',
-            'spy_casualties',
-            'spy_kills',
-            'spy_attacks'
-        ];
-    }
-
-    /**
-     * Extract cities data from a nation object.
-     *
-     * @param mixed $nation
-     * @return array
-     */
-    private function extractCitiesData($nation): array
+    private function extractCitiesData(array $nation): array
     {
         $cities = [];
-        if (empty($nation->cities)) {
+        if (empty($nation['cities'])) {
             return $cities;
         }
-        $keys = $this->getCityKeys();
-        $keysFlipped = array_flip($keys);
-        foreach ($nation->cities as $city) {
-            $cities[] = array_intersect_key((array)$city, $keysFlipped);
+        foreach ($nation['cities'] as $city) {
+            $cityArray = is_array($city) ? $city : (array) $city;
+            $cityData = $this->mapValues($cityArray, self::CITY_COLUMNS);
+            $cityData['nation_id'] = $nation['id'];
+            $cityData['updated_at'] = $this->syncTimestampString;
+            $cityData['created_at'] = $this->syncTimestampString;
+            $cities[] = $cityData;
         }
         return $cities;
-    }
-
-    /**
-     * Get the list of keys for city data extraction.
-     *
-     * @return array
-     */
-    private function getCityKeys(): array
-    {
-        return [
-            'id',
-            'nation_id',
-            'name',
-            'date',
-            'infrastructure',
-            'land',
-            'powered',
-            'oil_power',
-            'wind_power',
-            'coal_power',
-            'nuclear_power',
-            'coal_mine',
-            'oil_well',
-            'uranium_mine',
-            'barracks',
-            'farm',
-            'police_station',
-            'hospital',
-            'recycling_center',
-            'subway',
-            'supermarket',
-            'bank',
-            'shopping_mall',
-            'stadium',
-            'lead_mine',
-            'iron_mine',
-            'bauxite_mine',
-            'oil_refinery',
-            'aluminum_refinery',
-            'steel_mill',
-            'munitions_factory',
-            'factory',
-            'hangar',
-            'drydock'
-        ];
     }
 
     /**
@@ -332,35 +490,64 @@ class SyncNationsJob implements ShouldQueue
     {
         DB::transaction(function () use ($nationData, $resourcesData, $militaryData, $citiesData) {
             if (!empty($nationData)) {
-                Nation::upsert(
-                    $nationData,
-                    ['id'],
-                    array_keys(reset($nationData))
-                );
+                foreach (array_chunk($nationData, self::UPSERT_CHUNK_SIZE) as $chunk) {
+                    // Query builder upserts avoid the overhead of hydrating Eloquent models per row.
+                    DB::table(self::TABLE_NATIONS)->upsert($chunk, ['id'], self::NATION_UPDATE_COLUMNS);
+                }
             }
             if (!empty($resourcesData)) {
-                NationResources::upsert(
-                    $resourcesData,
-                    ['nation_id'],
-                    array_keys(reset($resourcesData))
-                );
+                foreach (array_chunk($resourcesData, self::UPSERT_CHUNK_SIZE) as $chunk) {
+                    DB::table(self::TABLE_NATION_RESOURCES)->upsert($chunk, ['nation_id'], self::RESOURCE_UPDATE_COLUMNS);
+                }
             }
             if (!empty($militaryData)) {
-                NationMilitary::upsert(
-                    $militaryData,
-                    ['nation_id'],
-                    array_keys(reset($militaryData))
-                );
+                foreach (array_chunk($militaryData, self::UPSERT_CHUNK_SIZE) as $chunk) {
+                    DB::table(self::TABLE_NATION_MILITARY)->upsert($chunk, ['nation_id'], self::MILITARY_UPDATE_COLUMNS);
+                }
             }
             if (!empty($citiesData)) {
-                foreach (array_chunk($citiesData, 500) as $chunk) {
-                    City::upsert(
-                        $chunk,
-                        ['id'],
-                        array_keys(reset($chunk))
-                    );
+                foreach (array_chunk($citiesData, self::UPSERT_CHUNK_SIZE) as $chunk) {
+                    DB::table(self::TABLE_CITIES)->upsert($chunk, ['id'], self::CITY_UPDATE_COLUMNS);
                 }
             }
         });
+    }
+
+    /**
+     * Map the selected columns from the source payload onto a null-filled template.
+     *
+     * Using cached templates keeps us from rebuilding the column list on every row and greatly
+     * reduces per-record CPU churn compared to repeated foreach assignment.
+     *
+     * @return array<string, mixed>
+     */
+    private function mapValues(array $source, array $columns): array
+    {
+        static $templates = [];
+
+        $key = md5(implode('|', $columns));
+
+        if (!isset($templates[$key])) {
+            $templates[$key] = array_fill_keys($columns, null);
+        }
+
+        $template = $templates[$key];
+
+        return array_replace($template, array_intersect_key($source, $template));
+    }
+
+    /**
+     * Track how many records were persisted so the finalizer knows the batch made progress.
+     */
+    private function recordProcessedCount(int $count): void
+    {
+        if (!isset($this->batchId) || $count === 0) {
+            return;
+        }
+
+        $cacheKey = "sync_batch:{$this->batchId}:nations_processed";
+
+        Cache::add($cacheKey, 0, now()->addHours(6));
+        Cache::increment($cacheKey, $count);
     }
 }

--- a/app/Jobs/SyncWarsJob.php
+++ b/app/Jobs/SyncWarsJob.php
@@ -5,14 +5,19 @@ namespace App\Jobs;
 use App\Models\War;
 use App\Services\AllianceMembershipService;
 use App\Services\WarQueryService;
+use Carbon\CarbonImmutable;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
+/**
+ * Queue job that synchronises a page of war records for the configured alliance context.
+ */
 class SyncWarsJob implements ShouldQueue
 {
     use Queueable, InteractsWithQueue, Batchable;
@@ -21,7 +26,128 @@ class SyncWarsJob implements ShouldQueue
     {
     }
 
+    private CarbonImmutable $syncTimestamp;
+    private string $syncTimestampString;
+
     /**
+     * Keep war upserts aligned with the other sync jobs to minimise DB contention.
+     */
+    private const UPSERT_CHUNK_SIZE = 1000;
+
+    private const TABLE_WARS = 'wars';
+
+    private const WAR_COLUMNS = [
+        'id',
+        'date',
+        'end_date',
+        'reason',
+        'war_type',
+        'ground_control',
+        'air_superiority',
+        'naval_blockade',
+        'winner_id',
+        'turns_left',
+        'att_id',
+        'att_alliance_id',
+        'att_alliance_position',
+        'def_id',
+        'def_alliance_id',
+        'def_alliance_position',
+        'att_points',
+        'def_points',
+        'att_peace',
+        'def_peace',
+        'att_resistance',
+        'def_resistance',
+        'att_fortify',
+        'def_fortify',
+        'att_gas_used',
+        'def_gas_used',
+        'att_mun_used',
+        'def_mun_used',
+        'att_alum_used',
+        'def_alum_used',
+        'att_steel_used',
+        'def_steel_used',
+        'att_infra_destroyed',
+        'def_infra_destroyed',
+        'att_money_looted',
+        'def_money_looted',
+        'def_soldiers_lost',
+        'att_soldiers_lost',
+        'def_tanks_lost',
+        'att_tanks_lost',
+        'def_aircraft_lost',
+        'att_aircraft_lost',
+        'def_ships_lost',
+        'att_ships_lost',
+        'att_missiles_used',
+        'def_missiles_used',
+        'att_nukes_used',
+        'def_nukes_used',
+        'att_infra_destroyed_value',
+        'def_infra_destroyed_value',
+    ];
+
+    private const WAR_UPDATE_COLUMNS = [
+        'date',
+        'end_date',
+        'reason',
+        'war_type',
+        'ground_control',
+        'air_superiority',
+        'naval_blockade',
+        'winner_id',
+        'turns_left',
+        'att_id',
+        'att_alliance_id',
+        'att_alliance_position',
+        'def_id',
+        'def_alliance_id',
+        'def_alliance_position',
+        'att_points',
+        'def_points',
+        'att_peace',
+        'def_peace',
+        'att_resistance',
+        'def_resistance',
+        'att_fortify',
+        'def_fortify',
+        'att_gas_used',
+        'def_gas_used',
+        'att_mun_used',
+        'def_mun_used',
+        'att_alum_used',
+        'def_alum_used',
+        'att_steel_used',
+        'def_steel_used',
+        'att_infra_destroyed',
+        'def_infra_destroyed',
+        'att_money_looted',
+        'def_money_looted',
+        'def_soldiers_lost',
+        'att_soldiers_lost',
+        'def_tanks_lost',
+        'att_tanks_lost',
+        'def_aircraft_lost',
+        'att_aircraft_lost',
+        'def_ships_lost',
+        'att_ships_lost',
+        'att_missiles_used',
+        'def_missiles_used',
+        'att_nukes_used',
+        'def_nukes_used',
+        'att_infra_destroyed_value',
+        'def_infra_destroyed_value',
+        'updated_at',
+    ];
+
+    /**
+     * Execute the war sync for the configured page.
+     *
+     * We normalise the payload once, reuse cached column templates, and lean on the query builder
+     * for the actual upsert so we spend our CPU cycles on SQL execution rather than PHP array churn.
+     *
      * @return void
      */
     public function handle(): void
@@ -32,6 +158,9 @@ class SyncWarsJob implements ShouldQueue
         }
 
         try {
+            $this->syncTimestamp = now()->toImmutable();
+            $this->syncTimestampString = $this->syncTimestamp->toDateTimeString();
+
             $membershipService = app(AllianceMembershipService::class);
             $wars = WarQueryService::getMultipleWars([
                 'page' => $this->page,
@@ -39,19 +168,87 @@ class SyncWarsJob implements ShouldQueue
                 'alliance_id' => $membershipService->getPrimaryAllianceId(),
             ], $this->perPage, pagination: true, handlePagination: false);
 
+            if (empty($wars)) {
+                Log::warning("SyncWarsJob received no wars for page {$this->page}.");
+
+                return;
+            }
+
+            $records = [];
             $ids = [];
 
             foreach ($wars as $war) {
-                War::updateFromAPI($war);
-                $ids[] = $war->id;
+                // Normalise and flatten each payload exactly once before we touch the database.
+                $record = $this->extractWarData($war);
+                $records[] = $record;
+                $ids[] = $record['id'];
             }
 
+            if (!empty($records)) {
+                foreach (array_chunk($records, self::UPSERT_CHUNK_SIZE) as $chunk) {
+                    DB::table(self::TABLE_WARS)->upsert($chunk, ['id'], self::WAR_UPDATE_COLUMNS);
+                }
+            }
+
+            // Store the IDs processed on this page so the finalizer can detect gaps or missing rows.
             Cache::put("sync_batch:{$this->batchId}:{$this->page}", $ids, now()->addHours(1));
 
-            unset($wars, $ids);
+            Cache::add("sync_batch:{$this->batchId}:wars_processed", 0, now()->addHours(6));
+            Cache::increment("sync_batch:{$this->batchId}:wars_processed", count($records));
+
+            unset($wars, $records, $ids);
             gc_collect_cycles();
         } catch (Throwable $e) {
             Log::error("Failed to sync wars: {$e->getMessage()}");
         }
+    }
+
+    /**
+     * Build the persistence payload for a single war row.
+     */
+    private function extractWarData(mixed $war): array
+    {
+        $warArray = is_array($war) ? $war : (array) $war;
+
+        if (isset($warArray['att_soldiers_killed'])) {
+            $warArray = War::normalizeDeprecatedKilledFields($warArray);
+        }
+
+        $data = $this->mapValues($warArray, self::WAR_COLUMNS);
+        $data['date'] = $this->normalizeTimestamp($warArray['date'] ?? null);
+        $data['end_date'] = $this->normalizeTimestamp($warArray['end_date'] ?? null);
+        $data['updated_at'] = $this->syncTimestampString;
+        $data['created_at'] = $this->syncTimestampString;
+
+        return $data;
+    }
+
+    /**
+     * Project the requested columns from the war payload onto a cached template.
+     *
+     * @return array<string, mixed>
+     */
+    private function mapValues(array $source, array $columns): array
+    {
+        static $templates = [];
+
+        $key = md5(implode('|', $columns));
+
+        if (!isset($templates[$key])) {
+            $templates[$key] = array_fill_keys($columns, null);
+        }
+
+        $template = $templates[$key];
+
+        return array_replace($template, array_intersect_key($source, $template));
+    }
+
+    private function normalizeTimestamp(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return CarbonImmutable::parse($value)->toDateTimeString();
     }
 }


### PR DESCRIPTION
## Summary
- route alliance, nation, and war sync jobs through query builder chunked upserts to trim per-row CPU overhead
- cache column templates and document payload extraction so transformation loops stay lightweight and easier to follow
- add descriptive comments and batch progress tracking notes to guard finalizers against false wipeouts

## Testing
- `php -l app/Jobs/SyncNationsJob.php`
- `php -l app/Jobs/SyncAlliancesJob.php`
- `php -l app/Jobs/SyncWarsJob.php`


------
https://chatgpt.com/codex/tasks/task_e_6904ef7609188323b994fb27d4babd9a