### PR TITLE
Add alliance position to WarDeclared event.

### DIFF
--- a/app/Events/WarDeclared.php
+++ b/app/Events/WarDeclared.php
@@ -16,14 +16,18 @@ class WarDeclared
      * @param  int  $warId  War identifier from PW.
      * @param  int  $attackerNationId  Aggressor nation ID.
      * @param  int|null  $attackerAllianceId  Aggressor alliance ID (nullable for no alliance).
+     * @param  string|null  $attackerAlliancePosition  Aggressor alliance position (nullable for no alliance).
      * @param  int  $defenderNationId  Defender nation ID.
      * @param  int|null  $defenderAllianceId  Defender alliance ID.
+     * @param  string|null  $defenderAlliancePosition  Defender alliance position (nullable for no alliance).
      */
     public function __construct(
         public readonly int $warId,
         public readonly int $attackerNationId,
         public readonly ?int $attackerAllianceId,
+        public readonly ?string $attackerAlliancePosition,
         public readonly int $defenderNationId,
-        public readonly ?int $defenderAllianceId
+        public readonly ?int $defenderAllianceId,
+        public readonly ?string $defenderAlliancePosition
     ) {}
 }

--- a/app/Http/Controllers/API/SubController.php
+++ b/app/Http/Controllers/API/SubController.php
@@ -269,8 +269,10 @@ class SubController extends Controller
                     warId: $create['id'],
                     attackerNationId: $create['att_id'],
                     attackerAllianceId: $create['att_alliance_id'] ?? null,
+                    attackerAlliancePosition: $create['att_alliance_position'] ?? null,
                     defenderNationId: $create['def_id'],
                     defenderAllianceId: $create['def_alliance_id'] ?? null,
+                    defenderAlliancePosition: $create['def_alliance_position'] ?? null,
                 ));
             }
         }

--- a/app/Listeners/CreateCounterOnWarDeclared.php
+++ b/app/Listeners/CreateCounterOnWarDeclared.php
@@ -2,6 +2,7 @@
 
 namespace App\Listeners;
 
+use App\Enums\AlliancePositionEnum;
 use App\Events\WarDeclared;
 use App\Jobs\AutoPickCounterAssignmentsJob;
 use App\Models\WarCounter;
@@ -25,7 +26,8 @@ class CreateCounterOnWarDeclared
 
     public function handle(WarDeclared $event): void
     {
-        if (! $this->membershipService->contains($event->defenderAllianceId)) {
+        if (! $this->membershipService->contains($event->defenderAllianceId)
+            || $event->defenderAlliancePosition === AlliancePositionEnum::APPLICANT->value) {
             return;
         }
 

--- a/app/Logs/SubLog.php
+++ b/app/Logs/SubLog.php
@@ -55,14 +55,15 @@ class SubLog extends Log
             }
 
             $this->context = [
-                'type'     => $type,
+                'type' => $type,
                 'resource' => $resource,
-                'action'   => $action,
-                'channel'  => $m['channel'],
-                'attempt'  => (int) $m['attempt'],
+                'action' => $action,
+                'channel' => $m['channel'],
+                'attempt' => (int) $m['attempt'],
             ];
 
             $this->level = $type;
+
             return;
         }
 
@@ -74,11 +75,12 @@ class SubLog extends Log
             $type = 'subscribed';
 
             $this->context = [
-                'type'    => $type,
+                'type' => $type,
                 'channel' => $m['channel'],
             ];
 
             $this->level = $type;
+
             return;
         }
 
@@ -90,12 +92,13 @@ class SubLog extends Log
             $type = 'update-sent';
 
             $this->context = [
-                'type'  => $type,
+                'type' => $type,
                 'model' => $m['model'],
                 'count' => (int) $m['count'],
             ];
 
             $this->level = $type;
+
             return;
         }
 

--- a/app/Logs/SubLogLevel.php
+++ b/app/Logs/SubLogLevel.php
@@ -2,14 +2,12 @@
 
 namespace App\Logs;
 
-use Opcodes\LogViewer\LogLevels\LevelInterface;
 use Opcodes\LogViewer\LogLevels\LevelClass;
+use Opcodes\LogViewer\LogLevels\LevelInterface;
 
 class SubLogLevel implements LevelInterface
 {
-    public function __construct(public readonly string $value)
-    {
-    }
+    public function __construct(public readonly string $value) {}
 
     /**
      * Correct signature required by LevelInterface
@@ -56,17 +54,17 @@ class SubLogLevel implements LevelInterface
             'subscribed',
             'update-sent',
             'pusher-connected',
-            'create'          => LevelClass::success(),
+            'create' => LevelClass::success(),
 
             'received-channel',
-            'info'            => LevelClass::info(),
+            'info' => LevelClass::info(),
 
-            'config'          => LevelClass::warning(),
+            'config' => LevelClass::warning(),
 
             'delete',
-            'shutdown'        => LevelClass::danger(),
+            'shutdown' => LevelClass::danger(),
 
-            default           => LevelClass::none(),
+            default => LevelClass::none(),
         };
     }
 }


### PR DESCRIPTION
Introduces attacker and defender alliance position fields to the WarDeclared event and updates related controller and listener logic to handle these new properties. Also refactors SubLog and SubLogLevel for improved code style and consistency. Resolves #239