### PR TITLE
Add rolling nation sync tracking and UI

### DIFF
--- a/app/Console/Commands/SyncNationsRolling.php
+++ b/app/Console/Commands/SyncNationsRolling.php
@@ -65,9 +65,12 @@ class SyncNationsRolling extends Command
             ->then(fn (Batch $batch) => FinalizeNationSyncJob::dispatch($batch->id))
             ->allowFailures()
             ->onQueue('sync')
+            ->withOption('mode', 'rolling')
+            ->withOption('scope', $scope)
+            ->withOption('step_seconds', $stepSeconds)
             ->dispatch();
 
-        SettingService::setLastNationSyncBatchId($batch->id);
+        SettingService::setLastRollingNationSyncBatchId($batch->id);
 
         $this->info("Queued {$lastPage} rolling nation sync jobs using {$scope} scope.");
 

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -134,10 +134,20 @@ class SettingService
 
     public static function getLastNationSyncBatchId(): string
     {
+        return self::getLastManualNationSyncBatchId();
+    }
+
+    public static function setLastNationSyncBatchId(string $batchId): void
+    {
+        self::setLastManualNationSyncBatchId($batchId);
+    }
+
+    public static function getLastManualNationSyncBatchId(): string
+    {
         $value = self::getValue('last_nation_sync_batch_id');
 
         if (is_null($value)) {
-            self::setLastNationSyncBatchId('');
+            self::setLastManualNationSyncBatchId('');
 
             return '';
         }
@@ -145,9 +155,27 @@ class SettingService
         return $value;
     }
 
-    public static function setLastNationSyncBatchId(string $batchId): void
+    public static function setLastManualNationSyncBatchId(string $batchId): void
     {
         self::setValue('last_nation_sync_batch_id', $batchId);
+    }
+
+    public static function getLastRollingNationSyncBatchId(): string
+    {
+        $value = self::getValue('last_rolling_nation_sync_batch_id');
+
+        if (is_null($value)) {
+            self::setLastRollingNationSyncBatchId('');
+
+            return '';
+        }
+
+        return $value;
+    }
+
+    public static function setLastRollingNationSyncBatchId(string $batchId): void
+    {
+        self::setValue('last_rolling_nation_sync_batch_id', $batchId);
     }
 
     public static function getLastAllianceSyncBatchId(): string

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -32,6 +32,9 @@
                     Full sync jobs are automatically scheduled and run periodically, so manual execution is rarely needed. Manual sync should only be used to correct known discrepancies.
                 </p>
                 <p class="mb-2">
+                    The <strong>Manual Nation Sync</strong> runs immediately and cancels any in-progress rolling nation sync. The <strong>Rolling Nation Sync</strong> is queued by the scheduler and staggers the workload across ~23 hours; use the status card below to see when the last rolling job ran and when the next one is scheduled. Nations below 500 score are only included on the sync on Mondays.
+                </p>
+                <p class="mb-2">
                     Each sync fetches and updates all data for the selected type. Depending on system resources and queue activity, this can take anywhere from a few minutes to nearly an hour.
                 </p>
                 <p class="mb-0">
@@ -41,15 +44,24 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-4">
+        <div class="col-md-6">
             @include('components.admin.sync-card', [
-                'title' => 'Nation Sync',
+                'title' => 'Nation Sync (Manual)',
                 'batch' => $nationBatch,
                 'route' => route('admin.settings.sync.run'),
             ])
         </div>
 
-        <div class="col-md-4">
+        <div class="col-md-6">
+            @include('components.admin.rolling-sync-card', [
+                'batch' => $rollingNationBatch,
+                'rollingSchedule' => $rollingSchedule,
+            ])
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-6">
             @include('components.admin.sync-card', [
                 'title' => 'Alliance Sync',
                 'batch' => $allianceBatch,
@@ -57,7 +69,7 @@
             ])
         </div>
 
