### PR TITLE
Harden admin editor inputs and PNW config access

### DIFF
--- a/app/Notifications/NationVerification.php
+++ b/app/Notifications/NationVerification.php
@@ -45,9 +45,7 @@ class NationVerification extends Notification implements ShouldQueue
         return [
             'nation_id' => $this->user->nation_id,
             'subject' => 'Verify Your Account',
-            'message' => 'Welcome to '.env(
-                'APP_NAME'
-            )."! \n\nPlease verify your account by clicking the link below:\n\n".
+            'message' => 'Welcome to '.config('app.name')."! \n\nPlease verify your account by clicking the link below:\n\n".
                 '[link='.route('verify', ['code' => $this->verification_code]).']Click here to verify![/link]'.
                 "\n\nYour verification code: {$this->verification_code}",
         ];

--- a/app/Services/AllianceMembershipService.php
+++ b/app/Services/AllianceMembershipService.php
@@ -87,16 +87,16 @@ class AllianceMembershipService
         $primaryAllianceId = $this->getPrimaryAllianceId();
 
         if ($allianceId === $primaryAllianceId) {
-            $apiKey = env('PW_API_KEY');
-            $mutationKey = env('PW_API_MUTATION_KEY');
+            $apiKey = config('services.pw.api_key');
+            $mutationKey = config('services.pw.mutation_key');
 
-            if ($apiKey === null) {
+            if (! is_string($apiKey) || $apiKey === '') {
                 return null;
             }
 
             return [
                 'api_key' => $apiKey,
-                'mutation_key' => $mutationKey ?: null,
+                'mutation_key' => is_string($mutationKey) && $mutationKey !== '' ? $mutationKey : null,
             ];
         }
 

--- a/app/Services/PWMessageService.php
+++ b/app/Services/PWMessageService.php
@@ -8,17 +8,31 @@ use Illuminate\Support\Facades\Log;
 
 class PWMessageService
 {
-    protected string $apiKey;
+    protected ?string $apiKey;
 
     protected string $endpoint = 'https://politicsandwar.com/api/send-message/';
 
     public function __construct()
     {
-        $this->apiKey = env('PW_API_KEY');
+        $apiKey = config('services.pw.api_key');
+
+        $this->apiKey = is_string($apiKey) && $apiKey !== ''
+            ? $apiKey
+            : null;
     }
 
     public function sendMessage(int $nation_id, string $subject, string $message): bool
     {
+        if ($this->apiKey === null) {
+            Log::error('PNW Message Failed', [
+                'nation_id' => $nation_id,
+                'subject' => $subject,
+                'reason' => 'missing_api_key',
+            ]);
+
+            return false;
+        }
+
         $payload = [
             'key' => $this->apiKey,
             'to' => $nation_id,

--- a/resources/views/admin/customization/edit.blade.php
+++ b/resources/views/admin/customization/edit.blade.php
@@ -80,7 +80,7 @@
                     class="textarea js-ckeditor w-full"
                     data-editor-input="true"
                     rows="14"
-                >{!! $initialContent !!}</textarea>
+                >{{ $initialContent }}</textarea>
             </div>
 
             <div class="mt-6">

--- a/resources/views/admin/recruitment/index.blade.php
+++ b/resources/views/admin/recruitment/index.blade.php
@@ -40,7 +40,7 @@
                     hint="This message is sent immediately after a nation becomes eligible."
                     rows="10"
                     required
-                >{!! old('primary_message', $primaryMessage) !!}</x-textarea>
+                >{{ old('primary_message', $primaryMessage) }}</x-textarea>
 
                 <x-toggle
                     id="follow_up_enabled"
@@ -70,7 +70,7 @@
                     hint="The follow-up is only sent if the nation is still unaffiliated when the delay expires."
                     rows="10"
                     required
-                >{!! old('follow_up_message', $followUpMessage) !!}</x-textarea>
+                >{{ old('follow_up_message', $followUpMessage) }}</x-textarea>
 
                 <div class="flex justify-end">
                     <button type="submit" class="btn btn-primary">

--- a/tests/Feature/Security/XssBreakoutTest.php
+++ b/tests/Feature/Security/XssBreakoutTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\Page;
+use App\Models\RecruitmentMessage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\FeatureTestCase;
+
+class XssBreakoutTest extends FeatureTestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
+
+    public function test_customization_editor_does_not_allow_textarea_breakout(): void
+    {
+        $admin = User::factory()->admin()->create();
+        Gate::define('manage-custom-pages', fn (): bool => true);
+
+        $page = Page::query()->create([
+            'slug' => 'test-page',
+            'status' => Page::STATUS_DRAFT,
+            'draft' => '</textarea><script>alert("xss")</script>',
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('admin.customization.edit', $page))
+            ->assertOk()
+            ->assertSee('&lt;/textarea&gt;', false)
+            ->assertDontSee('</textarea><script>alert("xss")</script>', false);
+    }
+
+    public function test_recruitment_settings_do_not_allow_textarea_breakout(): void
+    {
+        $admin = User::factory()->admin()->create();
+        Gate::define('view-recruitment', fn (): bool => true);
+
+        RecruitmentMessage::query()->updateOrCreate(
+            ['type' => 'primary'],
+            ['message' => '</textarea><script>alert("primary")</script>']
+        );
+
+        RecruitmentMessage::query()->updateOrCreate(
+            ['type' => 'follow_up'],
+            ['message' => '</textarea><script>alert("followup")</script>']
+        );
+
+        $this->actingAs($admin)
+            ->get(route('admin.recruitment.index'))
+            ->assertOk()
+            ->assertSee('&lt;/textarea&gt;', false)
+            ->assertDontSee('</textarea><script>alert("primary")</script>', false)
+            ->assertDontSee('</textarea><script>alert("followup")</script>', false);
+    }
+}

--- a/tests/Unit/Notifications/NotificationPayloadTest.php
+++ b/tests/Unit/Notifications/NotificationPayloadTest.php
@@ -131,6 +131,7 @@ class NotificationPayloadTest extends FeatureTestCase
 
         $this->assertNotNull($user->fresh()->verification_code);
         $this->assertSame($user->fresh()->verification_code, $notification->verification_code);
+        $this->assertStringContainsString('Welcome to '.config('app.name').'!', $payload['message']);
         $this->assertStringContainsString($notification->verification_code, $payload['message']);
         $this->assertStringContainsString(route('verify', ['code' => $notification->verification_code]), $payload['message']);
     }

--- a/tests/Unit/Services/PWMessageServiceTest.php
+++ b/tests/Unit/Services/PWMessageServiceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\PWMessageService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class PWMessageServiceTest extends TestCase
+{
+    public function test_send_message_returns_false_when_api_key_is_missing(): void
+    {
+        Config::set('services.pw.api_key', null);
+        Log::spy();
+
+        $service = new PWMessageService;
+
+        $this->assertFalse($service->sendMessage(123456, 'Subject', 'Body'));
+
+        Http::assertNothingSent();
+        Log::shouldHaveReceived('error')->once();
+    }
+}


### PR DESCRIPTION
## Summary
- escape admin CKEditor seed content inside textareas so stored HTML cannot break out before the editor hydrates
- replace app-level \ lookups with \ in PNW notification/service paths
- keep missing P&W API keys explicit instead of silently posting with an empty key
- add regression coverage for textarea breakout and missing-key handling

## Testing
- php artisan test tests/Feature/Security/XssBreakoutTest.php tests/Unit/Notifications/NotificationPayloadTest.php tests/Unit/Services/PWMessageServiceTest.php

## Operational notes
- no migrations
- no cache key changes
- no queue restarts required