### PR TITLE
🛡️ Sentinel: Replace direct env() calls with config()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2025-05-24 - Enforce Config Over Env
+**Vulnerability:** Direct 'env()' calls outside of config files.
+**Learning:** In Laravel, 'env()' returns null when configuration is cached, leading to application failure or insecure defaults in production.
+**Prevention:** Always use 'config()' for all environment-dependent values and ensure they are mapped in 'config/' files.

--- a/app/Notifications/NationVerification.php
+++ b/app/Notifications/NationVerification.php
@@ -45,9 +45,9 @@ class NationVerification extends Notification implements ShouldQueue
         return [
             'nation_id' => $this->user->nation_id,
             'subject' => 'Verify Your Account',
-            'message' => 'Welcome to '.env(
-                'APP_NAME'
-            )."! \n\nPlease verify your account by clicking the link below:\n\n".
+            // Use config() instead of env() to support configuration caching and ensure
+            // the application remains secure and functional in production environments.
+            'message' => 'Welcome to '.config('app.name')."! \n\nPlease verify your account by clicking the link below:\n\n".
                 '[link='.route('verify', ['code' => $this->verification_code]).']Click here to verify![/link]'.
                 "\n\nYour verification code: {$this->verification_code}",
         ];

--- a/app/Services/AllianceMembershipService.php
+++ b/app/Services/AllianceMembershipService.php
@@ -87,8 +87,10 @@ class AllianceMembershipService
         $primaryAllianceId = $this->getPrimaryAllianceId();
 
         if ($allianceId === $primaryAllianceId) {
-            $apiKey = env('PW_API_KEY');
-            $mutationKey = env('PW_API_MUTATION_KEY');
+            // Use config() instead of env() to support configuration caching and ensure
+            // sensitive credentials are reliably retrieved in production.
+            $apiKey = config('services.pw.api_key');
+            $mutationKey = config('services.pw.mutation_key');
 
             if ($apiKey === null) {
                 return null;

--- a/app/Services/PWMessageService.php
+++ b/app/Services/PWMessageService.php
@@ -14,7 +14,9 @@ class PWMessageService
 
     public function __construct()
     {
-        $this->apiKey = env('PW_API_KEY');
+        // Use config() instead of env() to support configuration caching and ensure
+        // sensitive credentials are reliably retrieved in production.
+        $this->apiKey = config('services.pw.api_key');
     }
 
     public function sendMessage(int $nation_id, string $subject, string $message): bool


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Direct 'env()' calls outside of configuration files.
🎯 Impact: In Laravel, 'env()' returns null when configuration is cached. This can cause application failure or fallback to insecure/incorrect defaults in production environments when 'php artisan config:cache' is run.
🔧 Fix: Replaced direct 'env()' calls in 'app/Notifications/NationVerification.php', 'app/Services/PWMessageService.php', and 'app/Services/AllianceMembershipService.php' with 'config()' calls. Added security comments explaining the change. Created a security journal entry in '.jules/sentinel.md'.
✅ Verification: Confirmed 'config()' keys map to environment variables in 'config/services.php'. Verified values via 'php artisan tinker'. Ran relevant tests ('NotificationPayloadTest').

---
*PR created automatically by Jules for task [14043293818213041605](https://jules.google.com/task/14043293818213041605) started by @Yosodog*