-        <div class="col-md-4">
+        <div class="col-md-6">
             @include('components.admin.sync-card', [
                 'title' => 'War Sync',
                 'batch' => $warBatch,
@@ -67,9 +79,9 @@
     </div>
 
     {{-- Other Settings Sections Go Below --}}
-    <div class="row mt-5 g-3">
+    <div class="row mt-2 g-3">
         <div class="col-md-12">
-            <h4 class="mb-3">Other Settings</h4>
+            <h4 class="mb-2">Other Settings</h4>
         </div>
         <div class="col-lg-6">
             <div class="card shadow-sm">

--- a/resources/views/components/admin/rolling-sync-card.blade.php
+++ b/resources/views/components/admin/rolling-sync-card.blade.php
@@ -1,0 +1,100 @@
+<div class="card shadow-sm mb-4 h-100">
+    <div class="card-header d-flex justify-content-between align-items-start flex-wrap gap-2">
+        <div>
+            <h5 class="mb-0 text-primary fw-semibold">Rolling Nation Sync</h5>
+            <p class="mb-0 text-muted small">
+                Scheduled command that staggers nation syncs over ~23 hours (scope: {{ $rollingSchedule['scope'] ? ucfirst($rollingSchedule['scope']) : 'unknown' }}).
+            </p>
+        </div>
+
+        @if($batch && !$batch->finished() && !$batch->cancelled())
+            <div class="d-flex gap-2 ms-auto">
+                <form method="POST" action="{{ route('admin.settings.sync.cancel') }}"
+                      onsubmit="return confirm('Cancel the active rolling nation sync?')">
+                    @csrf
+                    <input type="hidden" name="batch_id" value="{{ $batch->id }}">
+                    <input type="hidden" name="type" value="rolling_nation">
+                    <button type="submit" class="btn btn-sm btn-danger">
+                        <i class="bi bi-x-circle me-1"></i> Cancel Rolling
+                    </button>
+                </form>
+            </div>
+
+        @endif
+    </div>
+
+    <div class="card-body small">
+        @if($batch)
+            @php
+                $progressPercent = $batch->progress();
+                $progressBarClasses = match (true) {
+                    $batch->cancelled() => 'bg-secondary',
+                    $batch->finished() => 'bg-success',
+                    default => 'bg-success progress-bar-striped progress-bar-animated',
+                };
+            @endphp
+
+            <dl class="row mb-0">
+                <dt class="col-sm-4 text-muted">Status</dt>
+                <dd class="col-sm-8">
+                    @if($batch->cancelled())
+                        <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i> Cancelled</span>
+                    @elseif($batch->finished())
+                        <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i> Finished</span>
+                    @else
+                        <span class="badge bg-warning text-dark"><i class="bi bi-clock me-1"></i> Running</span>
+                    @endif
+                </dd>
+
+                <dt class="col-sm-4 text-muted">Jobs Completed</dt>
+                <dd class="col-sm-8">{{ $batch->processedJobs() }} / {{ $batch->totalJobs }}</dd>
+
+                <dt class="col-sm-4 text-muted">Progress</dt>
+                <dd class="col-sm-8">
+                    <div class="progress" style="height: 20px;">
+                        <div class="progress-bar {{ $progressBarClasses }}" style="width: {{ $progressPercent }}%;">
+                            {{ round($progressPercent) }}%
+                        </div>
+                    </div>
+                </dd>
+
+                <dt class="col-sm-4 text-muted">Last Job</dt>
+                <dd class="col-sm-8">
+                    @if($rollingSchedule['lastRunAt'])
+                        {{ $rollingSchedule['lastRunAt']->toDayDateTimeString() }} ({{ $rollingSchedule['lastRunAt']->diffForHumans() }})
+                    @else
+                        Not started yet
+                    @endif
+                </dd>
+
+                <dt class="col-sm-4 text-muted">Next Job</dt>
+                <dd class="col-sm-8">
+                    @if($rollingSchedule['nextRunAt'])
+                        {{ $rollingSchedule['nextRunAt']->toDayDateTimeString() }} ({{ $rollingSchedule['nextRunAt']->diffForHumans() }})
+                    @elseif($batch->finished())
+                        Completed
+                    @else
+                        Pending schedule
+                    @endif
+                </dd>
+
+                <dt class="col-sm-4 text-muted">Started</dt>
+                <dd class="col-sm-8">{{ $batch->createdAt->toDayDateTimeString() }} ({{ $batch->createdAt->diffForHumans() }})</dd>
+
+                @if($batch->finishedAt)
+                    <dt class="col-sm-4 text-muted">Finished</dt>
+                    <dd class="col-sm-8">{{ $batch->finishedAt->toDayDateTimeString() }} ({{ $batch->finishedAt->diffForHumans() }})</dd>
+                @endif
+
+                @if($batch->cancelledAt)
+                    <dt class="col-sm-4 text-muted">Cancelled</dt>
+                    <dd class="col-sm-8 text-danger">{{ $batch->cancelledAt->toDayDateTimeString() }} ({{ $batch->cancelledAt->diffForHumans() }})</dd>
+                @endif
+            </dl>
+        @else
+            <p class="mb-0 text-muted">
+                No rolling nation sync is currently scheduled. The nightly scheduler will queue it automatically.
+            </p>
+        @endif
+    </div>
+</div>


### PR DESCRIPTION
Introduces separate tracking for manual and rolling nation sync batches, updates sync commands and job finalization logic to support both modes, and adds a new rolling nation sync status card to the admin settings view. Improves cancellation handling and provides detailed scheduling info for rolling syncs. Resolves #249