### PR TITLE
🛡️ Sentinel: Fix XSS vulnerabilities in admin textareas

### DIFF
--- a/resources/views/admin/customization/edit.blade.php
+++ b/resources/views/admin/customization/edit.blade.php
@@ -80,7 +80,7 @@
                     class="textarea js-ckeditor w-full"
                     data-editor-input="true"
                     rows="14"
-                >{!! $initialContent !!}</textarea>
+                >{{ $initialContent }}</textarea>
             </div>
 
             <div class="mt-6">

--- a/resources/views/admin/recruitment/index.blade.php
+++ b/resources/views/admin/recruitment/index.blade.php
@@ -40,7 +40,7 @@
                     hint="This message is sent immediately after a nation becomes eligible."
                     rows="10"
                     required
-                >{!! old('primary_message', $primaryMessage) !!}</x-textarea>
+                >{{ old('primary_message', $primaryMessage) }}</x-textarea>
 
                 <x-toggle
                     id="follow_up_enabled"
@@ -70,7 +70,7 @@
                     hint="The follow-up is only sent if the nation is still unaffiliated when the delay expires."
                     rows="10"
                     required
-                >{!! old('follow_up_message', $followUpMessage) !!}</x-textarea>
+                >{{ old('follow_up_message', $followUpMessage) }}</x-textarea>
 
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Reflected and Stored XSS in `<textarea>` tags.
🎯 Impact: Attackers could execute arbitrary JavaScript in the context of an administrator by providing a payload that closes the textarea tag (e.g., `</textarea><script>alert(1)</script>`).
🔧 Fix: Replaced raw Blade output `{!! ... !!}` with escaped output `{{ ... }}`. Laravel's escaping ensures that any HTML tags or breakout sequences are safely rendered as literal text within the textarea.
✅ Verification: Verified that the code changes were applied correctly and that the application still passes its basic unit and feature test suite. CKEditor (used on these fields) correctly handles the escaped HTML entities provided in the source textarea.

---
*PR created automatically by Jules for task [9509645714656491340](https://jules.google.com/task/9509645714656491340) started by @Yosodog*