### PR TITLE
Add alliance dashboard metrics and UI

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -3,11 +3,610 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\City;
+use App\Models\GrantApplication;
+use App\Models\Loan;
+use App\Models\Nation;
+use App\Models\NationMilitary;
+use App\Models\NationSignIn;
+use App\Models\Taxes;
+use App\Models\TradePrice;
+use App\Models\War;
+use App\Services\AllianceMembershipService;
+use App\Services\PWHelperService;
+use Carbon\Carbon;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
 {
-    public function dashboard()
+    private const CACHE_KEY = 'admin:dashboard:metrics';
+
+    private const CACHE_TTL_MINUTES = 30;
+
+    public function __construct(private readonly AllianceMembershipService $membershipService) {}
+
+    /**
+     * Render the alliance command center with aggregated telemetry and trend analysis.
+     */
+    public function dashboard(Request $request): View
     {
-        return view('admin.dashboard');
+        if ($request->boolean('refresh')) {
+            Cache::forget(self::CACHE_KEY);
+        }
+
+        $payload = Cache::remember(
+            self::CACHE_KEY,
+            now()->addMinutes(self::CACHE_TTL_MINUTES),
+            function () {
+                $metrics = $this->buildMetrics();
+
+                return [
+                    'generated_at' => Carbon::now()->toIso8601String(),
+                    'metrics' => $metrics,
+                ];
+            }
+        );
+
+        $generatedAt = isset($payload['generated_at'])
+            ? Carbon::parse($payload['generated_at'])
+            : Carbon::now();
+
+        $metrics = $payload['metrics'] ?? $payload;
+
+        return view('admin.dashboard', array_merge($metrics, [
+            'lastRefreshedAt' => $generatedAt,
+            'cacheTtlMinutes' => self::CACHE_TTL_MINUTES,
+        ]));
+    }
+
+    /**
+     * Build and normalize all dashboard metrics. Result is cached by dashboard().
+     */
+    private function buildMetrics(): array
+    {
+        $now = Carbon::now();
+
+        $memberAllianceIds = $this->membershipService->getAllianceIds()
+            ->map(fn ($id) => (int) $id)
+            ->filter(fn (int $id) => $id > 0)
+            ->values();
+
+        $memberAllianceIdList = $memberAllianceIds->all();
+
+        $memberNationIds = $this->constrainedNationQuery($memberAllianceIdList)
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        $memberNationIdCollection = collect($memberNationIds);
+        $totalMembers = $memberNationIdCollection->count();
+
+        $memberNationQuery = function () use ($memberAllianceIdList) {
+            return $this->constrainedNationQuery($memberAllianceIdList);
+        };
+
+        $totalCities = (int) ($totalMembers > 0 ? $memberNationQuery()->sum('num_cities') : 0);
+        $avgScore = $totalMembers > 0 ? round((float) $memberNationQuery()->avg('score'), 2) : 0.0;
+        $avgCitiesPerMember = $totalMembers > 0 ? round($totalCities / $totalMembers, 2) : 0.0;
+
+        $cityStatsBase = City::query()->whereIn('nation_id', $memberNationIds);
+
+        $cityStats = (clone $cityStatsBase)
+            ->selectRaw('COALESCE(SUM(infrastructure), 0) as infrastructure_total, COALESCE(SUM(land), 0) as land_total')
+            ->first();
+
+        $totalInfrastructure = $cityStats ? (float) $cityStats->infrastructure_total : 0.0;
+        $avgInfrastructure = $totalCities > 0 ? round($totalInfrastructure / $totalCities, 1) : 0.0;
+        $poweredCities = (clone $cityStatsBase)->where('powered', true)->count();
+        $powerCoverage = $totalCities > 0 ? round(($poweredCities / $totalCities) * 100, 1) : 0.0;
+
+        $topInfrastructureCities = City::query()
+            ->with('nation:id,leader_name,nation_name')
+            ->whereIn('nation_id', $memberNationIds)
+            ->orderByDesc('infrastructure')
+            ->limit(5)
+            ->get(['id', 'nation_id', 'name', 'infrastructure', 'land']);
+
+        $latestTradePrice = TradePrice::query()->orderByDesc('date')->first();
+
+        $latestSignInsSub = NationSignIn::query()
+            ->selectRaw('MAX(id) as id, nation_id')
+            ->whereIn('nation_id', $memberNationIds)
+            ->groupBy('nation_id');
+
+        $latestSignIns = NationSignIn::query()
+            ->joinSub($latestSignInsSub, 'latest_sign_ins', fn ($join) => $join->on('nation_sign_ins.id', '=', 'latest_sign_ins.id'))
+            ->join('nations', 'nations.id', '=', 'nation_sign_ins.nation_id')
+            ->whereIn('nations.id', $memberNationIds)
+            ->select([
+                'nation_sign_ins.id',
+                'nation_sign_ins.nation_id as nation_id',
+                'nation_sign_ins.num_cities',
+                'nation_sign_ins.score',
+                'nation_sign_ins.mmr_score',
+                'nation_sign_ins.money',
+                'nation_sign_ins.coal',
+                'nation_sign_ins.oil',
+                'nation_sign_ins.uranium',
+                'nation_sign_ins.iron',
+                'nation_sign_ins.bauxite',
+                'nation_sign_ins.lead',
+                'nation_sign_ins.gasoline',
+                'nation_sign_ins.munitions',
+                'nation_sign_ins.steel',
+                'nation_sign_ins.aluminum',
+                'nation_sign_ins.food',
+                'nation_sign_ins.created_at',
+                'nations.leader_name',
+                'nations.nation_name',
+            ])
+            ->get();
+
+        $commodityFields = PWHelperService::resources(false);
+
+        $cashTotal = (float) $latestSignIns->sum('money');
+        $cashPerMember = $totalMembers > 0 ? $cashTotal / $totalMembers : 0.0;
+
+        $resourceTotalsCollection = collect($commodityFields)
+            ->mapWithKeys(fn ($field) => [$field => (float) $latestSignIns->sum($field)]);
+
+        $resourceValuations = $resourceTotalsCollection->mapWithKeys(function (float $amount, string $resource) use ($latestTradePrice) {
+            if ($latestTradePrice) {
+                $price = (float) ($latestTradePrice->$resource ?? 0);
+
+                if ($price > 0) {
+                    return [$resource => $amount * $price];
+                }
+            }
+
+            return [$resource => $amount];
+        });
+
+        $resourceTotalValue = round($resourceValuations->sum(), 2);
+
+        $resourceValueBreakdown = $resourceValuations
+            ->filter(fn ($value) => $value > 0)
+            ->sortDesc();
+
+        if ($resourceValueBreakdown->count() > 5) {
+            $topResources = $resourceValueBreakdown->take(5);
+            $otherValue = $resourceValueBreakdown->slice(5)->sum();
+
+            if ($otherValue > 0) {
+                $resourceValueBreakdown = $topResources->put('Other', $otherValue);
+            } else {
+                $resourceValueBreakdown = $topResources;
+            }
+        }
+
+        $resourceTotals = $resourceTotalsCollection->all();
+
+        $militaryTotalsRecord = NationMilitary::query()
+            ->join('nations', 'nations.id', '=', 'nation_military.nation_id')
+            ->whereIn('nations.id', $memberNationIds)
+            ->selectRaw('
+                COALESCE(SUM(soldiers), 0) AS soldiers,
+                COALESCE(SUM(tanks), 0) AS tanks,
+                COALESCE(SUM(aircraft), 0) AS aircraft,
+                COALESCE(SUM(ships), 0) AS ships,
+                COALESCE(SUM(spies), 0) AS spies
+            ')
+            ->first();
+
+        $militaryTotalsCollection = collect([
+            'soldiers' => (int) ($militaryTotalsRecord->soldiers ?? 0),
+            'tanks' => (int) ($militaryTotalsRecord->tanks ?? 0),
+            'aircraft' => (int) ($militaryTotalsRecord->aircraft ?? 0),
+            'ships' => (int) ($militaryTotalsRecord->ships ?? 0),
+            'spies' => (int) ($militaryTotalsRecord->spies ?? 0),
+        ]);
+
+        $militaryCapacity = [
+            'soldiers' => $totalCities * 15000,
+            'tanks' => $totalCities * 1250,
+            'aircraft' => $totalCities * 75,
+            'ships' => $totalCities * 15,
+            'spies' => $totalMembers * 60,
+        ];
+
+        $militaryReadiness = collect($militaryCapacity)->mapWithKeys(function (int $capacity, string $field) use ($militaryTotalsCollection) {
+            if ($capacity <= 0) {
+                return [$field => 0.0];
+            }
+
+            $percentage = ($militaryTotalsCollection[$field] ?? 0) / $capacity * 100;
+
+            return [$field => round(min(100, $percentage), 1)];
+        });
+
+        $militaryPerUnitAverage = [
+            'soldiers' => $totalCities > 0 ? round($militaryTotalsCollection['soldiers'] / $totalCities) : 0,
+            'tanks' => $totalCities > 0 ? round($militaryTotalsCollection['tanks'] / $totalCities) : 0,
+            'aircraft' => $totalCities > 0 ? round($militaryTotalsCollection['aircraft'] / $totalCities, 1) : 0.0,
+            'ships' => $totalCities > 0 ? round($militaryTotalsCollection['ships'] / $totalCities, 2) : 0.0,
+            'spies' => $totalMembers > 0 ? round($militaryTotalsCollection['spies'] / $totalMembers, 1) : 0.0,
+        ];
+
+        $militaryTotals = $militaryTotalsCollection->all();
+
+        $mmrThreshold = 85;
+        $mmrSignIns = $latestSignIns->filter(fn ($signIn) => $signIn->mmr_score !== null);
+        $averageMmrScore = $mmrSignIns->isNotEmpty() ? round((float) $mmrSignIns->avg('mmr_score'), 1) : 0.0;
+        $mmrCompliantCount = $mmrSignIns->where('mmr_score', '>=', $mmrThreshold)->count();
+        $mmrCoverage = $totalMembers > 0 ? round(($mmrCompliantCount / $totalMembers) * 100, 1) : 0.0;
+
+        $mmrDistribution = $mmrSignIns
+            ->groupBy(fn ($signIn) => (int) floor($signIn->mmr_score / 10) * 10)
+            ->map(fn ($group, $bucket) => [
+                'bucket' => (int) $bucket,
+                'total' => $group->count(),
+            ])
+            ->sortBy('bucket')
+            ->values();
+
+        $chartWindowStart = $now->copy()->subDays(13)->startOfDay();
+
+        $thisWeekStart = $now->copy()->subDays(6)->startOfDay();
+        $lastWeekStart = $now->copy()->subDays(13)->startOfDay();
+        $lastWeekEnd = $now->copy()->subDays(7)->endOfDay();
+
+        $activeThreshold = $now->copy()->subHours(48);
+        $previousThreshold = $now->copy()->subHours(96);
+
+        $activeMembers = $memberNationQuery()
+            ->where('updated_at', '>=', $activeThreshold)
+            ->count();
+
+        $previousActiveMembers = $memberNationQuery()
+            ->whereBetween('updated_at', [$previousThreshold, $activeThreshold])
+            ->count();
+
+        $activeMemberTrend = $previousActiveMembers > 0
+            ? round((($activeMembers - $previousActiveMembers) / $previousActiveMembers) * 100, 1)
+            : null;
+
+        $taxBaseQuery = Taxes::query()
+            ->where('date', '>=', $chartWindowStart)
+            ->whereIn('receiver_id', $memberAllianceIdList);
+
+        $taxMoneyDaily = (clone $taxBaseQuery)
+            ->selectRaw('DATE(date) AS day, SUM(money) AS money')
+            ->groupBy(DB::raw('DATE(date)'))
+            ->orderBy(DB::raw('DATE(date)'))
+            ->get()
+            ->map(fn ($row) => [
+                'day' => Carbon::parse($row->day)->format('M d'),
+                'money' => (float) $row->money,
+            ])
+            ->values();
+
+        $taxResourceDaily = (clone $taxBaseQuery)
+            ->selectRaw('DATE(date) AS day,
+                SUM(steel) AS steel,
+                SUM(munitions) AS munitions,
+                SUM(aluminum) AS aluminum,
+                SUM(food) AS food')
+            ->groupBy(DB::raw('DATE(date)'))
+            ->orderBy(DB::raw('DATE(date)'))
+            ->get()
+            ->map(fn ($row) => [
+                'day' => Carbon::parse($row->day)->format('M d'),
+                'steel' => (float) $row->steel,
+                'munitions' => (float) $row->munitions,
+                'aluminum' => (float) $row->aluminum,
+                'food' => (float) $row->food,
+            ])
+            ->values();
+
+        $taxMoneyThisWeek = (float) Taxes::query()
+            ->where('date', '>=', $thisWeekStart)
+            ->whereIn('receiver_id', $memberAllianceIdList)
+            ->sum('money');
+
+        $taxMoneyLastWeek = (float) Taxes::query()
+            ->whereBetween('date', [$lastWeekStart, $lastWeekEnd])
+            ->whereIn('receiver_id', $memberAllianceIdList)
+            ->sum('money');
+
+        $taxMoneyTrend = $taxMoneyLastWeek > 0 ? round((($taxMoneyThisWeek - $taxMoneyLastWeek) / $taxMoneyLastWeek) * 100, 1) : null;
+
+        $warBaseQuery = War::query()
+            ->where('date', '>=', $chartWindowStart)
+            ->where(function ($query) use ($memberAllianceIdList) {
+                $query->whereIn('att_alliance_id', $memberAllianceIdList)
+                    ->orWhereIn('def_alliance_id', $memberAllianceIdList);
+            });
+
+        $warDaily = (clone $warBaseQuery)
+            ->selectRaw('DATE(date) AS day,
+                COUNT(*) AS wars_started,
+                SUM(att_infra_destroyed) AS att_infra,
+                SUM(def_infra_destroyed) AS def_infra,
+                SUM(att_money_looted) AS att_money,
+                SUM(def_money_looted) AS def_money')
+            ->groupBy(DB::raw('DATE(date)'))
+            ->orderBy(DB::raw('DATE(date)'))
+            ->get()
+            ->map(fn ($row) => [
+                'day' => Carbon::parse($row->day)->format('M d'),
+                'wars_started' => (int) $row->wars_started,
+                'infra_destroyed' => (float) ($row->att_infra + $row->def_infra),
+                'money_looted' => (float) ($row->att_money + $row->def_money),
+            ])
+            ->values();
+
+        $activeWars = War::query()
+            ->active()
+            ->where(function ($query) use ($memberAllianceIdList) {
+                $query->whereIn('att_alliance_id', $memberAllianceIdList)
+                    ->orWhereIn('def_alliance_id', $memberAllianceIdList);
+            })
+            ->count();
+
+        $warsThisWeek = War::query()
+            ->where('date', '>=', $thisWeekStart)
+            ->where(function ($query) use ($memberAllianceIdList) {
+                $query->whereIn('att_alliance_id', $memberAllianceIdList)
+                    ->orWhereIn('def_alliance_id', $memberAllianceIdList);
+            })
+            ->count();
+
+        $warsLastWeek = War::query()
+            ->whereBetween('date', [$lastWeekStart, $lastWeekEnd])
+            ->where(function ($query) use ($memberAllianceIdList) {
+                $query->whereIn('att_alliance_id', $memberAllianceIdList)
+                    ->orWhereIn('def_alliance_id', $memberAllianceIdList);
+            })
+            ->count();
+
+        $warTrend = $warsLastWeek > 0 ? round((($warsThisWeek - $warsLastWeek) / $warsLastWeek) * 100, 1) : null;
+
+        $activeWarDetails = War::query()
+            ->active()
+            ->where(function ($query) use ($memberAllianceIdList) {
+                $query->whereIn('att_alliance_id', $memberAllianceIdList)
+                    ->orWhereIn('def_alliance_id', $memberAllianceIdList);
+            })
+            ->with([
+                'attacker:id,leader_name,nation_name',
+                'defender:id,leader_name,nation_name',
+            ])
+            ->orderByRaw('LEAST(turns_left, att_resistance, def_resistance) asc')
+            ->orderBy('updated_at')
+            ->limit(5)
+            ->get([
+                'id',
+                'att_id',
+                'def_id',
+                'war_type',
+                'turns_left',
+                'att_points',
+                'def_points',
+                'att_resistance',
+                'def_resistance',
+                'att_money_looted',
+                'def_money_looted',
+                'att_infra_destroyed',
+                'def_infra_destroyed',
+                'att_missiles_used',
+                'def_missiles_used',
+                'att_nukes_used',
+                'def_nukes_used',
+                'att_fortify',
+                'def_fortify',
+                'updated_at',
+            ]);
+
+        $recentWars = War::query()
+            ->where(function ($query) use ($memberAllianceIdList) {
+                $query->whereIn('att_alliance_id', $memberAllianceIdList)
+                    ->orWhereIn('def_alliance_id', $memberAllianceIdList);
+            })
+            ->with([
+                'attacker:id,leader_name,nation_name',
+                'defender:id,leader_name,nation_name',
+            ])
+            ->orderByDesc('date')
+            ->limit(30)
+            ->get([
+                'id',
+                'date',
+                'war_type',
+                'att_id',
+                'def_id',
+                'winner_id',
+                'att_infra_destroyed',
+                'def_infra_destroyed',
+                'att_money_looted',
+                'def_money_looted',
+            ]);
+
+        $loanAvgInterest = Loan::query()
+            ->whereIn('nation_id', $memberNationIds)
+            ->whereNotNull('interest_rate')
+            ->avg('interest_rate');
+
+        $loanAvgTerm = Loan::query()
+            ->whereIn('nation_id', $memberNationIds)
+            ->whereNotNull('term_weeks')
+            ->avg('term_weeks');
+
+        $loanStats = [
+            'pending' => Loan::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->where('status', 'pending')
+                ->count(),
+            'active' => Loan::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->whereIn('status', ['approved', 'missed'])
+                ->count(),
+            'paid' => Loan::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->where('status', 'paid')
+                ->count(),
+            'outstanding_balance' => (float) Loan::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->whereIn('status', ['approved', 'missed'])
+                ->sum('remaining_balance'),
+            'avg_interest' => $loanAvgInterest !== null ? round((float) $loanAvgInterest, 2) : null,
+            'avg_term' => $loanAvgTerm !== null ? round((float) $loanAvgTerm, 1) : null,
+        ];
+
+        $grantStats = [
+            'pending' => GrantApplication::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->where('status', 'pending')
+                ->count(),
+            'approved_this_week' => GrantApplication::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->where('status', 'approved')
+                ->where('approved_at', '>=', $thisWeekStart)
+                ->count(),
+            'approved_total' => GrantApplication::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->where('status', 'approved')
+                ->count(),
+            'money_disbursed_30d' => (float) GrantApplication::query()
+                ->whereIn('nation_id', $memberNationIds)
+                ->where('status', 'approved')
+                ->where('approved_at', '>=', $now->copy()->subDays(30))
+                ->sum('money'),
+        ];
+
+        $topCashHolders = $latestSignIns
+            ->sortByDesc('money')
+            ->take(6)
+            ->map(fn ($signIn) => (object) [
+                'nation_id' => $signIn->nation_id,
+                'leader_name' => $signIn->leader_name,
+                'nation_name' => $signIn->nation_name,
+                'money' => (float) $signIn->money,
+                'snapshot_at' => $signIn->created_at,
+            ]);
+
+        $topScoringNations = $memberNationQuery()
+            ->orderByDesc('score')
+            ->limit(8)
+            ->get([
+                'id',
+                'leader_name',
+                'nation_name',
+                'score',
+                'num_cities',
+                'gross_national_income',
+                'gross_domestic_product',
+            ]);
+
+        $kpis = collect([
+            [
+                'icon' => 'bi bi-people-fill',
+                'bg' => 'text-bg-primary',
+                'title' => 'Active Members',
+                'value' => number_format($activeMembers),
+                'helper' => 'Seen in the last 48 hours',
+                'trend' => $activeMemberTrend,
+            ],
+            [
+                'icon' => 'bi bi-graph-up-arrow',
+                'bg' => 'text-bg-success',
+                'title' => 'Alliance Score',
+                'value' => number_format($avgScore, 1).' avg',
+                'helper' => "{$avgCitiesPerMember} cities per member",
+                'trend' => null,
+            ],
+            [
+                'icon' => 'bi bi-shield-lock',
+                'bg' => 'text-bg-info',
+                'title' => 'MMR Compliance',
+                'value' => "{$mmrCoverage}%",
+                'helper' => "{$mmrCompliantCount} nations ≥ {$mmrThreshold}",
+                'trend' => null,
+            ],
+            [
+                'icon' => 'bi bi-lightning-charge',
+                'bg' => 'text-bg-warning',
+                'title' => 'Power Coverage',
+                'value' => "{$powerCoverage}%",
+                'helper' => "{$poweredCities} of {$totalCities} cities online",
+                'trend' => null,
+            ],
+            [
+                'icon' => 'bi bi-cash-stack',
+                'bg' => 'text-bg-dark',
+                'title' => 'Alliance Cash',
+                'value' => '$'.number_format($cashTotal, 0),
+                'helper' => $totalMembers > 0 ? '$'.number_format($cashPerMember, 0).' per member' : 'No members',
+                'trend' => null,
+            ],
+            [
+                'icon' => 'bi bi-exclamation-octagon',
+                'bg' => 'text-bg-danger',
+                'title' => 'Active Wars',
+                'value' => number_format($activeWars),
+                'helper' => "{$warsThisWeek} wars started last 7 days",
+                'trend' => $warTrend,
+            ],
+        ]);
+
+        return [
+            'kpis' => $kpis,
+            'totalMembers' => $totalMembers,
+            'totalCities' => $totalCities,
+            'poweredCities' => $poweredCities,
+            'powerCoverage' => $powerCoverage,
+            'totalInfrastructure' => $totalInfrastructure,
+            'avgInfrastructure' => $avgInfrastructure,
+            'topInfrastructureCities' => $topInfrastructureCities,
+            'cashTotal' => $cashTotal,
+            'cashPerMember' => $cashPerMember,
+            'resourceTotals' => $resourceTotals,
+            'resourceTotalValue' => $resourceTotalValue,
+            'resourceValueBreakdown' => $resourceValueBreakdown,
+            'latestTradePriceDate' => $latestTradePrice?->date?->format('M d, Y'),
+            'militaryTotals' => $militaryTotals,
+            'militaryReadiness' => $militaryReadiness->all(),
+            'militaryCapacity' => $militaryCapacity,
+            'militaryPerUnitAverage' => $militaryPerUnitAverage,
+            'averageMmrScore' => $averageMmrScore,
+            'mmrThreshold' => $mmrThreshold,
+            'mmrCompliantCount' => $mmrCompliantCount,
+            'mmrCoverage' => $mmrCoverage,
+            'mmrDistribution' => $mmrDistribution,
+            'taxMoneyDaily' => $taxMoneyDaily,
+            'taxResourceDaily' => $taxResourceDaily,
+            'taxMoneyThisWeek' => $taxMoneyThisWeek,
+            'taxMoneyTrend' => $taxMoneyTrend,
+            'warDaily' => $warDaily,
+            'warsThisWeek' => $warsThisWeek,
+            'warTrend' => $warTrend,
+            'activeWars' => $activeWars,
+            'activeWarDetails' => $activeWarDetails,
+            'recentWars' => $recentWars,
+            'loanStats' => $loanStats,
+            'grantStats' => $grantStats,
+            'topCashHolders' => $topCashHolders,
+            'topScoringNations' => $topScoringNations,
+            'memberNationIds' => $memberNationIds,
+        ];
+    }
+
+    /**
+     * Base query for active alliance members excluding applicants and nations in vacation mode.
+     */
+    private function constrainedNationQuery(array $allianceIds)
+    {
+        return Nation::query()
+            ->whereIn('alliance_id', $allianceIds)
+            ->where(function ($query) {
+                $query->whereNull('alliance_position')
+                    ->orWhere('alliance_position', '!=', 'APPLICANT');
+            })
+            ->where(function ($query) {
+                $query->whereNull('vacation_mode_turns')
+                    ->orWhere('vacation_mode_turns', '<=', 0);
+            });
     }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,17 +1,872 @@
 @extends('layouts.admin')
 
-@section("content")
+@section('content')
     <div class="app-content-header">
         <div class="container-fluid">
-            <div class="row">
-                <div class="col-sm-6"><h3 class="mb-0">Dashboard</h3></div>
+            <div class="row align-items-center">
+                <div class="col-12 col-lg-6">
+                    <h3 class="mb-1">Alliance Dashboard</h3>
+                    <p class="text-secondary mb-0">
+                        Telemetry cached {{ $lastRefreshedAt->diffForHumans() }} (expires {{ $lastRefreshedAt->copy()->addMinutes($cacheTtlMinutes)->diffForHumans() }}).
+                    </p>
+                </div>
+                <div class="col-12 col-lg-6 mt-3 mt-lg-0">
+                    <div class="d-flex flex-wrap gap-2 justify-content-lg-end align-items-center">
+                        <span class="badge bg-primary-subtle text-primary-emphasis">
+                            <i class="bi bi-people me-1"></i> Members: {{ number_format($totalMembers) }}
+                        </span>
+                        <span class="badge bg-success-subtle text-success-emphasis">
+                            <i class="bi bi-building me-1"></i> Cities: {{ number_format($totalCities) }}
+                        </span>
+                        <span class="badge bg-dark-subtle text-dark-emphasis">
+                            <i class="bi bi-cash-stack me-1"></i> Cash: ${{ number_format($cashTotal, 0) }}
+                        </span>
+                        <a href="{{ route('admin.dashboard', ['refresh' => 1]) }}" class="btn btn-sm btn-outline-primary">
+                            <i class="bi bi-arrow-clockwise me-1"></i> Refresh
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 
-    <div class="app-content">
-        <div class="container-fluid">
-            <p>Eventually put stuff here</p>
+    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3 mb-4">
+        @foreach ($kpis as $kpi)
+            <div class="col">
+                <div class="info-box shadow-sm h-100">
+                    <span class="info-box-icon {{ $kpi['bg'] }} text-white shadow">
+                        <i class="{{ $kpi['icon'] }}"></i>
+                    </span>
+                    <div class="info-box-content">
+                        <span class="info-box-text text-uppercase text-secondary fw-semibold">{{ $kpi['title'] }}</span>
+                        <div class="d-flex align-items-baseline justify-content-between">
+                            <span class="info-box-number fs-3 fw-semibold">{{ $kpi['value'] }}</span>
+                            @if (! is_null($kpi['trend']))
+                                <span class="badge {{ $kpi['trend'] >= 0 ? 'bg-success-subtle text-success-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
+                                    <i class="bi {{ $kpi['trend'] >= 0 ? 'bi-arrow-up-right' : 'bi-arrow-down-right' }}"></i>
+                                    {{ $kpi['trend'] >= 0 ? '+' : '' }}{{ number_format($kpi['trend'], 1) }}%
+                                </span>
+                            @endif
+                        </div>
+                        @if (! empty($kpi['helper']))
+                            <span class="text-secondary small d-block mt-1">{{ $kpi['helper'] }}</span>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold">Tax Intake (Money)</span>
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="badge bg-success-subtle text-success-emphasis">
+                            ${{ number_format($taxMoneyThisWeek, 0) }} / 7d
+                        </span>
+                        @if (! is_null($taxMoneyTrend))
+                            <span class="badge {{ $taxMoneyTrend >= 0 ? 'bg-success-subtle text-success-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
+                                {{ $taxMoneyTrend >= 0 ? '+' : '' }}{{ number_format($taxMoneyTrend, 1) }}% vs prior week
+                            </span>
+                        @endif
+                    </div>
+                </div>
+                <div class="card-body">
+                    <canvas id="taxMoneyChart" height="220"></canvas>
+                    <p class="text-secondary small mt-3 mb-0">
+                        Shows cash delivered into alliance banks (primary + offshore) across the past two weeks.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Tax Intake (Resources)</div>
+                <div class="card-body">
+                    <canvas id="taxResourceChart" height="220"></canvas>
+                    <p class="text-secondary small mt-3 mb-0">
+                        Focused on steel, munitions, aluminum, and food flows captured in the same window.
+                    </p>
+                </div>
+            </div>
         </div>
     </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold">War Tempo & Damage (14 Days)</span>
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="badge bg-danger-subtle text-danger-emphasis">
+                            {{ number_format($warsThisWeek) }} wars launched
+                        </span>
+                        @if (! is_null($warTrend))
+                            <span class="badge {{ $warTrend >= 0 ? 'bg-danger-subtle text-danger-emphasis' : 'bg-success-subtle text-success-emphasis' }}">
+                                {{ $warTrend >= 0 ? '+' : '' }}{{ number_format($warTrend, 1) }}% vs prior week
+                            </span>
+                        @endif
+                    </div>
+                </div>
+                <div class="card-body">
+                    <canvas id="warChart" height="220"></canvas>
+                    <p class="text-secondary small mt-3 mb-0">
+                        Tracks wars involving our alliance family only, combining infra destruction and looted cash.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold">MMR Readiness</span>
+                    <span class="badge bg-info-subtle text-info-emphasis">
+                        {{ number_format($mmrCoverage, 1) }}% compliant ({{ $mmrCompliantCount }}/{{ number_format($totalMembers) }})
+                    </span>
+                </div>
+                <div class="card-body">
+                    <canvas id="mmrChart" height="220"></canvas>
+                    <div class="mt-3">
+                        <div class="d-flex justify-content-between align-items-center mb-1">
+                            <span class="text-secondary small">Coverage to {{ $mmrThreshold }} score</span>
+                            <span class="fw-semibold small">{{ number_format($mmrCoverage, 1) }}%</span>
+                        </div>
+                        <div class="progress" style="height: 6px;">
+                            <div class="progress-bar bg-info" role="progressbar"
+                                 style="width: {{ min(100, $mmrCoverage) }}%"
+                                 aria-valuenow="{{ $mmrCoverage }}" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold">Resource Stockpile</span>
+                    <span class="badge bg-dark-subtle text-dark-emphasis">
+                        Total value ≈ ${{ number_format($resourceTotalValue, 0) }}
+                    </span>
+                </div>
+                <div class="card-body">
+                    <canvas id="resourceChart" height="240"></canvas>
+                    <p class="text-secondary small mt-3 mb-2">
+                        {{ $latestTradePriceDate ? "Valued with market snapshot {$latestTradePriceDate}." : 'Market snapshot unavailable; displaying raw tonnage.' }}
+                    </p>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                            <tr>
+                                <th>Resource</th>
+                                <th class="text-end">Units</th>
+                                <th class="text-end">Value</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach ($resourceValueBreakdown as $resource => $value)
+                                @php
+                                    $resourceKey = is_string($resource) ? $resource : 'Other';
+                                    $units = $resourceTotals[$resourceKey] ?? null;
+                                @endphp
+                                <tr>
+                                    <td class="text-capitalize">{{ str_replace('_', ' ', $resourceKey) }}</td>
+                                    <td class="text-end">{{ $units !== null ? number_format($units, $units >= 1000 ? 0 : 2) : '—' }}</td>
+                                    <td class="text-end">${{ number_format($value, 0) }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold">Military Readiness</span>
+                    <span class="badge bg-warning-subtle text-warning-emphasis">
+                        Max posture: 15k soldiers / 1.25k tanks / 75 aircraft / 15 ships (per city) · 60 spies (per nation)
+                    </span>
+                </div>
+                <div class="card-body">
+                    <canvas id="militaryChart" height="240"></canvas>
+                    <div class="row text-secondary small mt-3">
+                        <div class="col-12 col-md-6 mb-3 mb-md-0">
+                            <p class="mb-1">Current vs capacity</p>
+                            <ul class="list-unstyled mb-0">
+                                @foreach ($militaryTotals as $unit => $total)
+                                    <li class="d-flex justify-content-between">
+                                        <span class="text-capitalize">{{ str_replace('_', ' ', $unit) }}</span>
+                                        <span class="text-dark fw-semibold">
+                                            {{ number_format($total) }}
+                                            /
+                                            {{ number_format($militaryCapacity[$unit]) }}
+                                        </span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                        <div class="col-12 col-md-6">
+                            <p class="mb-1">Average posture</p>
+                            <ul class="list-unstyled mb-0">
+                                <li class="d-flex justify-content-between">
+                                    <span>Soldiers / city</span>
+                                    <span class="text-dark fw-semibold">{{ number_format($militaryPerUnitAverage['soldiers']) }}</span>
+                                </li>
+                                <li class="d-flex justify-content-between">
+                                    <span>Tanks / city</span>
+                                    <span class="text-dark fw-semibold">{{ number_format($militaryPerUnitAverage['tanks']) }}</span>
+                                </li>
+                                <li class="d-flex justify-content-between">
+                                    <span>Aircraft / city</span>
+                                    <span class="text-dark fw-semibold">{{ number_format($militaryPerUnitAverage['aircraft'], 1) }}</span>
+                                </li>
+                                <li class="d-flex justify-content-between">
+                                    <span>Ships / city</span>
+                                    <span class="text-dark fw-semibold">{{ number_format($militaryPerUnitAverage['ships'], 2) }}</span>
+                                </li>
+                                <li class="d-flex justify-content-between">
+                                    <span>Spies / member</span>
+                                    <span class="text-dark fw-semibold">{{ number_format($militaryPerUnitAverage['spies'], 1) }}</span>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Infrastructure Focus</div>
+                <div class="card-body">
+                    <p class="text-secondary small">
+                        Alliance infrastructure totals {{ number_format($totalInfrastructure, 0) }}. Power coverage at {{ number_format($powerCoverage, 1) }}% keeps the network ready.
+                    </p>
+                    <ul class="list-group list-group-flush">
+                        @forelse ($topInfrastructureCities as $city)
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                <div>
+                                    <a href="https://politicsandwar.com/city/id={{ $city->id }}" target="_blank" rel="noopener" class="fw-semibold text-decoration-none">
+                                        {{ $city->name }}
+                                    </a>
+                                    <span class="text-secondary small d-block">
+                                        <a href="https://politicsandwar.com/nation/id={{ $city->nation?->id }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                            {{ $city->nation?->leader_name ?? 'Unknown' }}
+                                        </a>
+                                    </span>
+                                </div>
+                                <div class="text-end">
+                                    <div class="fw-semibold">{{ number_format($city->infrastructure, 0) }} infra</div>
+                                    <div class="text-secondary small">{{ number_format($city->land, 0) }} land</div>
+                                </div>
+                            </li>
+                        @empty
+                            <li class="list-group-item text-secondary small">No city telemetry captured yet.</li>
+                        @endforelse
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Wealth Concentration</div>
+                <div class="card-body">
+                    <p class="text-secondary small">
+                        Alliance-wide cash reserves average ${{ number_format($cashPerMember, 0) }} per member.
+                    </p>
+                    <ul class="list-group list-group-flush">
+                        @forelse ($topCashHolders as $holder)
+                            <li class="list-group-item d-flex justify-content-between">
+                                <div>
+                                    <a href="https://politicsandwar.com/nation/id={{ $holder->nation_id }}" target="_blank" rel="noopener" class="fw-semibold text-decoration-none">
+                                        {{ $holder->leader_name }}
+                                    </a>
+                                    <span class="text-secondary small d-block">{{ $holder->nation_name }}</span>
+                                </div>
+                                <div class="text-end">
+                                    <div class="fw-semibold">${{ number_format($holder->money, 0) }}</div>
+                                    <div class="text-secondary small">{{ optional($holder->snapshot_at)->diffForHumans() ?? 'Snapshot pending' }}</div>
+                                </div>
+                            </li>
+                        @empty
+                            <li class="list-group-item text-secondary small">No resource telemetry available yet.</li>
+                        @endforelse
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Top Scoring Nations</div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                            <tr>
+                                <th>Nation</th>
+                                <th class="text-end">Score</th>
+                                <th class="text-end">Cities</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse ($topScoringNations as $nation)
+                                <tr>
+                                    <td>
+                                        <a href="https://politicsandwar.com/nation/id={{ $nation->id }}" target="_blank" rel="noopener" class="fw-semibold text-decoration-none">
+                                            {{ $nation->leader_name }}
+                                        </a>
+                                        <span class="text-secondary small d-block">{{ $nation->nation_name }}</span>
+                                    </td>
+                                    <td class="text-end">{{ number_format($nation->score, 2) }}</td>
+                                    <td class="text-end">{{ number_format($nation->num_cities) }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="3" class="text-secondary small">No nations tracked yet.</td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Loan Program Snapshot</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-7 text-secondary small text-uppercase">Pending approvals</dt>
+                        <dd class="col-5 text-end fw-semibold">{{ number_format($loanStats['pending']) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Active or delinquent</dt>
+                        <dd class="col-5 text-end fw-semibold">{{ number_format($loanStats['active']) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Paid-off loans</dt>
+                        <dd class="col-5 text-end fw-semibold">{{ number_format($loanStats['paid']) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Outstanding balance</dt>
+                        <dd class="col-5 text-end fw-semibold">${{ number_format($loanStats['outstanding_balance'], 0) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Avg interest</dt>
+                        <dd class="col-5 text-end fw-semibold">
+                            {{ $loanStats['avg_interest'] !== null ? number_format($loanStats['avg_interest'], 2).'%' : '—' }}
+                        </dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Avg term (weeks)</dt>
+                        <dd class="col-5 text-end fw-semibold">
+                            {{ $loanStats['avg_term'] !== null ? number_format($loanStats['avg_term'], 1) : '—' }}
+                        </dd>
+                    </dl>
+                    <p class="text-secondary small mt-3 mb-0">
+                        Balances include approved and missed loans across the primary alliance and all offshores.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Grant Program Snapshot</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-7 text-secondary small text-uppercase">Pending applications</dt>
+                        <dd class="col-5 text-end fw-semibold">{{ number_format($grantStats['pending']) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Approved this week</dt>
+                        <dd class="col-5 text-end fw-semibold">{{ number_format($grantStats['approved_this_week']) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Total approvals</dt>
+                        <dd class="col-5 text-end fw-semibold">{{ number_format($grantStats['approved_total']) }}</dd>
+
+                        <dt class="col-7 text-secondary small text-uppercase">Money issued (30d)</dt>
+                        <dd class="col-5 text-end fw-semibold">${{ number_format($grantStats['money_disbursed_30d'], 0) }}</dd>
+                    </dl>
+                    <p class="text-secondary small mt-3 mb-0">
+                        Resource payouts are calculated from the latest 30 days of approved grant disbursements.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mb-4">
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">Active War Rooms</div>
+                <div class="card-body">
+                    <ul class="list-group list-group-flush">
+                        @forelse ($activeWarDetails as $war)
+                            @php
+                                $attIsMember = in_array($war->att_id, $memberNationIds, true);
+                                $defIsMember = in_array($war->def_id, $memberNationIds, true);
+                            @endphp
+                            <li class="list-group-item py-3">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <a href="https://politicsandwar.com/nation/id={{ $war->att_id }}" target="_blank" rel="noopener" class="fw-semibold text-decoration-none">
+                                            {{ $war->attacker?->leader_name ?? 'Unknown' }}
+                                        </a>
+                                        @if ($attIsMember)
+                                            <span class="badge bg-primary-subtle text-primary-emphasis align-middle ms-1"
+                                                  data-bs-toggle="tooltip" title="Alliance member">
+                                                <i class="bi bi-shield-check"></i>
+                                            </span>
+                                        @endif
+                                        <span class="text-secondary small d-block">
+                                            vs <a href="https://politicsandwar.com/nation/id={{ $war->def_id }}" target="_blank" rel="noopener" class="text-decoration-none">
+                                                {{ $war->defender?->leader_name ?? 'Unknown' }}
+                                            </a>
+                                            @if ($defIsMember)
+                                                <span class="badge bg-primary-subtle text-primary-emphasis align-middle ms-1"
+                                                      data-bs-toggle="tooltip" title="Alliance member">
+                                                    <i class="bi bi-shield-check"></i>
+                                                </span>
+                                            @endif
+                                        </span>
+                                    </div>
+                                    <div class="text-end">
+                                        <span class="badge bg-danger-subtle text-danger-emphasis text-uppercase small">
+                                            {{ \Illuminate\Support\Str::headline($war->war_type) }}
+                                        </span>
+                                        <div class="text-secondary small mt-1">Turns left: {{ number_format($war->turns_left) }}</div>
+                                    </div>
+                                </div>
+                                <div class="mt-2 text-secondary small">
+                                    <div class="d-flex justify-content-between">
+                                        <span>Resistance</span>
+                                        <span>{{ $war->att_resistance }} / {{ $war->def_resistance }}</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Points</span>
+                                        <span>{{ $war->att_points }} - {{ $war->def_points }}</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Infra loss</span>
+                                        <span>{{ number_format($war->att_infra_destroyed + $war->def_infra_destroyed, 0) }}</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Bank loot</span>
+                                        <span>${{ number_format($war->att_money_looted + $war->def_money_looted, 0) }}</span>
+                                    </div>
+                                    @if ($war->att_fortify || $war->def_fortify)
+                                        <div class="d-flex justify-content-between">
+                                            <span>Fortify</span>
+                                            <span>{{ $war->att_fortify ? 'Att' : '' }}{{ $war->att_fortify && $war->def_fortify ? ' & ' : '' }}{{ $war->def_fortify ? 'Def' : '' }}</span>
+                                        </div>
+                                    @endif
+                                </div>
+                                <a href="https://politicsandwar.com/nation/war/timeline/war={{ $war->id }}" target="_blank" rel="noopener" class="d-inline-block mt-2 small">
+                                    View timeline →
+                                </a>
+                            </li>
+                        @empty
+                            <li class="list-group-item text-secondary small">No active conflicts at the moment.</li>
+                        @endforelse
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-8">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold d-flex justify-content-between align-items-center">
+                    <span>Recent War Outcomes</span>
+                    <span class="text-secondary small">Last {{ $recentWars->count() }} wars involving alliance members</span>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                            <tr>
+                                <th>Date</th>
+                                <th>Attacker</th>
+                                <th>Defender</th>
+                                <th class="text-end">Infra Loss</th>
+                                <th class="text-end">Bank Loot</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse ($recentWars as $war)
+                                @php
+                                    $attIsMember = in_array($war->att_id, $memberNationIds, true);
+                                    $defIsMember = in_array($war->def_id, $memberNationIds, true);
+                                @endphp
+                                <tr>
+                                    <td>{{ $war->date ? \Carbon\Carbon::parse($war->date)->format('M d') : '—' }}</td>
+                                    <td>
+                                        <a href="https://politicsandwar.com/nation/id={{ $war->att_id }}" target="_blank" rel="noopener" class="fw-semibold text-decoration-none">
+                                            {{ $war->attacker?->leader_name ?? 'Unknown' }}
+                                        </a>
+                                        @if ($attIsMember)
+                                            <span class="badge bg-primary-subtle text-primary-emphasis align-middle ms-1"
+                                                  data-bs-toggle="tooltip" title="Alliance member">
+                                                <i class="bi bi-shield-check"></i>
+                                            </span>
+                                        @endif
+                                        @if ($war->winner_id === $war->att_id)
+                                            <span class="badge bg-success-subtle text-success-emphasis ms-1"
+                                                  data-bs-toggle="tooltip" title="Winner">
+                                                W
+                                            </span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <a href="https://politicsandwar.com/nation/id={{ $war->def_id }}" target="_blank" rel="noopener" class="fw-semibold text-decoration-none">
+                                            {{ $war->defender?->leader_name ?? 'Unknown' }}
+                                        </a>
+                                        @if ($defIsMember)
+                                            <span class="badge bg-primary-subtle text-primary-emphasis align-middle ms-1"
+                                                  data-bs-toggle="tooltip" title="Alliance member">
+                                                <i class="bi bi-shield-check"></i>
+                                            </span>
+                                        @endif
+                                        @if ($war->winner_id === $war->def_id)
+                                            <span class="badge bg-success-subtle text-success-emphasis ms-1"
+                                                  data-bs-toggle="tooltip" title="Winner">
+                                                W
+                                            </span>
+                                        @endif
+                                    </td>
+                                    <td class="text-end">
+                                        {{ number_format($war->att_infra_destroyed + $war->def_infra_destroyed, 0) }}
+                                    </td>
+                                    <td class="text-end">
+                                        ${{ number_format($war->att_money_looted + $war->def_money_looted, 0) }}
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="text-secondary small">No recent wars recorded.</td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('scripts')
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const palette = {
+                primary: '#2563eb',
+                secondary: '#1d4ed8',
+                success: '#16a34a',
+                warning: '#f97316',
+                danger: '#dc2626',
+                info: '#0ea5e9',
+                neutral: '#64748b',
+            };
+
+            const taxMoneyData = @json($taxMoneyDaily);
+            const taxResourceData = @json($taxResourceDaily);
+            const warData = @json($warDaily);
+            const mmrBuckets = @json($mmrDistribution);
+            const resourceBreakdown = @json($resourceValueBreakdown instanceof \Illuminate\Support\Collection ? $resourceValueBreakdown->toArray() : $resourceValueBreakdown);
+            const militaryReadiness = @json($militaryReadiness instanceof \Illuminate\Support\Collection ? $militaryReadiness->toArray() : $militaryReadiness);
+
+            const numberFormat = (value) => new Intl.NumberFormat('en-US').format(value ?? 0);
+            const currencyFormat = (value) => '$' + new Intl.NumberFormat('en-US', {maximumFractionDigits: 0}).format(value ?? 0);
+
+            const ctxTaxMoney = document.getElementById('taxMoneyChart');
+            if (ctxTaxMoney) {
+                new Chart(ctxTaxMoney, {
+                    type: 'line',
+                    data: {
+                        labels: taxMoneyData.map(item => item.day),
+                        datasets: [
+                            {
+                                label: 'Money',
+                                data: taxMoneyData.map(item => item.money),
+                                borderColor: palette.success,
+                                backgroundColor: palette.success + '33',
+                                fill: true,
+                                tension: 0.3,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        return `${context.dataset.label}: ${currencyFormat(context.parsed.y)}`;
+                                    },
+                                },
+                            },
+                        },
+                        scales: {
+                            y: { beginAtZero: true },
+                        },
+                    },
+                });
+            }
+
+            const ctxTaxResource = document.getElementById('taxResourceChart');
+            if (ctxTaxResource) {
+                new Chart(ctxTaxResource, {
+                    type: 'line',
+                    data: {
+                        labels: taxResourceData.map(item => item.day),
+                        datasets: [
+                            {
+                                label: 'Steel',
+                                data: taxResourceData.map(item => item.steel),
+                                borderColor: palette.primary,
+                                backgroundColor: palette.primary + '22',
+                                fill: true,
+                                tension: 0.3,
+                            },
+                            {
+                                label: 'Munitions',
+                                data: taxResourceData.map(item => item.munitions),
+                                borderColor: palette.warning,
+                                backgroundColor: palette.warning + '22',
+                                fill: true,
+                                tension: 0.3,
+                            },
+                            {
+                                label: 'Aluminum',
+                                data: taxResourceData.map(item => item.aluminum),
+                                borderColor: palette.info,
+                                backgroundColor: palette.info + '22',
+                                fill: true,
+                                tension: 0.3,
+                            },
+                            {
+                                label: 'Food',
+                                data: taxResourceData.map(item => item.food),
+                                borderColor: palette.neutral,
+                                backgroundColor: palette.neutral + '22',
+                                fill: true,
+                                tension: 0.3,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { display: true },
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        return `${context.dataset.label}: ${numberFormat(context.parsed.y)}`;
+                                    },
+                                },
+                            },
+                        },
+                        scales: {
+                            y: { beginAtZero: true },
+                        },
+                    },
+                });
+            }
+
+            const ctxWar = document.getElementById('warChart');
+            if (ctxWar) {
+                new Chart(ctxWar, {
+                    data: {
+                        labels: warData.map(item => item.day),
+                        datasets: [
+                            {
+                                type: 'bar',
+                                label: 'Wars Started',
+                                data: warData.map(item => item.wars_started),
+                                backgroundColor: palette.danger + '55',
+                                borderRadius: 6,
+                                yAxisID: 'y',
+                            },
+                            {
+                                type: 'line',
+                                label: 'Infra Destroyed',
+                                data: warData.map(item => item.infra_destroyed),
+                                borderColor: palette.warning,
+                                borderWidth: 2,
+                                tension: 0.3,
+                                yAxisID: 'y1',
+                            },
+                            {
+                                type: 'line',
+                                label: 'Money Looted',
+                                data: warData.map(item => item.money_looted),
+                                borderColor: palette.success,
+                                borderDash: [6, 4],
+                                borderWidth: 2,
+                                tension: 0.3,
+                                yAxisID: 'y1',
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            y: { beginAtZero: true, position: 'left' },
+                            y1: {
+                                beginAtZero: true,
+                                position: 'right',
+                                grid: { drawOnChartArea: false },
+                            },
+                        },
+                        plugins: {
+                            legend: { display: true },
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        const label = context.dataset.label;
+                                        const value = context.parsed.y;
+
+                                        if (label === 'Money Looted') {
+                                            return `${label}: ${currencyFormat(value)}`;
+                                        }
+
+                                        return `${label}: ${numberFormat(value)}`;
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            }
+
+            const ctxMmr = document.getElementById('mmrChart');
+            if (ctxMmr) {
+                new Chart(ctxMmr, {
+                    type: 'bar',
+                    data: {
+                        labels: mmrBuckets.map(item => `${item.bucket}s`),
+                        datasets: [
+                            {
+                                label: 'Nations',
+                                data: mmrBuckets.map(item => item.total),
+                                backgroundColor: palette.info + '66',
+                                borderRadius: 6,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            y: { beginAtZero: true },
+                        },
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        return `${context.parsed.y} nations`;
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            }
+
+            const ctxResource = document.getElementById('resourceChart');
+            if (ctxResource) {
+                const labels = Object.keys(resourceBreakdown || {});
+                const values = Object.values(resourceBreakdown || {});
+                new Chart(ctxResource, {
+                    type: 'doughnut',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                data: values,
+                                backgroundColor: [
+                                    palette.primary,
+                                    palette.success,
+                                    palette.info,
+                                    palette.warning,
+                                    palette.danger,
+                                    palette.neutral,
+                                ],
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { position: 'bottom' },
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        return `${context.label}: ${currencyFormat(context.parsed)}`;
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            }
+
+            const ctxMilitary = document.getElementById('militaryChart');
+            if (ctxMilitary) {
+                const labels = Object.keys(militaryReadiness || {}).map(label => label.replace(/_/g, ' '));
+                const readiness = Object.values(militaryReadiness || {});
+                new Chart(ctxMilitary, {
+                    type: 'radar',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                label: 'Readiness %',
+                                data: readiness,
+                                borderColor: palette.primary,
+                                backgroundColor: palette.primary + '33',
+                                borderWidth: 2,
+                                pointBackgroundColor: palette.primary,
+                            },
+                        ],
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            r: {
+                                beginAtZero: true,
+                                suggestedMax: 100,
+                                ticks: {
+                                    callback(value) {
+                                        return `${value}%`;
+                                    },
+                                },
+                            },
+                        },
+                        plugins: {
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        return `${context.label}: ${context.parsed.r}%`;
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            }
+
+            const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+            tooltipTriggerList.forEach(triggerEl => {
+                if (window.bootstrap?.Tooltip) {
+                    new bootstrap.Tooltip(triggerEl);
+                }
+            });
+        });
+    </script>
 @endsection


### PR DESCRIPTION
Implemented comprehensive alliance dashboard metrics in DashboardController, including KPIs, resource and military stats, tax and war trends, loan and grant program snapshots, and caching for performance. Updated dashboard.blade.php to display all metrics with charts, tables, and improved UI for alliance telemetry and analysis. Resolves #157 