### PR TITLE
Harden weekly amortization loans and expand user/admin transparency

### DIFF
--- a/app/Http/Controllers/AccountsController.php
+++ b/app/Http/Controllers/AccountsController.php
@@ -82,6 +82,12 @@ class AccountsController extends Controller
                     ]);
                 }
 
+                if (! in_array($loan->status, ['approved', 'missed'], true)) {
+                    throw ValidationException::withMessages([
+                        'to' => ['This loan cannot currently receive repayments.'],
+                    ]);
+                }
+
                 // Validate account ownership
                 if ($account->nation_id !== Auth::user()->nation_id) {
                     throw ValidationException::withMessages([
@@ -363,7 +369,7 @@ class AccountsController extends Controller
         }
 
         $activeLoans = Loan::where('nation_id', $nationId)
-            ->where('status', 'approved')
+            ->whereIn('status', ['approved', 'missed'])
             ->where('remaining_balance', '>', 0)
             ->get();
 

--- a/app/Http/Controllers/Admin/ManualDisbursementController.php
+++ b/app/Http/Controllers/Admin/ManualDisbursementController.php
@@ -209,7 +209,7 @@ class ManualDisbursementController extends Controller
             'status' => 'pending',
         ]);
 
-        $this->loanService->approveLoan($loan, $data['amount'], $data['interest_rate'], $data['term_weeks'], $nation);
+        $this->loanService->approveLoan($loan, $data['amount'], $data['interest_rate'], $data['term_weeks']);
 
         $this->auditLogger->recordAfterCommit(
             category: 'loans',

--- a/app/Models/Loan.php
+++ b/app/Models/Loan.php
@@ -23,6 +23,9 @@ class Loan extends Model
         'amount',
         'remaining_balance',
         'weekly_interest_paid',
+        'scheduled_weekly_payment',
+        'past_due_amount',
+        'accrued_interest_due',
         'interest_rate',
         'term_weeks',
         'status',
@@ -32,6 +35,13 @@ class Loan extends Model
 
     protected $casts = [
         'next_due_date' => 'datetime',
+        'amount' => 'float',
+        'remaining_balance' => 'float',
+        'weekly_interest_paid' => 'float',
+        'scheduled_weekly_payment' => 'float',
+        'past_due_amount' => 'float',
+        'accrued_interest_due' => 'float',
+        'interest_rate' => 'float',
     ];
 
     /**
@@ -62,20 +72,9 @@ class Loan extends Model
 
     public function getNextPaymentDue(): float
     {
-        $loanService = app(LoanService::class); // Resolve the service
-        $weeklyPayment = $loanService->calculateWeeklyPayment($this);
+        $loanService = app(LoanService::class);
 
-        if (! $this->next_due_date) {
-            return $weeklyPayment;
-        }
-
-        // Get total early payments made since last due date
-        $earlyPayments = $this->payments()
-            ->where('payment_date', '>=', $this->next_due_date->copy()->subDays(7))
-            ->sum('amount');
-
-        // If early payments cover the weekly payment, the next payment is $0
-        return max(0, $weeklyPayment - $earlyPayments);
+        return $loanService->calculateCurrentAmountDue($this);
     }
 
     /**

--- a/app/Notifications/LoanNotification.php
+++ b/app/Notifications/LoanNotification.php
@@ -57,8 +57,9 @@ class LoanNotification extends Notification implements ShouldQueue
                 .'- Next due date: [b]'.($this->loan->next_due_date ? $this->loan->next_due_date->format(
                     'M d, Y'
                 ) : 'N/A')."[/b]\n"
+                .'- Scheduled weekly payment: [b]$'.number_format((float) $this->loan->scheduled_weekly_payment, 2)."[/b]\n"
                 ."- Funds have been deposited into your selected account.\n\n"
-                .'Make sure to [b]repay your loan on time[/b] to avoid penalties.';
+                .'Your payment amount follows weekly amortization (interest first, then principal).';
         } elseif ($this->status === 'denied') {
             $subject = 'Loan Denied';
             $message = 'Unfortunately, your loan request for [b]$'.number_format(
@@ -95,6 +96,16 @@ class LoanNotification extends Notification implements ShouldQueue
                 ).'[/b] toward this week, '
                 ."you owe nothing for this cycle.\n\n"
                 ."Your next payment will be due on [b]{$this->loan->next_due_date->format('M d, Y')}[/b].";
+        } elseif ($this->status === 'missed_payment') {
+            $subject = 'Loan Payment Missed';
+            $message = 'A scheduled loan payment was missed, and the amount due has rolled forward.'."\n\n"
+                .'[b]Current Amount Due:[/b] $'.number_format((float) ($this->paymentAmount ?? 0), 2)."\n"
+                .'[b]Past Due Amount:[/b] $'.number_format((float) $this->loan->past_due_amount, 2)."\n"
+                .'[b]Accrued Interest Due:[/b] $'.number_format((float) $this->loan->accrued_interest_due, 2)."\n\n"
+                .'Make a payment when possible to reduce accrued interest and principal.';
+        } else {
+            $subject = 'Loan Update';
+            $message = 'Your loan has been updated.';
         }
 
         return [

--- a/database/migrations/2026_02_23_184313_add_amortization_tracking_fields_to_loans_table.php
+++ b/database/migrations/2026_02_23_184313_add_amortization_tracking_fields_to_loans_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('loans', function (Blueprint $table) {
+            $table->decimal('scheduled_weekly_payment', 15, 2)->default(0)->after('weekly_interest_paid');
+            $table->decimal('past_due_amount', 15, 2)->default(0)->after('scheduled_weekly_payment');
+            $table->decimal('accrued_interest_due', 15, 2)->default(0)->after('past_due_amount');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('loans', function (Blueprint $table) {
+            $table->dropColumn([
+                'scheduled_weekly_payment',
+                'past_due_amount',
+                'accrued_interest_due',
+            ]);
+        });
+    }
+};

--- a/resources/views/admin/loans/view.blade.php
+++ b/resources/views/admin/loans/view.blade.php
@@ -5,39 +5,155 @@
     <div class="app-content-header">
         <div class="container-fluid">
             <div class="row">
-                <div class="col-sm-6">
-                    <h3 class="mb-0">View Loan #{{ $loan->id }} - <a
-                                href="https://politicsandwar.com/nation/id={{ $loan->nation_id }}"
-                                target="_blank">{{ $loan->nation->leader_name }}</a></h3>
+                <div class="col-sm-9">
+                    <h3 class="mb-1">
+                        Loan #{{ $loan->id }} -
+                        <a href="https://politicsandwar.com/nation/id={{ $loan->nation_id }}" target="_blank" rel="noopener noreferrer">
+                            {{ $loan->nation->leader_name ?? ('Nation #'.$loan->nation_id) }}
+                        </a>
+                    </h3>
+                    <p class="text-muted mb-0">
+                        Status:
+                        @if ($loan->status === 'missed')
+                            <span class="badge text-bg-warning">Missed</span>
+                        @elseif ($loan->status === 'approved')
+                            <span class="badge text-bg-success">Approved</span>
+                        @elseif ($loan->status === 'paid')
+                            <span class="badge text-bg-primary">Paid</span>
+                        @else
+                            <span class="badge text-bg-secondary">{{ ucfirst($loan->status) }}</span>
+                        @endif
+                    </p>
                 </div>
             </div>
         </div>
     </div>
 
-    {{-- Loan Summary Info Boxes --}}
+    @if (! $loanPaymentsEnabled)
+        <div class="alert alert-warning mt-2">
+            <i class="bi bi-pause-circle me-2"></i>
+            Loan payments are paused globally. Weekly accrual and required due are frozen until resumed.
+        </div>
+    @endif
+
     <div class="row">
         <div class="col-md-3">
-            <x-admin.info-box icon="bi bi-cash" bgColor="text-bg-success" title="Loan Amount"
-                              :value="number_format($loan->amount, 2)"/>
+            <x-admin.info-box icon="bi bi-cash" bgColor="text-bg-success" title="Original Principal"
+                              :value="number_format((float) $loan->amount, 2)"/>
         </div>
         <div class="col-md-3">
-            <x-admin.info-box icon="bi bi-piggy-bank" bgColor="text-bg-primary" title="Remaining Balance"
-                              :value="number_format($loan->remaining_balance, 2)"/>
+            <x-admin.info-box icon="bi bi-piggy-bank" bgColor="text-bg-primary" title="Remaining Principal"
+                              :value="number_format((float) $loan->remaining_balance, 2)"/>
         </div>
         <div class="col-md-3">
-            <x-admin.info-box icon="bi bi-calendar" bgColor="text-bg-warning" title="Next Payment Due"
-                              :value="$loan->next_due_date ? $loan->next_due_date->format('M d, Y') : 'N/A'"/>
+            <x-admin.info-box icon="bi bi-arrow-repeat" bgColor="text-bg-info" title="Scheduled Weekly Payment"
+                              :value="number_format((float) $scheduledWeeklyPayment, 2)"/>
         </div>
         <div class="col-md-3">
-            <x-admin.info-box icon="bi bi-credit-card" bgColor="text-bg-danger" title="Minimum Payment Due"
-                              :value="number_format($nextMinimumPayment, 2)"/>
+            <x-admin.info-box icon="bi bi-credit-card" bgColor="text-bg-danger" title="Current Required Payment"
+                              :value="number_format((float) $nextMinimumPayment, 2)"/>
+        </div>
+        <div class="col-md-3">
+            <x-admin.info-box icon="bi bi-exclamation-triangle" bgColor="text-bg-warning" title="Past Due Amount"
+                              :value="number_format((float) $loan->past_due_amount, 2)"/>
+        </div>
+        <div class="col-md-3">
+            <x-admin.info-box icon="bi bi-percent" bgColor="text-bg-secondary" title="Interest Due Now"
+                              :value="number_format((float) ($fullPayoffPreview['interest'] ?? 0), 2)"/>
+        </div>
+        <div class="col-md-3">
+            <x-admin.info-box icon="bi bi-wallet2" bgColor="text-bg-dark" title="Total Payoff Now"
+                              :value="number_format((float) (($fullPayoffPreview['interest'] ?? 0) + $loan->remaining_balance), 2)"/>
+        </div>
+        <div class="col-md-3">
+            <x-admin.info-box icon="bi bi-calendar" bgColor="text-bg-warning" title="Next Due Date"
+                              :value="$loan->next_due_date ? Carbon::parse($loan->next_due_date)->format('M d, Y') : 'N/A'"/>
         </div>
     </div>
 
-    {{-- Loan Edit Form --}}
+    <div class="card mt-4">
+        <div class="card-header">Loan Operations Summary</div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-lg-4">
+                    <div class="border rounded p-3 h-100">
+                        <p class="fw-semibold mb-2">Cycle Progress</p>
+                        <p class="mb-1">
+                            Cycle window:
+                            <strong>
+                                {{ $cycleProgress['cycle_start'] ? Carbon::parse($cycleProgress['cycle_start'])->format('M d') : 'N/A' }}
+                                -
+                                {{ $cycleProgress['cycle_end'] ? Carbon::parse($cycleProgress['cycle_end'])->format('M d') : 'N/A' }}
+                            </strong>
+                        </p>
+                        <p class="mb-1">Paid this cycle: <strong>${{ number_format((float) $cycleProgress['paid_this_cycle'], 2) }}</strong></p>
+                        <p class="mb-0">Remaining to scheduled target: <strong>${{ number_format((float) $cycleProgress['remaining_to_scheduled'], 2) }}</strong></p>
+                    </div>
+                </div>
+                <div class="col-lg-4">
+                    <div class="border rounded p-3 h-100">
+                        <p class="fw-semibold mb-2">Next Required Payment Split</p>
+                        <p class="mb-1">Required now: <strong>${{ number_format((float) $nextMinimumPayment, 2) }}</strong></p>
+                        <p class="mb-1">Interest portion: <strong>${{ number_format((float) ($nextPaymentPreview['interest'] ?? 0), 2) }}</strong></p>
+                        <p class="mb-0">Principal portion: <strong>${{ number_format((float) ($nextPaymentPreview['principal'] ?? 0), 2) }}</strong></p>
+                    </div>
+                </div>
+                <div class="col-lg-4">
+                    <div class="border rounded p-3 h-100">
+                        <p class="fw-semibold mb-2">Payment History Totals</p>
+                        <p class="mb-1">Total paid: <strong>${{ number_format((float) $totals['paid_total'], 2) }}</strong></p>
+                        <p class="mb-1">Principal paid: <strong>${{ number_format((float) $totals['paid_principal'], 2) }}</strong></p>
+                        <p class="mb-0">Interest paid: <strong>${{ number_format((float) $totals['paid_interest'], 2) }}</strong></p>
+                    </div>
+                </div>
+            </div>
+
+            <hr>
+
+            <div class="row g-3">
+                <div class="col-lg-4">
+                    <div class="border rounded p-3 h-100">
+                        <p class="fw-semibold mb-2">Contract Context</p>
+                        <p class="mb-1">Approved at: <strong>{{ $loan->approved_at ? Carbon::parse($loan->approved_at)->format('M d, Y') : 'N/A' }}</strong></p>
+                        <p class="mb-1">Weeks elapsed: <strong>{{ min($weeksElapsed, (int) $loan->term_weeks) }}</strong> / {{ (int) $loan->term_weeks }}</p>
+                        <p class="mb-0">Weekly rate: <strong>{{ number_format((float) $loan->interest_rate, 2) }}%</strong></p>
+                    </div>
+                </div>
+                <div class="col-lg-8">
+                    <div class="border rounded p-3 h-100">
+                        <p class="fw-semibold mb-2">Accounting Rules in Effect</p>
+                        <ul class="mb-0 ps-3">
+                            <li>Interest accrues weekly at cycle close (not daily).</li>
+                            <li>Cycle interest is locked to cycle-opening principal.</li>
+                            <li>Payments apply to accrued interest first, then principal.</li>
+                            <li>Only cycle shortfall rolls into past due.</li>
+                            <li>No penalty fees are currently added on missed cycles.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="card mt-4">
         <div class="card-header">Modify Loan Details</div>
         <div class="card-body">
+            @php
+                $loanIsImmutable = $loan->payments->isNotEmpty();
+            @endphp
+
+            @if ($loanIsImmutable)
+                <div class="alert alert-warning">
+                    <p class="mb-1 fw-semibold">This loan is locked because payments already exist.</p>
+                    <p class="mb-1">To preserve accounting integrity, terms and balances can no longer be edited directly.</p>
+                    <p class="mb-0">
+                        If a correction is required:
+                        1) mark this loan as paid, and
+                        2) create a replacement loan via manual disbursement with corrected terms/amount.
+                    </p>
+                </div>
+            @endif
+
             <form method="POST" action="{{ route('admin.loans.update', $loan) }}">
                 @csrf
 
@@ -45,66 +161,112 @@
                     <label for="amount" class="form-label">Loan Amount</label>
                     <input type="number" name="amount" id="amount" min="1"
                            value="{{ $loan->amount }}" class="form-control"
-                           @if($loan->payments()->exists()) disabled @endif>
-                    @if($loan->payments()->exists())
-                        <p class="text-sm text-muted">If there have been payments towards this loan, you cannot modify
-                            the loan amount</p>
+                           @if($loanIsImmutable) disabled @endif>
+                    @if($loanIsImmutable)
+                        <p class="text-sm text-muted mb-0">Locked after first payment.</p>
                     @endif
                 </div>
 
                 <div class="mb-3">
-                    <label for="interest_rate" class="form-label">Interest Rate (%)</label>
+                    <label for="interest_rate" class="form-label">Weekly Interest Rate (%)</label>
                     <input type="number" name="interest_rate" id="interest_rate" min="0" max="100" step="0.01"
-                           value="{{ $loan->interest_rate }}" class="form-control">
+                           value="{{ $loan->interest_rate }}" class="form-control"
+                           @if($loanIsImmutable) disabled @endif>
                 </div>
 
                 <div class="mb-3">
                     <label for="term_weeks" class="form-label">Loan Term (Weeks)</label>
-                    <input type="number" name="term_weeks" id="term_weeks" min="1" max="104"
-                           value="{{ $loan->term_weeks }}" class="form-control">
+                    <input type="number" name="term_weeks" id="term_weeks" min="1" max="52"
+                           value="{{ $loan->term_weeks }}" class="form-control"
+                           @if($loanIsImmutable) disabled @endif>
                 </div>
 
                 <div class="mb-3">
                     <label for="next_due_date" class="form-label">Next Payment Due Date</label>
                     <input type="date" name="next_due_date" id="next_due_date"
-                           value="{{ $loan->next_due_date->format('Y-m-d') }}" class="form-control">
+                           value="{{ $loan->next_due_date ? Carbon::parse($loan->next_due_date)->format('Y-m-d') : '' }}" class="form-control"
+                           @if($loanIsImmutable) disabled @endif>
                 </div>
 
                 <div class="mb-3">
-                    <label for="remaining_balance" class="form-label">Remaining Balance</label>
+                    <label for="remaining_balance" class="form-label">Remaining Principal Balance</label>
                     <input type="number" name="remaining_balance" id="remaining_balance" min="0" step="0.01"
                            max="{{ $loan->amount }}"
-                           value="{{ $loan->remaining_balance }}" class="form-control">
+                           value="{{ $loan->remaining_balance }}" class="form-control"
+                           @if($loanIsImmutable) disabled @endif>
                 </div>
 
-                <button type="submit" class="btn btn-primary w-full">Update Loan</button>
+                <div class="d-flex justify-content-end">
+                    <button type="submit" class="btn btn-primary px-4" @if($loanIsImmutable) disabled @endif>
+                        Update Loan
+                    </button>
+                </div>
             </form>
-            {{-- Mark Loan as Paid Button --}}
+
             <form method="POST" action="{{ route('admin.loans.markPaid', $loan) }}" class="mt-4">
                 @csrf
-                <button type="submit" class="btn btn-danger w-full"
-                        onclick="return confirm('Are you sure you want to mark this loan as fully paid? This action cannot be undone.')">
-                    Mark Loan as Paid
-                </button>
+                <div class="d-flex justify-content-end">
+                    <button type="submit" class="btn btn-outline-danger px-4"
+                            onclick="return confirm('Are you sure you want to mark this loan as fully paid? This action cannot be undone.')">
+                        Mark Loan as Paid
+                    </button>
+                </div>
             </form>
         </div>
     </div>
 
-    {{-- Loan Payment History --}}
+    <div class="card mt-4">
+        <div class="card-header">Contract Amortization Schedule</div>
+        <div class="card-body">
+            @if (empty($amortizationSchedule))
+                <p class="text-muted mb-0">No schedule available for this loan.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-striped table-sm align-middle mb-0">
+                        <thead>
+                        <tr>
+                            <th>Week</th>
+                            <th>Scheduled Date</th>
+                            <th>Opening Balance</th>
+                            <th>Payment</th>
+                            <th>Interest</th>
+                            <th>Principal</th>
+                            <th>Closing Balance</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach ($amortizationSchedule as $row)
+                            <tr>
+                                <td>{{ $row['week'] }}</td>
+                                <td>{{ ! empty($row['due_date']) ? Carbon::parse($row['due_date'])->format('M d, Y') : 'N/A' }}</td>
+                                <td>${{ number_format((float) $row['opening_balance'], 2) }}</td>
+                                <td>${{ number_format((float) $row['payment'], 2) }}</td>
+                                <td>${{ number_format((float) $row['interest'], 2) }}</td>
+                                <td>${{ number_format((float) $row['principal'], 2) }}</td>
+                                <td>${{ number_format((float) $row['closing_balance'], 2) }}</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+
     <div class="card mt-4">
         <div class="card-header">Loan Payment History</div>
         <div class="card-body">
             @if ($loan->payments->isEmpty())
-                <p class="text-gray-500">No payments have been made for this loan.</p>
+                <p class="text-muted mb-0">No payments have been made for this loan.</p>
             @else
-                <div class="overflow-x-auto">
-                    <table class="table table-striped">
+                <div class="table-responsive">
+                    <table class="table table-striped table-sm align-middle">
                         <thead>
                         <tr>
                             <th>Payment ID</th>
                             <th>Amount</th>
-                            <th>Principal Paid</th>
                             <th>Interest Paid</th>
+                            <th>Principal Paid</th>
                             <th>Paid From Account</th>
                             <th>Payment Date</th>
                         </tr>
@@ -113,11 +275,11 @@
                         @foreach ($loan->payments as $payment)
                             <tr>
                                 <td>{{ $payment->id }}</td>
-                                <td>${{ number_format($payment->amount, 2) }}</td>
-                                <td>${{ number_format($payment->principal_paid, 2) }}</td>
-                                <td>${{ number_format($payment->interest_paid, 2) }}</td>
+                                <td>${{ number_format((float) $payment->amount, 2) }}</td>
+                                <td>${{ number_format((float) $payment->interest_paid, 2) }}</td>
+                                <td>${{ number_format((float) $payment->principal_paid, 2) }}</td>
                                 <td>{{ $payment->account->name ?? 'N/A' }}</td>
-                                <td>{{ Carbon::create($payment->payment_date)->format('M d, Y') }}</td>
+                                <td>{{ Carbon::parse($payment->payment_date)->format('M d, Y H:i') }}</td>
                             </tr>
                         @endforeach
                         </tbody>

--- a/resources/views/loans/index.blade.php
+++ b/resources/views/loans/index.blade.php
@@ -1,34 +1,60 @@
-@php use Carbon\Carbon; @endphp
 @extends('layouts.main')
 
-@section("content")
+@section('content')
     <div class="mx-auto space-y-8">
-        <div class="rounded-2xl bg-base-100 border border-base-300 p-6 shadow-md">
+        <div class="rounded-2xl border border-base-300 bg-base-100 p-6 shadow-md">
             <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div>
-                    <p class="text-xs uppercase tracking-wide text-base-content/60">Funding desk</p>
+                    <p class="text-xs uppercase tracking-wide text-base-content/60">Funding Desk</p>
                     <h1 class="text-3xl font-bold leading-tight">Loans</h1>
-                    <p class="text-sm text-base-content/70">Apply, repay early, and monitor your history with one modern view.</p>
+                    <p class="text-sm text-base-content/70">Weekly amortized loans with transparent payment math.</p>
                 </div>
-                <div class="flex flex-wrap gap-3">
-                    <div class="rounded-xl bg-primary/10 border border-primary/30 px-4 py-3">
-                        <p class="text-xs uppercase text-base-content/70">Active loans</p>
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <div class="rounded-xl border border-base-300 bg-base-200 px-4 py-3">
+                        <p class="text-xs uppercase text-base-content/60">Active Loans</p>
                         <p class="text-xl font-bold">{{ $activeLoans->count() }}</p>
                     </div>
-                    <div class="rounded-xl bg-base-200 border border-base-300 px-4 py-3">
-                        <p class="text-xs uppercase text-base-content/70">Requests on file</p>
-                        <p class="text-xl font-bold">{{ $loanHistory->count() }}</p>
+                    <div class="rounded-xl border border-base-300 bg-base-200 px-4 py-3">
+                        <p class="text-xs uppercase text-base-content/60">Outstanding Principal</p>
+                        <p class="text-xl font-bold">${{ number_format((float) $activeLoans->sum('remaining_balance'), 2) }}</p>
+                    </div>
+                    <div class="rounded-xl border border-base-300 bg-base-200 px-4 py-3">
+                        <p class="text-xs uppercase text-base-content/60">Total Currently Due</p>
+                        <p class="text-xl font-bold">${{ number_format((float) $activeLoans->sum('next_payment_due'), 2) }}</p>
                     </div>
                 </div>
             </div>
         </div>
+
+        <x-utils.card title="Loan In 30 Seconds" extraClasses="shadow-lg">
+            <div class="grid gap-4 text-sm text-base-content/85 md:grid-cols-2">
+                <div class="rounded-xl border border-base-300 bg-base-200 p-4">
+                    <p class="font-semibold">What happens</p>
+                    <ul class="mt-2 list-disc space-y-1 pl-5">
+                        <li>You receive money up front.</li>
+                        <li>You owe a minimum payment every 7 days.</li>
+                        <li>Each payment pays interest first, then principal.</li>
+                        <li>As principal goes down, future interest gets smaller.</li>
+                    </ul>
+                </div>
+                <div class="rounded-xl border border-base-300 bg-base-200 p-4">
+                    <p class="font-semibold">If a payment is missed</p>
+                    <ul class="mt-2 list-disc space-y-1 pl-5">
+                        <li>The missed weekly amount moves into past due.</li>
+                        <li>Weekly cycle interest continues to accrue.</li>
+                        <li>No penalty fee is added right now.</li>
+                        <li>Paying catches up interest first, then principal.</li>
+                    </ul>
+                </div>
+            </div>
+        </x-utils.card>
 
         @if (! $loanPaymentsEnabled)
             <div class="alert alert-warning shadow-md">
                 <div>
                     <p class="font-semibold">Loan payments are paused.</p>
                     <p class="text-sm">
-                        Required payments and interest are frozen. Due dates will shift forward when payments resume.
+                        Scheduled deductions and weekly interest accrual are frozen. Due dates shift forward when payments resume.
                         @if ($loanPaymentsPausedAt)
                             Paused since {{ $loanPaymentsPausedAt->format('M d, Y H:i') }}.
                         @endif
@@ -41,43 +67,32 @@
             <div class="alert alert-warning shadow-md">
                 <div>
                     <p class="font-semibold">Loan applications are currently closed.</p>
-                    <p class="text-sm">
-                        New requests are paused. You can still review your history and make payments on active loans.
-                    </p>
+                    <p class="text-sm">You can still make payments on existing loans.</p>
                 </div>
             </div>
         @endif
 
-        <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-            <x-utils.card title="Apply for a loan" extraClasses="shadow-lg">
+        <div class="grid gap-6 lg:grid-cols-2">
+            <x-utils.card title="Apply for a Loan" extraClasses="shadow-lg">
                 @if ($loanApplicationsEnabled)
                     <form method="POST" action="{{ route('loans.apply') }}" class="space-y-4">
                         @csrf
-
                         <div class="form-control">
                             <label class="label" for="amount">
-                                <span class="label-text font-semibold">Loan amount</span>
-                                <span class="label-text-alt text-base-content/60">USD</span>
+                                <span class="label-text font-semibold">Loan Amount</span>
                             </label>
-                            <input type="number"
-                                   name="amount"
-                                   id="amount"
-                                   min="100000"
-                                   step="0.01"
-                                   required
-                                   placeholder="Enter loan amount"
-                                   class="input input-bordered w-full">
+                            <input type="number" name="amount" id="amount" min="100000" step="0.01" required
+                                   class="input input-bordered w-full" placeholder="Enter amount">
                         </div>
 
                         <div class="form-control">
                             <label class="label" for="account_id">
-                                <span class="label-text font-semibold">Deposit into account</span>
-                                <span class="label-text-alt text-base-content/60">Balance shown</span>
+                                <span class="label-text font-semibold">Deposit Account</span>
                             </label>
-                            <select name="account_id" id="account_id" class="select select-bordered w-full">
+                            <select name="account_id" id="account_id" class="select select-bordered w-full" required>
                                 @foreach ($accounts as $account)
-                                    <option value="{{ $account->id }}" data-balance="{{ $account->money }}">
-                                        {{ $account->name }} (Balance: ${{ number_format($account->money, 2) }})
+                                    <option value="{{ $account->id }}">
+                                        {{ $account->name }} (Balance: ${{ number_format((float) $account->money, 2) }})
                                     </option>
                                 @endforeach
                             </select>
@@ -85,210 +100,476 @@
 
                         <div class="form-control">
                             <label class="label" for="term_weeks">
-                                <span class="label-text font-semibold">Loan term (weeks)</span>
-                                <span class="label-text-alt text-base-content/60">1-52</span>
+                                <span class="label-text font-semibold">Term (Weeks)</span>
                             </label>
-                            <input type="number"
-                                   id="term_weeks"
-                                   name="term_weeks"
-                                   min="1"
-                                   max="52"
-                                   step="1"
-                                   required
-                                   placeholder="Enter term length (1-52 weeks)"
-                                   class="input input-bordered w-full">
+                            <input type="number" id="term_weeks" name="term_weeks" min="1" max="52" step="1" required
+                                   class="input input-bordered w-full" placeholder="1-52">
                         </div>
 
-                        <button type="submit" class="btn btn-primary w-full">
-                            Apply for loan
-                        </button>
+                        <button type="submit" class="btn btn-primary w-full">Submit Application</button>
                     </form>
                 @else
-                    <p class="text-sm text-base-content/70">
-                        Applications are closed at the moment. Check back later or contact an admin if you need an
-                        urgent disbursement.
-                    </p>
+                    <p class="text-sm text-base-content/70">Applications are closed right now.</p>
                 @endif
             </x-utils.card>
 
-            @if (!$activeLoans->isEmpty())
-                <x-utils.card title="Make an early payment" extraClasses="shadow-lg">
-                    <form method="POST" action="{{ route('loans.repay') }}" class="space-y-3">
+            <x-utils.card title="Make a Payment" extraClasses="shadow-lg">
+                @if ($activeLoans->isEmpty())
+                    <p class="text-sm text-base-content/70">No active loans available for repayment.</p>
+                @else
+                    <form method="POST" action="{{ route('loans.repay') }}" class="space-y-4" id="repayForm">
                         @csrf
                         <div class="form-control">
-                            <label class="label">Select loan</label>
-                            <select name="loan_id" id="repayment_loan_id" class="select select-bordered w-full">
+                            <label class="label" for="repayment_loan_id">
+                                <span class="label-text font-semibold">Loan</span>
+                            </label>
+                            <select name="loan_id" id="repayment_loan_id" class="select select-bordered w-full" required>
                                 @foreach ($activeLoans as $loan)
-                                    <option value="{{ $loan->id }}" data-balance="{{ $loan->remaining_balance }}">Loan
-                                        #{{ $loan->id }} - Balance:
-                                        ${{ number_format($loan->remaining_balance, 2) }}</option>
+                                    <option value="{{ $loan->id }}">Loan #{{ $loan->id }} ({{ strtoupper($loan->status) }})</option>
                                 @endforeach
                             </select>
                         </div>
 
                         <div class="form-control">
-                            <label class="label" for="repayment_account_id">Payment account</label>
-                            <select name="account_id" id="repayment_account_id" class="select select-bordered w-full">
+                            <label class="label" for="repayment_account_id">
+                                <span class="label-text font-semibold">Payment Account</span>
+                            </label>
+                            <select name="account_id" id="repayment_account_id" class="select select-bordered w-full" required>
                                 @foreach ($accounts as $account)
-                                    <option value="{{ $account->id }}" data-balance="{{ $account->money }}">{{ $account->name }}
-                                        (Balance:
-                                        ${{ number_format($account->money, 2) }})
+                                    <option value="{{ $account->id }}">
+                                        {{ $account->name }} (Balance: ${{ number_format((float) $account->money, 2) }})
                                     </option>
                                 @endforeach
                             </select>
                         </div>
 
                         <div class="form-control">
-                            <label class="label" for="repayment_amount">Payment amount</label>
-                            <input type="number"
-                                   name="amount"
-                                   id="repayment_amount"
-                                   min="0.01"
-                                   step="0.01"
-                                   required
-                                   placeholder="Enter repayment amount"
-                                   class="input input-bordered w-full">
+                            <label class="label" for="repayment_amount">
+                                <span class="label-text font-semibold">Payment Amount</span>
+                            </label>
+                            <input type="number" name="amount" id="repayment_amount" min="0.01" step="0.01" required
+                                   class="input input-bordered w-full" placeholder="Enter amount">
+                            <div class="mt-2 flex items-center justify-between gap-2">
+                                <button type="button" id="use_min_due" class="btn btn-outline btn-sm">
+                                    Use Minimum Due
+                                </button>
+                                <span id="use_min_due_hint" class="text-xs text-base-content/60">Current due: $0.00</span>
+                            </div>
                         </div>
 
-                        <button type="submit" class="btn btn-success w-full">Submit payment</button>
+                        <div class="form-control">
+                            <label class="label" for="repayment_slider">
+                                <span class="label-text font-semibold">What Happens If I Pay This Amount?</span>
+                            </label>
+                            <input type="range" id="repayment_slider" min="0" max="100" value="0" class="range range-primary">
+                            <div class="mt-1 flex justify-between text-xs text-base-content/60">
+                                <span>$0</span>
+                                <span id="slider_max_label">$0</span>
+                            </div>
+                        </div>
+
+                        <div class="rounded-xl border border-base-300 bg-base-200 p-4 text-sm">
+                            <p class="font-semibold">Payment Preview</p>
+                            <div class="mt-2 grid grid-cols-1 gap-1 sm:grid-cols-2">
+                                <p>Current Amount Due: <span id="preview_due" class="font-semibold">$0.00</span></p>
+                                <p>Total Owed Right Now: <span id="preview_total" class="font-semibold">$0.00</span></p>
+                                <p>Estimated Interest: <span id="preview_interest" class="font-semibold">$0.00</span></p>
+                                <p>Estimated Principal: <span id="preview_principal" class="font-semibold">$0.00</span></p>
+                                <p>Estimated Remaining Principal: <span id="preview_remaining" class="font-semibold">$0.00</span></p>
+                                <p>Estimated Weeks Saved: <span id="preview_weeks_saved" class="font-semibold">0</span></p>
+                            </div>
+                        </div>
+
+                        <button type="submit" class="btn btn-success w-full">Submit Payment</button>
                     </form>
-                </x-utils.card>
-            @else
-                <x-utils.card title="No active loans" extraClasses="h-full">
-                    <p class="text-sm text-base-content/70">Submit a new application to see repayment options here.</p>
-                </x-utils.card>
-            @endif
+                @endif
+            </x-utils.card>
         </div>
 
-        @if (!$activeLoans->isEmpty())
-            <x-utils.card title="Your Active Loans" extraClasses="shadow-lg">
-                <div class="overflow-x-auto rounded-xl border border-base-300">
-                    <table class="table table-zebra w-full">
-                        <thead class="bg-base-200">
-                        <tr>
-                            <th>ID</th>
-                            <th>Loan amount</th>
-                            <th>Remaining balance</th>
-                            <th>Interest rate</th>
-                            <th>Term (weeks)</th>
-                            <th>Account</th>
-                            <th>Next payment due</th>
-                            <th>Next minimum payment</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @foreach ($activeLoans as $loan)
-                            <tr>
-                                <td>{{ $loan->id }}</td>
-                                <td>${{ number_format($loan->amount, 2) }}</td>
-                                <td>${{ number_format($loan->remaining_balance, 2) }}</td>
-                                <td>{{ number_format($loan->interest_rate, 2) }}%</td>
-                                <td>{{ $loan->term_weeks }}</td>
-                                <td>
-                                    <a href="{{ route('accounts.view', $loan->account->id) }}"
-                                       class="link link-primary">{{ $loan->account->name }}</a>
-                                </td>
-                                <td>
-                                    @if ($loanPaymentsEnabled)
-                                        {{ $loan->next_due_date ? $loan->next_due_date->format('M d, Y') : 'N/A' }}
-                                    @else
-                                        <span class="badge badge-warning">Paused</span>
-                                    @endif
-                                </td>
-                                <td>
-                                    @if ($loanPaymentsEnabled)
-                                        ${{ number_format($loan->next_payment_due, 2) }}
-                                    @else
-                                        <span class="text-base-content/60">--</span>
-                                    @endif
-                                </td>
-                            </tr>
+        <x-utils.card title="Loan Formula and Rules" extraClasses="shadow-lg">
+            <div class="space-y-4 text-sm text-base-content/80">
+                <p>
+                    The scheduled weekly payment uses standard amortization with a weekly rate:
+                </p>
+                <div class="mockup-code">
+                    <pre data-prefix="$"><code>Payment = (r * P) / (1 - (1 + r)^(-n))</code></pre>
+                </div>
+                <ul class="list-disc space-y-1 pl-5">
+                    <li><strong>P</strong> = original principal</li>
+                    <li><strong>r</strong> = weekly interest rate (decimal form, e.g. 2% = 0.02)</li>
+                    <li><strong>n</strong> = total number of weekly payments</li>
+                    <li>Each payment is applied interest first, then principal.</li>
+                    <li>Interest accrues on a weekly cycle, not daily.</li>
+                    <li>If a payment is missed, due amounts roll forward and continue to accumulate.</li>
+                    <li>Early repayments are allowed and reduce principal immediately.</li>
+                </ul>
+            </div>
+        </x-utils.card>
 
-                            @if (!$loan->payments->isEmpty())
-                                <tr>
-                                    <td colspan="8" class="bg-base-200/60">
-                                        <div class="mt-2 space-y-2">
-                                            <div class="font-semibold text-sm">Payment history</div>
-                                            <div class="overflow-x-auto rounded-lg border border-base-300 bg-base-100">
-                                                <table class="table table-sm">
-                                                    <thead class="bg-base-200">
-                                                    <tr>
-                                                        <th>Amount</th>
-                                                        <th>Principal paid</th>
-                                                        <th>Interest paid</th>
-                                                        <th>Payment date</th>
-                                                        <th>Account</th>
-                                                    </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                    @foreach ($loan->payments as $payment)
-                                                        <tr>
-                                                            <td>${{ number_format($payment->amount, 2) }}</td>
-                                                            <td>${{ number_format($payment->principal_paid, 2) }}</td>
-                                                            <td>${{ number_format($payment->interest_paid, 2) }}</td>
-                                                            <td>{{ Carbon::create($payment->payment_date)->format('M d, Y') }}</td>
-                                                            <td>
-                                                                <a href="{{ route('accounts.view', $payment->account->id) }}"
-                                                                   class="link link-primary">{{ $payment->account->name }}</a>
-                                                            </td>
-                                                        </tr>
-                                                    @endforeach
-                                                    </tbody>
-                                                </table>
-                                            </div>
-                                        </div>
-                                    </td>
-                                </tr>
+        <x-utils.card title="How Loan Payments Work" extraClasses="shadow-lg">
+            <div class="grid gap-4 md:grid-cols-2">
+                <div class="rounded-xl border border-base-300 bg-base-200 p-4 text-sm">
+                    <h3 class="text-base font-semibold">Payment Cycle</h3>
+                    <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/80">
+                        <li>First payment is due 7 days after approval.</li>
+                        <li>Then payments are due every 7 days.</li>
+                        <li>Current required payment can be $0 before the first due date.</li>
+                        <li>Weekly interest is posted when the cycle reaches its due date.</li>
+                    </ul>
+                </div>
+                <div class="rounded-xl border border-base-300 bg-base-200 p-4 text-sm">
+                    <h3 class="text-base font-semibold">If Payments Are Frozen</h3>
+                    <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/80">
+                        <li>Automatic deductions are paused.</li>
+                        <li>Weekly accrual and required dues are frozen while paused.</li>
+                        <li>On resume, due dates are shifted forward by the paused duration.</li>
+                        <li>You may still make manual early repayments while frozen.</li>
+                    </ul>
+                </div>
+                <div class="rounded-xl border border-base-300 bg-base-200 p-4 text-sm">
+                    <h3 class="text-base font-semibold">Missed Payments (No Penalties)</h3>
+                    <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/80">
+                        <li>Missed installments are moved into past due.</li>
+                        <li>Interest for each missed weekly cycle is added to accrued interest due.</li>
+                        <li>No extra penalty fee is added right now.</li>
+                        <li>Next payment first clears accrued interest, then principal.</li>
+                    </ul>
+                </div>
+                <div class="rounded-xl border border-base-300 bg-base-200 p-4 text-sm">
+                    <h3 class="text-base font-semibold">Early Repayment</h3>
+                    <ul class="mt-2 list-disc space-y-1 pl-5 text-base-content/80">
+                        <li>You can pay early at any time.</li>
+                        <li>Early payments immediately reduce principal (after any accrued interest due).</li>
+                        <li>Lower principal reduces future weekly interest.</li>
+                        <li>Payoff is allowed up to total currently owed.</li>
+                    </ul>
+                </div>
+            </div>
+        </x-utils.card>
+
+        <x-utils.card title="Glossary" extraClasses="shadow-lg">
+            <div class="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Principal</p><p>The remaining borrowed amount.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Interest</p><p>The borrowing cost based on weekly rate.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Scheduled Weekly Payment</p><p>The formula-based weekly target payment.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Current Required Payment</p><p>The minimum needed to stay current right now.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Past Due</p><p>Missed installments rolled forward.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Accrued Interest Due</p><p>Interest earned but not yet paid.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Amortization</p><p>Repayment where each payment splits into interest and principal.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Payoff</p><p>Total required to close the loan now.</p></div>
+                <div class="rounded-lg border border-base-300 bg-base-200 p-3"><p class="font-semibold">Weeks Saved</p><p>Estimated reduction in remaining term from extra payment.</p></div>
+            </div>
+        </x-utils.card>
+
+        @if (! $activeLoans->isEmpty())
+            <x-utils.card title="Active Loans and Amortization" extraClasses="shadow-lg">
+                <div class="space-y-8">
+                    @foreach ($activeLoans as $loan)
+                        @php
+                            $schedule = $loan->amortization_schedule;
+                            $chartLabels = collect($schedule)->map(function ($row) {
+                                if (! empty($row['due_date'])) {
+                                    return 'W'.$row['week'].' ('.\Carbon\Carbon::parse($row['due_date'])->format('M d').')';
+                                }
+
+                                return 'W'.$row['week'];
+                            });
+                            $chartInterest = collect($schedule)->pluck('interest');
+                            $chartPrincipal = collect($schedule)->pluck('principal');
+                            $contractInterest = (float) collect($schedule)->sum('interest');
+                            $interestPaidToDate = (float) $loan->payments->sum('interest_paid');
+                            $remainingContractInterest = max(0, $contractInterest - $interestPaidToDate);
+                            $projectedExtraInterest4Weeks = round((float) $loan->remaining_balance * ((float) $loan->interest_rate / 100) * 4, 2);
+                            $approvedAt = $loan->approved_at ? \Carbon\Carbon::parse($loan->approved_at) : null;
+                            $firstDue = $approvedAt ? $approvedAt->copy()->addDays(7) : null;
+                            $elapsedWeeks = $approvedAt ? max(0, (int) floor($approvedAt->diffInDays(now()) / 7)) : 0;
+                        @endphp
+
+                        <div class="rounded-xl border border-base-300 p-4">
+                            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <h3 class="text-lg font-bold">Loan #{{ $loan->id }}</h3>
+                                    <p class="text-sm text-base-content/70">
+                                        @if ($loan->status === 'missed')
+                                            <span class="badge badge-warning">Missed</span>
+                                        @else
+                                            <span class="badge badge-success">Approved</span>
+                                        @endif
+                                        Next due: {{ optional($loan->next_due_date)->format('M d, Y') ?? 'N/A' }}
+                                    </p>
+                                </div>
+                                <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                                    <div>
+                                        <p class="text-base-content/60">Remaining Principal</p>
+                                        <p class="font-semibold">${{ number_format((float) $loan->remaining_balance, 2) }}</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-base-content/60">Scheduled Weekly</p>
+                                        <p class="font-semibold">${{ number_format((float) $loan->scheduled_weekly_payment, 2) }}</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-base-content/60">Past Due</p>
+                                        <p class="font-semibold text-error">${{ number_format((float) $loan->past_due_amount, 2) }}</p>
+                                    </div>
+                                    <div>
+                                        <p class="text-base-content/60">Accrued Interest Due</p>
+                                        <p class="font-semibold text-warning">${{ number_format((float) $loan->effective_interest_due_now, 2) }}</p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="mt-4 grid gap-3 md:grid-cols-4 text-sm">
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">Approved On</p>
+                                    <p class="font-semibold">{{ $approvedAt ? $approvedAt->format('M d, Y') : 'N/A' }}</p>
+                                </div>
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">First Due</p>
+                                    <p class="font-semibold">{{ $firstDue ? $firstDue->format('M d, Y') : 'N/A' }}</p>
+                                </div>
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">Term Progress</p>
+                                    <p class="font-semibold">{{ min($elapsedWeeks, (int) $loan->term_weeks) }} / {{ (int) $loan->term_weeks }} weeks</p>
+                                </div>
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">Weekly Interest Rate</p>
+                                    <p class="font-semibold">{{ number_format((float) $loan->interest_rate, 2) }}%</p>
+                                </div>
+                            </div>
+
+                            @if ((float) $loan->past_due_amount > 0 || (float) $loan->next_payment_due > 0)
+                                <div class="mt-4 rounded-xl border border-warning/40 bg-warning/10 p-3 text-sm">
+                                    @if ((float) $loan->past_due_amount > 0)
+                                        <p class="font-semibold">You are behind on this loan.</p>
+                                        <p>To get current now, pay at least <strong>${{ number_format((float) max($loan->past_due_amount, $loan->next_payment_due), 2) }}</strong>.</p>
+                                    @else
+                                        <p class="font-semibold">Next required payment is due on {{ optional($loan->next_due_date)->format('M d, Y') }}.</p>
+                                    @endif
+                                </div>
                             @endif
-                        @endforeach
-                        </tbody>
-                    </table>
+
+                            <div class="mt-4 grid gap-4 md:grid-cols-2">
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3 text-sm">
+                                    <p class="font-semibold">Current Required Payment</p>
+                                    <p class="text-xl font-bold">${{ number_format((float) $loan->next_payment_due, 2) }}</p>
+                                    <p class="mt-2">Interest portion: <strong>${{ number_format((float) ($loan->next_payment_preview['interest'] ?? 0), 2) }}</strong></p>
+                                    <p>Principal portion: <strong>${{ number_format((float) ($loan->next_payment_preview['principal'] ?? 0), 2) }}</strong></p>
+                                    <p class="mt-2 text-xs text-base-content/80">
+                                        This cycle ({{ $loan->cycle_start ? \Carbon\Carbon::parse($loan->cycle_start)->format('M d') : 'N/A' }}
+                                        to {{ $loan->cycle_end ? \Carbon\Carbon::parse($loan->cycle_end)->format('M d') : 'N/A' }}):
+                                        paid <strong>${{ number_format((float) $loan->paid_this_cycle, 2) }}</strong>,
+                                        remaining to hit scheduled target
+                                        <strong>${{ number_format((float) $loan->remaining_to_scheduled, 2) }}</strong>.
+                                    </p>
+                                    @if ((float) $loan->next_payment_due <= 0.0)
+                                        <p class="mt-2 text-xs text-base-content/70">
+                                            No payment is required right now. Your scheduled weekly payment still starts at the next due date.
+                                        </p>
+                                    @endif
+                                </div>
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3 text-sm">
+                                    <p class="font-semibold">If You Pay Required Amount</p>
+                                    <p>Remaining principal after payment:
+                                        <strong>${{ number_format((float) ($loan->next_payment_preview['remaining_after'] ?? $loan->remaining_balance), 2) }}</strong>
+                                    </p>
+                                    <p>Accrued interest after payment:
+                                        <strong>${{ number_format((float) ($loan->next_payment_preview['accrued_interest_after'] ?? 0), 2) }}</strong>
+                                    </p>
+                                    <p>Total payoff now:
+                                        <strong>${{ number_format((float) $loan->total_owed_now, 2) }}</strong>
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="mt-4 grid gap-3 text-sm md:grid-cols-3">
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">Total Contract Interest (On Schedule)</p>
+                                    <p class="font-semibold">${{ number_format($contractInterest, 2) }}</p>
+                                </div>
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">Estimated Remaining Contract Interest</p>
+                                    <p class="font-semibold">${{ number_format($remainingContractInterest, 2) }}</p>
+                                </div>
+                                <div class="rounded-lg border border-base-300 bg-base-200 p-3">
+                                    <p class="text-base-content/60">If Unpaid 4 More Weeks (Estimate)</p>
+                                    <p class="font-semibold">+${{ number_format($projectedExtraInterest4Weeks, 2) }} interest</p>
+                                </div>
+                            </div>
+
+                            @if (! empty($schedule))
+                                <div class="mt-6 space-y-4">
+                                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                        <h4 class="text-md font-semibold">Contract Amortization Schedule</h4>
+                                        <button class="btn btn-outline btn-sm" type="button"
+                                                onclick="downloadScheduleCsv('loan-schedule-{{ $loan->id }}', 'loan-{{ $loan->id }}-amortization.csv')">
+                                            Download CSV
+                                        </button>
+                                    </div>
+                                    <div class="h-96 rounded-lg border border-base-300 bg-base-100 p-3">
+                                        <canvas id="amortization-chart-{{ $loan->id }}"></canvas>
+                                    </div>
+                                    <div class="max-h-80 overflow-y-auto rounded-lg border border-base-300">
+                                        <table class="table table-sm table-zebra w-full" id="loan-schedule-{{ $loan->id }}">
+                                            <thead>
+                                            <tr>
+                                                <th>Week</th>
+                                                <th>Scheduled Date</th>
+                                                <th>Opening Balance</th>
+                                                <th>Payment</th>
+                                                <th>Interest</th>
+                                                <th>Principal</th>
+                                                <th>Closing Balance</th>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            @foreach ($schedule as $row)
+                                                <tr>
+                                                    <td>{{ $row['week'] }}</td>
+                                                    <td>{{ ! empty($row['due_date']) ? \Carbon\Carbon::parse($row['due_date'])->format('M d, Y') : 'N/A' }}</td>
+                                                    <td>${{ number_format((float) $row['opening_balance'], 2) }}</td>
+                                                    <td>${{ number_format((float) $row['payment'], 2) }}</td>
+                                                    <td class="text-warning">${{ number_format((float) $row['interest'], 2) }}</td>
+                                                    <td class="text-success">${{ number_format((float) $row['principal'], 2) }}</td>
+                                                    <td>${{ number_format((float) $row['closing_balance'], 2) }}</td>
+                                                </tr>
+                                            @endforeach
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <script>
+                                    (() => {
+                                        const ctx = document.getElementById('amortization-chart-{{ $loan->id }}');
+                                        if (!ctx || typeof Chart === 'undefined') {
+                                            return;
+                                        }
+
+                                        new Chart(ctx, {
+                                            type: 'bar',
+                                            data: {
+                                                labels: @json($chartLabels),
+                                                datasets: [
+                                                    {
+                                                        label: 'Interest',
+                                                        data: @json($chartInterest),
+                                                        backgroundColor: 'rgba(245, 158, 11, 0.65)',
+                                                        borderColor: 'rgba(245, 158, 11, 1)',
+                                                        borderWidth: 1,
+                                                    },
+                                                    {
+                                                        label: 'Principal',
+                                                        data: @json($chartPrincipal),
+                                                        backgroundColor: 'rgba(16, 185, 129, 0.65)',
+                                                        borderColor: 'rgba(16, 185, 129, 1)',
+                                                        borderWidth: 1,
+                                                    }
+                                                ]
+                                            },
+                                            options: {
+                                                responsive: true,
+                                                maintainAspectRatio: false,
+                                                plugins: {
+                                                    legend: {
+                                                        position: 'top',
+                                                    }
+                                                },
+                                                scales: {
+                                                    x: {
+                                                        stacked: true,
+                                                        title: {
+                                                            display: true,
+                                                            text: 'Week',
+                                                        }
+                                                    },
+                                                    y: {
+                                                        stacked: true,
+                                                        beginAtZero: true,
+                                                        title: {
+                                                            display: true,
+                                                            text: 'Amount ($)',
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        });
+                                    })();
+                                </script>
+                            @endif
+
+                            @if (! $loan->payments->isEmpty())
+                                <div class="mt-6">
+                                    <h4 class="text-md font-semibold">Payment History</h4>
+                                    <div class="max-h-72 overflow-y-auto rounded-lg border border-base-300">
+                                        <table class="table table-sm table-zebra w-full">
+                                            <thead>
+                                            <tr>
+                                                <th>Date</th>
+                                                <th>Amount</th>
+                                                <th>Interest</th>
+                                                <th>Principal</th>
+                                                <th>Account</th>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            @foreach ($loan->payments as $payment)
+                                                <tr>
+                                                    <td>{{ \Carbon\Carbon::create($payment->payment_date)->format('M d, Y') }}</td>
+                                                    <td>${{ number_format((float) $payment->amount, 2) }}</td>
+                                                    <td>${{ number_format((float) $payment->interest_paid, 2) }}</td>
+                                                    <td>${{ number_format((float) $payment->principal_paid, 2) }}</td>
+                                                    <td>{{ $payment->account->name ?? 'N/A' }}</td>
+                                                </tr>
+                                            @endforeach
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            @endif
+                        </div>
+                    @endforeach
                 </div>
             </x-utils.card>
         @endif
 
-        <script>
-            function switchTab(tab, element) {
-                document.querySelectorAll(".tab").forEach(t => t.classList.remove("tab-active"));
-                document.querySelectorAll(".tab-content").forEach(c => c.classList.add("hidden"));
+        <x-utils.card title="Loan FAQ" extraClasses="shadow-lg">
+            <div class="space-y-2">
+                @php
+                    $faqs = [
+                        ['q' => 'Why is my current required payment $0?', 'a' => 'Before the first due date, no weekly cycle has matured yet. Required due can be $0 until the first due date arrives.'],
+                        ['q' => 'Why is the interest portion $0 right now?', 'a' => 'Interest is accrued weekly at due cycles, not continuously every day.'],
+                        ['q' => 'Does interest increase daily?', 'a' => 'No. This system accrues at weekly cycle boundaries.'],
+                        ['q' => 'Can I pay early?', 'a' => 'Yes. Early payments reduce principal immediately after any accrued interest is paid.'],
+                        ['q' => 'Can I pay more than the required payment?', 'a' => 'Yes, up to total currently owed. During a cycle, payments count toward that cycle target first; any amount above target effectively accelerates principal reduction.'],
+                        ['q' => 'What happens if I pay part of the week but not all of it?', 'a' => 'What you paid during that week is credited toward that cycle. At cycle close, only the remaining shortfall rolls into past due.'],
+                        ['q' => 'What happens if I miss one week?', 'a' => 'The unpaid shortfall for that cycle moves into past due, and weekly cycle interest keeps accruing.'],
+                        ['q' => 'Are there late fees right now?', 'a' => 'No penalty fees are currently configured.'],
+                        ['q' => 'What does Past Due mean?', 'a' => 'Scheduled weekly installments that were not paid when due.'],
+                        ['q' => 'What does Accrued Interest Due mean?', 'a' => 'Interest already earned by the lender but not yet paid by the borrower.'],
+                        ['q' => 'What if payments are frozen by leadership?', 'a' => 'Auto-pay and weekly accrual freeze; due dates shift forward when resumed.'],
+                        ['q' => 'Can I still pay manually while frozen?', 'a' => 'Yes, manual payments are still allowed.'],
+                        ['q' => 'What is amortization?', 'a' => 'A fixed scheduled payment where interest share declines and principal share rises over time.'],
+                        ['q' => 'Why does my payment split change each week?', 'a' => 'Because interest is calculated on remaining principal; as principal drops, interest drops.'],
+                        ['q' => 'What does the chart show?', 'a' => 'Each bar stacks interest and principal by week for the contract schedule.'],
+                        ['q' => 'What does the schedule table date mean?', 'a' => 'The planned due date for that weekly installment under the original schedule.'],
+                        ['q' => 'Can my term end earlier than shown?', 'a' => 'Yes, if you pay extra principal, payoff can happen sooner.'],
+                        ['q' => 'What is total payoff now?', 'a' => 'Remaining principal plus accrued interest due as of now.'],
+                        ['q' => 'Why can’t I overpay beyond payoff?', 'a' => 'System caps payment at what is owed to avoid accidental overpayment.'],
+                        ['q' => 'Does this follow US mortgage rules?', 'a' => 'It follows general amortization math but is simplified for weekly game cycles.'],
+                        ['q' => 'Can admins change loan settings after approval?', 'a' => 'Admins can update loan settings in admin tools, which can affect schedule projections.'],
+                    ];
+                @endphp
 
-                element.classList.add("tab-active");
-                document.getElementById(`content-${tab}`).classList.remove("hidden");
-            }
+                @foreach ($faqs as $item)
+                    <details class="rounded-lg border border-base-300 bg-base-200 p-3">
+                        <summary class="cursor-pointer font-semibold">{{ $item['q'] }}</summary>
+                        <p class="mt-2 text-sm text-base-content/80">{{ $item['a'] }}</p>
+                    </details>
+                @endforeach
+            </div>
+        </x-utils.card>
 
-            document.addEventListener("DOMContentLoaded", function () {
-                document.querySelector(".tab-active")?.click();
-            });
-
-            document.addEventListener('DOMContentLoaded', function () {
-                const amountInput = document.getElementById('amount');
-                if (amountInput) {
-                    amountInput.addEventListener('change', function () {
-                        let value = parseFloat(this.value);
-                        if (!isNaN(value) && value < 0.01) {
-                            this.value = 0.01;
-                        }
-                    });
-                }
-
-                const termInput = document.getElementById('term_weeks');
-                if (termInput) {
-                    termInput.addEventListener('change', function () {
-                        if (this.value !== '') {
-                            let value = parseInt(this.value);
-                            if (!isNaN(value)) {
-                                value = Math.round(value);
-                                if (value < 1) value = 1;
-                                if (value > 52) value = 52;
-                                this.value = value;
-                            }
-                        }
-                    });
-                }
-            });
-        </script>
-
-        <x-utils.card title="Your loan history" extraClasses="shadow-lg">
+        <x-utils.card title="Loan History" extraClasses="shadow-lg">
             @if ($loanHistory->isEmpty())
                 <p class="text-base-content/70">No previous loan applications found.</p>
             @else
@@ -306,7 +587,7 @@
                         <tbody>
                         @foreach ($loanHistory as $loan)
                             <tr>
-                                <td>${{ number_format($loan->amount, 2) }}</td>
+                                <td>${{ number_format((float) $loan->amount, 2) }}</td>
                                 <td>{{ $loan->term_weeks }}</td>
                                 <td>
                                     @if($loan->account)
@@ -321,6 +602,8 @@
                                         <span class="badge badge-warning">Pending</span>
                                     @elseif ($loan->status === 'approved')
                                         <span class="badge badge-success">Approved</span>
+                                    @elseif ($loan->status === 'missed')
+                                        <span class="badge badge-warning">Missed</span>
                                     @elseif ($loan->status === 'paid')
                                         <span class="badge badge-primary">Paid</span>
                                     @else
@@ -336,85 +619,199 @@
             @endif
         </x-utils.card>
 
-        <x-utils.card title="How loans work">
-            <div class="steps w-full mb-6">
-                <div class="step step-primary">Apply</div>
-                <div class="step step-primary">Approval</div>
-                <div class="step step-primary">Repayment</div>
-                <div class="step step-primary">Completion</div>
-            </div>
-
-            <div class="grid gap-4 md:grid-cols-2">
-                <div class="bg-base-200 p-6 rounded-lg shadow-md">
-                    <h3 class="text-lg font-bold mb-2">📌 Step 1: Applying for a Loan</h3>
-                    <p class="text-sm">To apply for a loan, follow these steps:</p>
-                    <ul class="list-disc ml-5 text-sm space-y-1">
-                        <li>Choose the amount you want to borrow.</li>
-                        <li>Select the account where the funds will be deposited.</li>
-                        <li>Pick a repayment term (between 1 and 52 weeks).</li>
-                        <li>Submit your request and wait for admin approval.</li>
-                    </ul>
-                </div>
-
-                <div class="bg-base-200 p-6 rounded-lg shadow-md">
-                    <h3 class="text-lg font-bold mb-2">📌 Step 2: Loan Approval</h3>
-                    <p class="text-sm">Once submitted, your loan request will be reviewed by an admin:</p>
-                    <ul class="list-disc ml-5 text-sm space-y-1">
-                        <li>Admins evaluate applications based on eligibility.</li>
-                        <li>Approval will specify the final interest rate and terms.</li>
-                        <li>If approved, the loan funds will be deposited into your selected account.</li>
-                    </ul>
-                </div>
-
-                <div class="bg-base-200 p-6 rounded-lg shadow-md">
-                    <h3 class="text-lg font-bold mb-2">📌 Step 3: Repayment</h3>
-                    <p class="text-sm">Your loan repayments will occur as follows:</p>
-                    <ul class="list-disc ml-5 text-sm space-y-1">
-                        <li>Payments are automatically deducted from your bank account weekly.</li>
-                        <li>You can make early payments to reduce interest costs.</li>
-                        <li>Missed payments will result in penalties and potential loan restrictions.</li>
-                    </ul>
-                </div>
-
-                <div class="bg-base-200 p-6 rounded-lg shadow-md">
-                    <h3 class="text-lg font-bold mb-2">📌 Step 4: Completion</h3>
-                    <p class="text-sm">Once your loan is fully repaid:</p>
-                    <ul class="list-disc ml-5 text-sm space-y-1">
-                        <li>Your status will be updated to <span class="badge badge-primary">Paid</span></li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="bg-base-200 p-6 rounded-lg shadow-md mt-4">
-                <h3 class="text-lg font-bold mb-2">📊 How Interest is Calculated</h3>
-                <p class="text-sm">Loan interest is applied weekly based on the outstanding balance. The scheduled payment uses:</p>
-                <div class="mockup-code mt-3">
-                    <pre data-prefix="$"><code>Weekly Payment = (Interest Rate × Principal) / (1 - (1 + Interest Rate)⁻ⁿ)</code></pre>
-                </div>
-                <p class="mt-3 text-sm">
-                    Where:
-                </p>
-                <ul class="list-disc ml-5 text-sm space-y-1">
-                    <li><strong>Principal</strong> = The original amount borrowed.</li>
-                    <li><strong>Interest Rate</strong> = The admin-approved weekly rate.</li>
-                    <li><strong>n</strong> = Loan term in weeks.</li>
-                </ul>
-                <p class="mt-3 text-sm">
-                    Interest is charged weekly on the remaining balance, so early payments reduce how much interest is paid over time.
-                </p>
-            </div>
-
-            <div class="bg-base-200 p-6 rounded-lg shadow-md mt-4">
-                <h3 class="text-lg font-bold mb-2">📆 How Due Dates Work</h3>
-                <p class="text-sm">Loan payments are scheduled weekly and follow this structure:</p>
-                <ul class="list-disc ml-5 text-sm space-y-1">
-                    <li><strong>First payment is due 7 days after approval.</strong></li>
-                    <li>Subsequent minimum payments are automatically deducted from the account you selected every 7 days.
-                    </li>
-                    <li>If an early payment is made, the next minimum payment is reduced (future weeks stay on schedule).</li>
-                    <li>Missed payments may result in late fees and increased interest.</li>
-                </ul>
-            </div>
-        </x-utils.card>
+        <div class="rounded-xl border border-base-300 bg-base-100 p-4 text-xs text-base-content/70">
+            <p><strong>Calculation assumptions:</strong> weekly interest cycles, amortized scheduled payment, no penalty fees, interest paid before principal.</p>
+            <p class="mt-1"><strong>Last updated:</strong> {{ now()->format('M d, Y H:i T') }}</p>
+        </div>
     </div>
+
+    @if (! $activeLoans->isEmpty())
+        @php
+            $loanDataForPreview = $activeLoans->mapWithKeys(function ($loan) {
+                $weeklyRate = (float) $loan->interest_rate / 100;
+
+                return [
+                    $loan->id => [
+                        'remaining_balance' => (float) $loan->remaining_balance,
+                        'interest_due_now' => (float) $loan->effective_interest_due_now,
+                        'current_due' => (float) $loan->next_payment_due,
+                        'total_owed_now' => (float) $loan->total_owed_now,
+                        'scheduled_weekly' => (float) $loan->scheduled_weekly_payment,
+                        'weekly_rate' => $weeklyRate,
+                    ],
+                ];
+            });
+        @endphp
+        <script>
+            function downloadScheduleCsv(tableId, filename) {
+                const table = document.getElementById(tableId);
+                if (!table) {
+                    return;
+                }
+
+                const rows = Array.from(table.querySelectorAll('tr'));
+                const csv = rows.map((row) => {
+                    const cols = Array.from(row.querySelectorAll('th,td')).map((col) => {
+                        const text = (col.innerText || '').replace(/\"/g, '\"\"').trim();
+                        return `\"${text}\"`;
+                    });
+                    return cols.join(',');
+                }).join('\n');
+
+                const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = filename;
+                link.style.display = 'none';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+            }
+
+            document.addEventListener('DOMContentLoaded', () => {
+                const loanData = @json($loanDataForPreview);
+
+                const loanSelect = document.getElementById('repayment_loan_id');
+                const amountInput = document.getElementById('repayment_amount');
+                const slider = document.getElementById('repayment_slider');
+                const sliderMaxLabel = document.getElementById('slider_max_label');
+                const useMinDueButton = document.getElementById('use_min_due');
+                const useMinDueHint = document.getElementById('use_min_due_hint');
+                const previewInterest = document.getElementById('preview_interest');
+                const previewPrincipal = document.getElementById('preview_principal');
+                const previewRemaining = document.getElementById('preview_remaining');
+                const previewDue = document.getElementById('preview_due');
+                const previewTotal = document.getElementById('preview_total');
+                const previewWeeksSaved = document.getElementById('preview_weeks_saved');
+
+                function formatMoney(value) {
+                    return '$' + Number(value || 0).toLocaleString(undefined, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                    });
+                }
+
+                function estimateWeeksToPayoff(balance, weeklyRate, scheduledPayment) {
+                    if (balance <= 0 || scheduledPayment <= 0) {
+                        return 0;
+                    }
+
+                    if (weeklyRate <= 0) {
+                        return Math.ceil(balance / scheduledPayment);
+                    }
+
+                    const ratio = 1 - ((weeklyRate * balance) / scheduledPayment);
+                    if (ratio <= 0) {
+                        return Number.POSITIVE_INFINITY;
+                    }
+
+                    const n = -Math.log(ratio) / Math.log(1 + weeklyRate);
+                    return Math.ceil(n);
+                }
+
+                function updatePreview() {
+                    if (!loanSelect || !amountInput || !slider || !sliderMaxLabel) {
+                        return;
+                    }
+
+                    const selectedLoanId = loanSelect.value;
+                    const selectedLoan = loanData[selectedLoanId];
+
+                    if (!selectedLoan) {
+                        previewInterest.textContent = formatMoney(0);
+                        previewPrincipal.textContent = formatMoney(0);
+                        previewRemaining.textContent = formatMoney(0);
+                        previewDue.textContent = formatMoney(0);
+                        previewTotal.textContent = formatMoney(0);
+                        previewWeeksSaved.textContent = '0';
+                        return;
+                    }
+
+                    const maxAmount = Math.max(0, Number(selectedLoan.total_owed_now || 0));
+                    slider.max = Math.ceil(maxAmount * 100);
+                    sliderMaxLabel.textContent = formatMoney(maxAmount);
+                    amountInput.max = maxAmount;
+                    if (useMinDueHint) {
+                        useMinDueHint.textContent = `Current due: ${formatMoney(selectedLoan.current_due)}`;
+                    }
+
+                    const rawAmount = parseFloat(amountInput.value || '0');
+                    const amount = Math.max(0, Math.min(rawAmount, selectedLoan.total_owed_now));
+                    const interest = Math.min(amount, selectedLoan.interest_due_now);
+                    const principal = Math.max(0, amount - interest);
+                    const remaining = Math.max(0, selectedLoan.remaining_balance - principal);
+
+                    const beforeWeeks = estimateWeeksToPayoff(
+                        selectedLoan.remaining_balance,
+                        selectedLoan.weekly_rate,
+                        selectedLoan.scheduled_weekly
+                    );
+                    const afterWeeks = estimateWeeksToPayoff(
+                        remaining,
+                        selectedLoan.weekly_rate,
+                        selectedLoan.scheduled_weekly
+                    );
+                    const weeksSaved = Number.isFinite(beforeWeeks) && Number.isFinite(afterWeeks)
+                        ? Math.max(0, beforeWeeks - afterWeeks)
+                        : 0;
+
+                    previewInterest.textContent = formatMoney(interest);
+                    previewPrincipal.textContent = formatMoney(principal);
+                    previewRemaining.textContent = formatMoney(remaining);
+                    previewDue.textContent = formatMoney(selectedLoan.current_due);
+                    previewTotal.textContent = formatMoney(selectedLoan.total_owed_now);
+                    previewWeeksSaved.textContent = String(weeksSaved);
+                }
+
+                function syncAmountFromSlider() {
+                    const selectedLoan = loanData[loanSelect.value];
+                    if (! selectedLoan) {
+                        return;
+                    }
+
+                    const sliderValue = Number(slider.value || 0) / 100;
+                    amountInput.value = sliderValue.toFixed(2);
+                    updatePreview();
+                }
+
+                function syncSliderFromAmount() {
+                    const selectedLoan = loanData[loanSelect.value];
+                    if (! selectedLoan) {
+                        return;
+                    }
+
+                    const rawAmount = parseFloat(amountInput.value || '0');
+                    const amount = Math.max(0, Math.min(rawAmount, selectedLoan.total_owed_now));
+                    slider.value = Math.round(amount * 100);
+                    updatePreview();
+                }
+
+                loanSelect.addEventListener('change', () => {
+                    amountInput.value = '';
+                    slider.value = 0;
+                    updatePreview();
+                });
+
+                if (useMinDueButton) {
+                    useMinDueButton.addEventListener('click', () => {
+                        const selectedLoan = loanData[loanSelect.value];
+                        if (! selectedLoan) {
+                            return;
+                        }
+
+                        const minimumDue = Math.max(0, Number(selectedLoan.current_due || 0));
+                        amountInput.value = minimumDue.toFixed(2);
+                        slider.value = Math.round(minimumDue * 100);
+                        updatePreview();
+                    });
+                }
+                slider.addEventListener('input', syncAmountFromSlider);
+                amountInput.addEventListener('input', syncSliderFromAmount);
+
+                updatePreview();
+            });
+        </script>
+    @endif
 @endsection


### PR DESCRIPTION
- Refactor loan servicing to true weekly amortization behavior with interest-first allocation
- Lock each cycle’s interest to cycle-opening principal to prevent end-of-cycle interest gaming
- Freeze loan accrual/due behavior consistently when loan payments are paused
- Enforce strict loan state transitions (pending-only approve/deny) and fix borrower notification routing
- Add amortization tracking fields and improve due/payoff calculations, cycle progress, and repayment previews
- Expand member loan UX with clearer formulas, glossary/FAQ/help text, schedule context, and minimum-due helpers
- Upgrade admin loan overview/detail pages with operational metrics, cycle breakdowns, and payoff visibility
- Prevent editing loan terms/balances after payment history exists; provide admin remediation guidance
- Improve robustness for string-backed date values in admin loan views to prevent runtime formatting errors