### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in PageRenderer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [XSS vulnerability in PageRenderer]
+**Vulnerability:** The PageRenderer used `{!! !!}` in Blade views to render CMS content without server-side sanitization.
+**Learning:** The application allowed raw HTML content from the database to be rendered directly. Regex-based sanitization is insufficient and brittle.
+**Prevention:** Use established sanitization libraries like HTMLPurifier or context-aware escaping. Always sanitize HTML on the server before rendering with unescaped Blade tags.

--- a/app/Services/PageRenderer.php
+++ b/app/Services/PageRenderer.php
@@ -30,7 +30,15 @@ class PageRenderer
 
     private function normalizeHtml(string $html): string
     {
-        return trim($html);
+        $config = \HTMLPurifier_Config::createDefault();
+        $config->set('HTML.Allowed', 'p,br,b,strong,i,em,u,ul,ol,li,a[href],img[src|alt],div,span,h1,h2,h3,h4,h5,h6,blockquote,pre,code,iframe[src|title]');
+        $config->set('URI.AllowedSchemes', ['http' => true, 'https' => true, 'mailto' => true, 'data' => true]);
+        $config->set('HTML.SafeIframe', true);
+        $config->set('URI.SafeIframeRegexp', '%^(https?:)?//(www\.youtube(?:-nocookie)?\.com/embed/|youtu\.be/)%');
+
+        $purifier = new \HTMLPurifier($config);
+
+        return trim($purifier->purify($html));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.5",
         "doctrine/dbal": "^4.4",
+        "ezyang/htmlpurifier": "^4.19",
         "laravel/fortify": "^1.24",
         "laravel/framework": "^13.0",
         "laravel/pulse": "^1.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8beff1e3a4a409a0779f1c3a8055e76",
+    "content-hash": "bddc92ec7af712f7f463c6d1cc88dabc",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -972,6 +972,67 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
+            },
+            "time": "2025-10-17T16:34:55+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "Nexus-AMS",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/Security/PageRendererXssTest.php
+++ b/tests/Feature/Security/PageRendererXssTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Services\PageRenderer;
+use Tests\TestCase;
+
+class PageRendererXssTest extends TestCase
+{
+    public function test_it_sanitizes_raw_html_content(): void
+    {
+        $renderer = new PageRenderer;
+        $payload = '<script>alert("xss")</script><div onclick="alert(1)">Safe</div><p>Normal</p>';
+
+        $result = $renderer->render($payload);
+
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringNotContainsString('onclick=', $result);
+        $this->assertStringContainsString('<div>Safe</div>', $result);
+        $this->assertStringContainsString('<p>Normal</p>', $result);
+    }
+
+    public function test_it_sanitizes_html_key_in_array_payload(): void
+    {
+        $renderer = new PageRenderer;
+        $payload = [
+            'html' => '<img src=x onerror=alert(1)><b>Bold</b><a href="javascript:alert(1)">Link</a>',
+        ];
+
+        $result = $renderer->render($payload);
+
+        $this->assertStringContainsString('<img src="x"', $result);
+        $this->assertStringNotContainsString('onerror=', $result);
+        $this->assertStringContainsString('<b>Bold</b>', $result);
+        $this->assertStringNotContainsString('javascript:alert(1)', $result);
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored Cross-Site Scripting (XSS) in CMS page rendering. The `PageRenderer` service was rendering raw HTML from the database using Blade's unescaped syntax `{!! !!}` without server-side sanitization.
🎯 Impact: An attacker with permissions to manage custom pages could inject malicious `<script>` tags or event handlers (e.g., `onclick`, `onerror`) that execute in the context of any user viewing the page, potentially leading to session theft or unauthorized actions.
🔧 Fix: Integrated the industry-standard `ezyang/htmlpurifier` library to sanitize all HTML content against a strict whitelist of allowed tags and attributes. Configured safe iframe support for YouTube video embeds and restricted URI schemes.
✅ Verification: Created a new feature test `tests/Feature/Security/PageRendererXssTest.php` which confirms that scripts, malicious event handlers, and `javascript:` URIs are correctly stripped or neutralized while safe HTML structure is preserved. Ran existing security tests and verified no regressions.

---
*PR created automatically by Jules for task [15944052072783793037](https://jules.google.com/task/15944052072783793037) started by @Yosodog*