### PR TITLE
🛡️ Sentinel: Fix XSS in PageRenderer HTML normalization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - HTML Sanitization in PageRenderer
+**Vulnerability:** XSS via unsanitized HTML in CMS pages.
+**Learning:** The PageRenderer::normalizeHtml method was only trimming input, allowing malicious scripts to be rendered using the `{!! !!}` Blade syntax.
+**Prevention:** Implement a whitelist-based HTML sanitizer using DOMDocument and DOMXPath, strictly validating tags, attributes, and URI protocols (blocking javascript:, data:, and vbscript:).

--- a/app/Services/PageRenderer.php
+++ b/app/Services/PageRenderer.php
@@ -28,9 +28,54 @@ class PageRenderer
         return $this->normalizeHtml($content);
     }
 
+    private const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'u', 's', 'a', 'b', 'i', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'blockquote', 'pre', 'code', 'img', 'iframe', 'figure', 'figcaption', 'div', 'span', 'table', 'thead', 'tbody', 'tr', 'th', 'td'];
+
+    private const ALLOWED_ATTRS = ['href', 'src', 'alt', 'title', 'class', 'target', 'rel', 'colspan', 'rowspan', 'loading', 'allowfullscreen'];
+
     private function normalizeHtml(string $html): string
     {
-        return trim($html);
+        if (($t = trim($html)) === '') {
+            return '';
+        }
+        $dom = new \DOMDocument;
+        libxml_use_internal_errors(true);
+        $dom->loadHTML('<?xml encoding="utf-8" ?>'.$t, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        foreach (iterator_to_array((new \DOMXPath($dom))->query('//*')) as $node) {
+            if (! in_array(strtolower($node->nodeName), self::ALLOWED_TAGS)) {
+                while ($node->firstChild) {
+                    $node->parentNode->insertBefore($node->firstChild, $node);
+                }
+                $node->parentNode->removeChild($node);
+
+                continue;
+            }
+            foreach (iterator_to_array($node->attributes) as $attr) {
+                $name = strtolower($attr->name);
+                if (! in_array($name, self::ALLOWED_ATTRS) || str_starts_with($name, 'on')) {
+                    $node->removeAttribute($attr->name);
+
+                    continue;
+                }
+                if (in_array($name, ['href', 'src'])) {
+                    $val = preg_replace('/[\x00-\x1F\s]/u', '', $attr->value);
+                    if (preg_match('/(javascript|data|vbscript):/i', $val)) {
+                        $node->removeAttribute($attr->name);
+
+                        continue;
+                    }
+                    if ($name === 'src') {
+                        $n = (strtolower($node->nodeName) === 'img') ? $this->normalizeImageSource($attr->value) : $this->normalizeEmbedSource($attr->value);
+                        if (! $n) {
+                            $node->removeAttribute($attr->name);
+                        } else {
+                            $node->setAttribute($attr->name, $n);
+                        }
+                    }
+                }
+            }
+        }
+
+        return preg_replace('/^<\?xml[^>]*>/i', '', trim($dom->saveHTML()));
     }
 
     /**

--- a/tests/Unit/Services/PageRendererXssTest.php
+++ b/tests/Unit/Services/PageRendererXssTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\PageRenderer;
+use Tests\UnitTestCase;
+
+class PageRendererXssTest extends UnitTestCase
+{
+    public function test_normalize_html_strips_dangerous_tags(): void
+    {
+        $renderer = new PageRenderer;
+        $badHtml = '<script>alert("xss")</script><p>Hello</p><iframe src="javascript:alert(1)"></iframe>';
+        $safeHtml = $renderer->render($badHtml);
+
+        $this->assertStringNotContainsString('<script>', $safeHtml);
+        $this->assertStringNotContainsString('src="javascript:alert(1)"', $safeHtml);
+        $this->assertStringContainsString('<p>Hello</p>', $safeHtml);
+    }
+
+    public function test_normalize_html_strips_event_handlers(): void
+    {
+        $renderer = new PageRenderer;
+        $badHtml = '<button onclick="alert(1)">Click me</button><img src="x" onerror="alert(1)">';
+        $safeHtml = $renderer->render($badHtml);
+
+        $this->assertStringNotContainsString('onclick', $safeHtml);
+        $this->assertStringNotContainsString('onerror', $safeHtml);
+    }
+
+    public function test_normalize_html_strips_javascript_uris(): void
+    {
+        $renderer = new PageRenderer;
+        $badHtml = '<a href="javascript:alert(1)">Link</a><img src="java&#10;script:alert(1)">';
+        $safeHtml = $renderer->render($badHtml);
+
+        $this->assertStringNotContainsString('javascript:', $safeHtml);
+        $this->assertStringNotContainsString('java&#10;script:', $safeHtml);
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS via unsanitized HTML in CMS pages. The `PageRenderer::normalizeHtml` method was only trimming input, allowing malicious scripts to be rendered using `{!! !!}` in Blade views.
🎯 Impact: Attackers could inject malicious scripts into CMS pages, leading to session theft, account takeover, or data exfiltration.
🔧 Fix: Implemented a strict whitelist-based HTML sanitizer using `DOMDocument` and `DOMXPath`. It filters tags and attributes, blocks event handlers, and validates URI protocols for `href` and `src`.
✅ Verification: Ran `tests/Unit/Services/PageRendererXssTest.php` and `tests/Unit/Services/PageRendererSecurityTest.php`. All tests passed. Verified code formatting with Pint.

---
*PR created automatically by Jules for task [5751555544067975693](https://jules.google.com/task/5751555544067975693) started by @Yosodog*