### PR TITLE
Add account freeze/unfreeze functionality

### DIFF
--- a/app/Http/Controllers/Admin/AccountController.php
+++ b/app/Http/Controllers/Admin/AccountController.php
@@ -18,6 +18,7 @@ use Closure;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Container\Container;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Request as RequestFacade;
@@ -126,6 +127,36 @@ class AccountController extends Controller
             'manualTransactions' => $manualTransactions,
             'directDepositLogs' => $directDepositLogs,
             'mmrPurchases' => $mmrPurchases,
+        ]);
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function freeze(Account $account): RedirectResponse
+    {
+        $this->authorize('manage-accounts');
+
+        $updated = AccountService::setFrozen($account, true);
+
+        return back()->with([
+            'alert-message' => $updated ? 'Account frozen successfully.' : 'Account is already frozen.',
+            'alert-type' => $updated ? 'success' : 'info',
+        ]);
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function unfreeze(Account $account): RedirectResponse
+    {
+        $this->authorize('manage-accounts');
+
+        $updated = AccountService::setFrozen($account, false);
+
+        return back()->with([
+            'alert-message' => $updated ? 'Account unfrozen successfully.' : 'Account was not frozen.',
+            'alert-type' => $updated ? 'success' : 'info',
         ]);
     }
 

--- a/resources/views/accounts/components/account_overview.blade.php
+++ b/resources/views/accounts/components/account_overview.blade.php
@@ -20,16 +20,21 @@
             </thead>
             <tbody>
             @foreach($accounts as $account)
-                <tr class="hover">
+                <tr class="hover {{ $account->frozen ? 'bg-error/10' : '' }}">
                     <td class="font-semibold flex items-center gap-2">
                         <a href="{{ route('accounts.view', ['accounts' => $account]) }}"
                            class="link link-primary">
                             {{ $account->name }}
                         </a>
 
-                        <div class="tooltip" data-tip="Generate deposit code">
+                        @if($account->frozen)
+                            <span class="badge badge-error badge-sm">Frozen</span>
+                        @endif
+
+                        <div class="tooltip" data-tip="{{ $account->frozen ? 'Account is frozen' : 'Generate deposit code' }}">
                             <button class="btn btn-square btn-ghost btn-xs deposit-request-btn"
-                                    data-account-id="{{ $account->id }}">
+                                    data-account-id="{{ $account->id }}"
+                                    @disabled($account->frozen)>
                                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
                                     <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clip-rule="evenodd"/>
                                 </svg>

--- a/resources/views/accounts/view.blade.php
+++ b/resources/views/accounts/view.blade.php
@@ -8,6 +8,15 @@
     @endphp
 
     <div class="mx-auto space-y-8">
+        @if($account->frozen)
+            <div class="alert alert-error shadow-sm">
+                <div>
+                    <h3 class="font-semibold">Account frozen</h3>
+                    <p class="text-sm">Withdrawals and transfers are disabled for this account. Please contact an administrator for assistance.</p>
+                </div>
+            </div>
+        @endif
+
         <div class="rounded-2xl border border-base-300 bg-base-100 p-6 shadow-md">
             <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div>
@@ -22,11 +31,16 @@
                         <span class="badge badge-outline">ID {{ $account->id }}</span>
                         <span class="badge badge-outline">${{ number_format($account->money, 2) }} cash</span>
                         <span class="badge badge-outline">{{ number_format($resourceTotal, 2) }} resources</span>
+                        <span class="badge {{ $account->frozen ? 'badge-error' : 'badge-success' }}">{{ $account->frozen ? 'Frozen' : 'Active' }}</span>
                     </div>
                 </div>
                 <div class="flex flex-wrap gap-2">
-                    <div class="tooltip" data-tip="Create a fresh deposit code for this account">
-                        <button class="btn btn-primary deposit-request-btn" data-account-id="{{ $account->id }}">Create deposit</button>
+                    <div class="tooltip" data-tip="{{ $account->frozen ? 'Account is frozen' : 'Create a fresh deposit code for this account' }}">
+                        <button class="btn btn-primary deposit-request-btn"
+                                data-account-id="{{ $account->id }}"
+                                @disabled($account->frozen)>
+                            Create deposit
+                        </button>
                     </div>
                     <a href="{{ route('accounts') }}" class="btn btn-ghost">Back to accounts</a>
                 </div>

--- a/resources/views/admin/accounts/dashboard.blade.php
+++ b/resources/views/admin/accounts/dashboard.blade.php
@@ -138,7 +138,7 @@
                     </thead>
                     <tbody>
                     @foreach ($accounts as $acc)
-                        <tr>
+                        <tr class="{{ $acc->frozen ? 'table-danger' : '' }}">
                             <td>
                                 @if($acc->user)
                                     <span class="fw-semibold"><a href="https://politicsandwar.com/nation/id={{ $acc->nation_id }}" target="_blank" rel="noopener" class="text-decoration-none">{{ $acc->user->name }}</a></span>
@@ -147,9 +147,14 @@
                                 @endif
                             </td>
                             <td>
-                                <a href="{{ route('admin.accounts.view', $acc->id) }}" class="link-primary fw-semibold">
-                                    {{ $acc->name }}
-                                </a>
+                                <div class="d-flex align-items-center gap-2">
+                                    <a href="{{ route('admin.accounts.view', $acc->id) }}" class="link-primary fw-semibold">
+                                        {{ $acc->name }}
+                                    </a>
+                                    @if($acc->frozen)
+                                        <span class="badge text-bg-danger">Frozen</span>
+                                    @endif
+                                </div>
                             </td>
                             <td class="text-end" data-order="{{ $acc->money }}">${{ number_format($acc->money, 2) }}</td>
                             @foreach($resourceList as $resource)

--- a/resources/views/admin/accounts/view.blade.php
+++ b/resources/views/admin/accounts/view.blade.php
@@ -8,6 +8,22 @@
                 <div class="col-sm-6">
                     <h3 class="mb-0">View Account - {{ $account->name }}</h3>
                 </div>
+                <div class="col-sm-6 mt-3 mt-sm-0 d-flex justify-content-sm-end align-items-start align-items-sm-center gap-2">
+                    <span class="badge {{ $account->frozen ? 'text-bg-danger' : 'text-bg-success' }}">
+                        {{ $account->frozen ? 'Frozen' : 'Active' }}
+                    </span>
+                    @can('manage-accounts')
+                        <form method="POST"
+                              action="{{ $account->frozen ? route('admin.accounts.unfreeze', $account) : route('admin.accounts.freeze', $account) }}"
+                              onsubmit="return confirm('Are you sure you want to {{ $account->frozen ? 'unfreeze' : 'freeze' }} this account?');">
+                            @csrf
+                            <button type="submit"
+                                    class="btn btn-sm {{ $account->frozen ? 'btn-outline-success' : 'btn-outline-danger' }}">
+                                {{ $account->frozen ? 'Unfreeze Account' : 'Freeze Account' }}
+                            </button>
+                        </form>
+                    @endcan
+                </div>
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -166,6 +166,12 @@ Route::middleware(['auth', EnsureUserIsVerified::class, DiscordVerifiedMiddlewar
         Route::post('/accounts/{account}/adjust', [AccountController::class, 'adjustBalance'])->name(
             'admin.accounts.adjust'
         );
+        Route::post('/accounts/{account}/freeze', [AccountController::class, 'freeze'])->name(
+            'admin.accounts.freeze'
+        );
+        Route::post('/accounts/{account}/unfreeze', [AccountController::class, 'unfreeze'])->name(
+            'admin.accounts.unfreeze'
+        );
         Route::post('/accounts/transactions/{transaction}/refund', [AccountController::class, 'refundTransaction'])
             ->name('admin.accounts.transactions.refund')
             ->middleware(BlockWhenPWDown::class);


### PR DESCRIPTION
Introduces the ability for admins to freeze or unfreeze accounts, preventing withdrawals and transfers on frozen accounts. Updates UI to display frozen status and disables deposit actions for frozen accounts. Adds routes and controller methods for freezing/unfreezing, and enforces restrictions in AccountService. Resolves #225