### PR TITLE
🛡️ Sentinel: Refactor environment variable access to use config()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Improper Configuration Access
+**Vulnerability:** Direct use of `env()` in application logic (Services and Notifications).
+**Learning:** Calling `env()` outside of configuration files is a security and stability risk in Laravel. If configuration is cached (`php artisan config:cache`), `env()` calls return `null`, potentially disabling security features or breaking the app.
+**Prevention:** Always wrap environment variables in a configuration file (e.g., `config/services.php`) and use the `config()` helper in application code.

--- a/app/Notifications/NationVerification.php
+++ b/app/Notifications/NationVerification.php
@@ -45,8 +45,8 @@ class NationVerification extends Notification implements ShouldQueue
         return [
             'nation_id' => $this->user->nation_id,
             'subject' => 'Verify Your Account',
-            'message' => 'Welcome to '.env(
-                'APP_NAME'
+            'message' => 'Welcome to '.config(
+                'app.name'
             )."! \n\nPlease verify your account by clicking the link below:\n\n".
                 '[link='.route('verify', ['code' => $this->verification_code]).']Click here to verify![/link]'.
                 "\n\nYour verification code: {$this->verification_code}",

--- a/app/Services/AllianceMembershipService.php
+++ b/app/Services/AllianceMembershipService.php
@@ -87,8 +87,8 @@ class AllianceMembershipService
         $primaryAllianceId = $this->getPrimaryAllianceId();
 
         if ($allianceId === $primaryAllianceId) {
-            $apiKey = env('PW_API_KEY');
-            $mutationKey = env('PW_API_MUTATION_KEY');
+            $apiKey = config('services.pw.api_key');
+            $mutationKey = config('services.pw.mutation_key');
 
             if ($apiKey === null) {
                 return null;

--- a/app/Services/PWMessageService.php
+++ b/app/Services/PWMessageService.php
@@ -14,7 +14,7 @@ class PWMessageService
 
     public function __construct()
     {
-        $this->apiKey = env('PW_API_KEY');
+        $this->apiKey = (string) config('services.pw.api_key');
     }
 
     public function sendMessage(int $nation_id, string $subject, string $message): bool


### PR DESCRIPTION
Refactored direct `env()` calls to use the `config()` helper in `PWMessageService`, `AllianceMembershipService`, and `NationVerification`. This improvement ensures that application secrets and names are accessed reliably even when configuration caching is enabled, preventing potential security gaps and functional regressions in production. Verified with tests and confirmed configuration mappings exist in `config/services.php` and `config/app.php`.

---
*PR created automatically by Jules for task [1657365690616694581](https://jules.google.com/task/1657365690616694581) started by @Yosodog*