### PR TITLE
🛡️ Sentinel: Refactor env() calls to config() for reliability and security

### DIFF
--- a/app/Notifications/NationVerification.php
+++ b/app/Notifications/NationVerification.php
@@ -45,9 +45,7 @@ class NationVerification extends Notification implements ShouldQueue
         return [
             'nation_id' => $this->user->nation_id,
             'subject' => 'Verify Your Account',
-            'message' => 'Welcome to '.env(
-                'APP_NAME'
-            )."! \n\nPlease verify your account by clicking the link below:\n\n".
+            'message' => 'Welcome to '.config('app.name')."! \n\nPlease verify your account by clicking the link below:\n\n".
                 '[link='.route('verify', ['code' => $this->verification_code]).']Click here to verify![/link]'.
                 "\n\nYour verification code: {$this->verification_code}",
         ];

--- a/app/Services/AllianceMembershipService.php
+++ b/app/Services/AllianceMembershipService.php
@@ -87,8 +87,8 @@ class AllianceMembershipService
         $primaryAllianceId = $this->getPrimaryAllianceId();
 
         if ($allianceId === $primaryAllianceId) {
-            $apiKey = env('PW_API_KEY');
-            $mutationKey = env('PW_API_MUTATION_KEY');
+            $apiKey = config('services.pw.api_key');
+            $mutationKey = config('services.pw.mutation_key');
 
             if ($apiKey === null) {
                 return null;

--- a/app/Services/PWMessageService.php
+++ b/app/Services/PWMessageService.php
@@ -14,7 +14,7 @@ class PWMessageService
 
     public function __construct()
     {
-        $this->apiKey = env('PW_API_KEY');
+        $this->apiKey = (string) config('services.pw.api_key');
     }
 
     public function sendMessage(int $nation_id, string $subject, string $message): bool


### PR DESCRIPTION
Identified and fixed a security/reliability issue where `env()` was used directly in application services and notifications. In Laravel, `env()` should only be used within configuration files. If the configuration is cached (a standard production optimization), `env()` calls outside of config files will return `null`, potentially breaking authentication and critical service integrations (Politics & War API). 

The refactor ensures the application correctly resolves these values from the config repository, which are already mapped in `config/app.php` and `config/services.php`.

Changes:
1. Updated `NationVerification` notification to use `config('app.name')`.
2. Updated `PWMessageService` to use `config('services.pw.api_key')`.
3. Updated `AllianceMembershipService` to use `config('services.pw.api_key')` and `config('services.pw.mutation_key')`.
4. Verified that relevant config mappings exist in `config/app.php` and `config/services.php`.
5. Ensured no generated test artifacts were included in the submission.

---
*PR created automatically by Jules for task [11002782484907137667](https://jules.google.com/task/11002782484907137667) started by @Yosodog*