### PR TITLE
🛡️ Sentinel: [security improvement] Refactor env() to config()

### DIFF
--- a/app/Notifications/NationVerification.php
+++ b/app/Notifications/NationVerification.php
@@ -42,11 +42,12 @@ class NationVerification extends Notification implements ShouldQueue
      */
     public function toPNW(object $notifiable): array
     {
+        // Use config(), not env(), for security and configuration caching.
         return [
             'nation_id' => $this->user->nation_id,
             'subject' => 'Verify Your Account',
-            'message' => 'Welcome to '.env(
-                'APP_NAME'
+            'message' => 'Welcome to '.config(
+                'app.name'
             )."! \n\nPlease verify your account by clicking the link below:\n\n".
                 '[link='.route('verify', ['code' => $this->verification_code]).']Click here to verify![/link]'.
                 "\n\nYour verification code: {$this->verification_code}",

--- a/app/Services/AllianceMembershipService.php
+++ b/app/Services/AllianceMembershipService.php
@@ -87,8 +87,9 @@ class AllianceMembershipService
         $primaryAllianceId = $this->getPrimaryAllianceId();
 
         if ($allianceId === $primaryAllianceId) {
-            $apiKey = env('PW_API_KEY');
-            $mutationKey = env('PW_API_MUTATION_KEY');
+            // Use config(), not env(), for security and configuration caching.
+            $apiKey = config('services.pw.api_key');
+            $mutationKey = config('services.pw.mutation_key');
 
             if ($apiKey === null) {
                 return null;

--- a/app/Services/PWMessageService.php
+++ b/app/Services/PWMessageService.php
@@ -14,7 +14,8 @@ class PWMessageService
 
     public function __construct()
     {
-        $this->apiKey = env('PW_API_KEY');
+        // Use config(), not env(), for security and configuration caching.
+        $this->apiKey = (string) config('services.pw.api_key');
     }
 
     public function sendMessage(int $nation_id, string $subject, string $message): bool


### PR DESCRIPTION
🚨 Severity: MEDIUM (Security Enhancement / Best Practice)
💡 Vulnerability: Direct use of `env()` outside of configuration files.
🎯 Impact: Prevents effective use of `php artisan config:cache` and exposes environment access patterns in logic.
🔧 Fix: Replaced `env()` calls with corresponding `config()` values from `config/services.php` and `config/app.php`.
✅ Verification: Ran `tests/Unit/Notifications/NotificationPayloadTest.php` which passed. Verified configuration mapping in `config/services.php` exists.

---
*PR created automatically by Jules for task [9769151340299815894](https://jules.google.com/task/9769151340299815894) started by @Yosodog*