### PR TITLE
🛡️ Sentinel: Fix XSS breakout and WarCounter syntax error

### DIFF
--- a/app/Http/Controllers/Admin/WarCounterController.php
+++ b/app/Http/Controllers/Admin/WarCounterController.php
@@ -585,7 +585,7 @@ class WarCounterController extends Controller
             return $record->fresh(['nation', 'account', 'manualTransaction']);
         });
 
-        event(new AllianceExpenseOccurred(new AllianceFinanceData(
+        event(new AllianceExpenseOccurred((new AllianceFinanceData(
             direction: AllianceFinanceEntry::DIRECTION_EXPENSE,
             category: 'counter_reimbursement',
             description: sprintf('Counter reimbursement for Nation #%d (Counter #%d)', $nationId, $counter->id),
@@ -608,7 +608,7 @@ class WarCounterController extends Controller
                 'infra_loss_cost' => $infraLossCost,
                 'correlation_id' => $correlationId,
             ]
-        )->toArray()));
+        ))->toArray()));
 
         $auditLogger->recordAfterCommit(
             category: 'war_counter',

--- a/resources/views/admin/customization/edit.blade.php
+++ b/resources/views/admin/customization/edit.blade.php
@@ -80,7 +80,7 @@
                     class="textarea js-ckeditor w-full"
                     data-editor-input="true"
                     rows="14"
-                >{!! $initialContent !!}</textarea>
+                >{{ $initialContent }}</textarea>
             </div>
 
             <div class="mt-6">

--- a/resources/views/admin/recruitment/index.blade.php
+++ b/resources/views/admin/recruitment/index.blade.php
@@ -40,7 +40,7 @@
                     hint="This message is sent immediately after a nation becomes eligible."
                     rows="10"
                     required
-                >{!! old('primary_message', $primaryMessage) !!}</x-textarea>
+                >{{ old('primary_message', $primaryMessage) }}</x-textarea>
 
                 <x-toggle
                     id="follow_up_enabled"
@@ -70,7 +70,7 @@
                     hint="The follow-up is only sent if the nation is still unaffiliated when the delay expires."
                     rows="10"
                     required
-                >{!! old('follow_up_message', $followUpMessage) !!}</x-textarea>
+                >{{ old('follow_up_message', $followUpMessage) }}</x-textarea>
 
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-primary">

--- a/tests/Feature/Security/XssBreakoutTest.php
+++ b/tests/Feature/Security/XssBreakoutTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+class XssBreakoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that initial content in the customization editor is escaped to prevent </textarea> breakout.
+     */
+    public function test_customization_editor_escapes_initial_content()
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        Gate::define('manage-custom-pages', fn() => true);
+
+        $page = Page::create([
+            'slug' => 'test-page',
+            'status' => 'draft',
+            'draft' => '</textarea><script>alert("xss")</script>',
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.customization.edit', $page))
+            ->assertStatus(200)
+            ->assertSee('&lt;/textarea&gt;&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;', false)
+            ->assertDontSee('</textarea><script>alert("xss")</script>', false);
+    }
+
+    /**
+     * Test that recruitment messages are escaped in the textarea to prevent </textarea> breakout.
+     */
+    public function test_recruitment_settings_escapes_messages()
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        Gate::define('view-recruitment', fn() => true);
+
+        // Mock setting values
+        config(['settings.recruitment_primary_message' => '</textarea><script>alert("primary")</script>']);
+        config(['settings.recruitment_follow_up_message' => '</textarea><script>alert("followup")</script>']);
+
+        $this->actingAs($admin)
+            ->get(route('admin.recruitment.index'))
+            ->assertStatus(200)
+            ->assertSee('&lt;/textarea&gt;&lt;script&gt;alert(&quot;primary&quot;)&lt;/script&gt;', false)
+            ->assertSee('&lt;/textarea&gt;&lt;script&gt;alert(&quot;followup&quot;)&lt;/script&gt;', false)
+            ->assertDontSee('</textarea><script>alert("primary")</script>', false)
+            ->assertDontSee('</textarea><script>alert("followup")</script>', false);
+    }
+}

--- a/tests/Feature/Security/XssBreakoutTest.php
+++ b/tests/Feature/Security/XssBreakoutTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Security;
 
 use App\Models\Page;
+use App\Models\RecruitmentMessage;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Gate;
@@ -11,6 +12,12 @@ use Tests\TestCase;
 class XssBreakoutTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
 
     /**
      * Test that initial content in the customization editor is escaped to prevent </textarea> breakout.
@@ -41,9 +48,15 @@ class XssBreakoutTest extends TestCase
         $admin = User::factory()->create(['is_admin' => true]);
         Gate::define('view-recruitment', fn() => true);
 
-        // Mock setting values
-        config(['settings.recruitment_primary_message' => '</textarea><script>alert("primary")</script>']);
-        config(['settings.recruitment_follow_up_message' => '</textarea><script>alert("followup")</script>']);
+        // Seed recruitment messages
+        RecruitmentMessage::updateOrCreate(
+            ['type' => 'primary'],
+            ['message' => '</textarea><script>alert("primary")</script>']
+        );
+        RecruitmentMessage::updateOrCreate(
+            ['type' => 'follow_up'],
+            ['message' => '</textarea><script>alert("followup")</script>']
+        );
 
         $this->actingAs($admin)
             ->get(route('admin.recruitment.index'))


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-controlled content was rendered using unescaped `{!! !!}` inside `<textarea>` tags in the customization and recruitment admin views, allowing for XSS breakout via `</textarea>` tags.
🎯 Impact: An attacker or compromised account could execute malicious scripts in the context of other administrative users.
🔧 Fix:
- Switched from unescaped `{!! !!}` to escaped `{{ }}` in `resources/views/admin/customization/edit.blade.php` and `resources/views/admin/recruitment/index.blade.php`.
- Fixed a syntax error in `app/Http/Controllers/Admin/WarCounterController.php` where an object instantiation was not properly wrapped for method chaining, breaking Artisan and routing.
- Added a regression test in `tests/Feature/Security/XssBreakoutTest.php`.
✅ Verification: Verified that `php artisan route:list` now executes successfully and that the affected views now correctly escape HTML entities.

---
*PR created automatically by Jules for task [3960865615244903667](https://jules.google.com/task/3960865615244903667) started by @Yosodog*