### PR TITLE
[codex] Harden workflows and refresh dashboard

### DIFF
--- a/app/Http/Controllers/Admin/CityGrantController.php
+++ b/app/Http/Controllers/Admin/CityGrantController.php
@@ -116,8 +116,16 @@ class CityGrantController
             ]);
         }
 
-        // Call service to deny grant
-        CityGrantService::denyGrant($grantRequest);
+        try {
+            CityGrantService::denyGrant($grantRequest);
+        } catch (ValidationException $exception) {
+            $details = collect($exception->errors())->flatten()->implode(' ');
+
+            return redirect()->back()->with([
+                'alert-message' => $details ?: 'Unable to deny this city grant request.',
+                'alert-type' => 'error',
+            ]);
+        }
 
         return redirect()->back()->with([
             'alert-message' => "City Grant for City #{$grantRequest->city_number} has been denied.",

--- a/app/Http/Controllers/Admin/GrantController.php
+++ b/app/Http/Controllers/Admin/GrantController.php
@@ -251,7 +251,16 @@ class GrantController
             ]);
         }
 
-        GrantService::denyGrant($application);
+        try {
+            GrantService::denyGrant($application);
+        } catch (ValidationException $exception) {
+            $details = collect($exception->errors())->flatten()->implode(' ');
+
+            return redirect()->back()->with([
+                'alert-message' => $details ?: 'Unable to deny this grant application.',
+                'alert-type' => 'error',
+            ]);
+        }
 
         return redirect()->back()
             ->with('alert-message', 'Grant application denied.')

--- a/app/Services/CityGrantService.php
+++ b/app/Services/CityGrantService.php
@@ -277,18 +277,35 @@ class CityGrantService
      */
     public static function denyGrant(CityGrantRequest $request): void
     {
-        app(SelfApprovalGuard::class)->ensureNotSelf(
-            requestNationId: $request->nation_id,
-            context: 'deny your own city grant request'
-        );
+        $deniedRequest = null;
 
-        $request->update([
-            'status' => 'denied',
-            'denied_at' => now(),
-            'pending_key' => null,
-        ]);
+        DB::transaction(function () use ($request, &$deniedRequest) {
+            $lockedRequest = CityGrantRequest::query()
+                ->with('nation')
+                ->lockForUpdate()
+                ->findOrFail($request->id);
 
-        $request->nation->notify(new CityGrantNotification($request->nation_id, $request, 'denied'));
+            if ($lockedRequest->status !== 'pending') {
+                throw ValidationException::withMessages([
+                    'request' => 'Grant is not pending.',
+                ]);
+            }
+
+            app(SelfApprovalGuard::class)->ensureNotSelf(
+                requestNationId: $lockedRequest->nation_id,
+                context: 'deny your own city grant request'
+            );
+
+            $lockedRequest->update([
+                'status' => 'denied',
+                'denied_at' => now(),
+                'pending_key' => null,
+            ]);
+
+            $deniedRequest = $lockedRequest->fresh();
+        }, attempts: 3);
+
+        $deniedRequest->nation->notify(new CityGrantNotification($deniedRequest->nation_id, $deniedRequest, 'denied'));
 
         app(PendingRequestsService::class)->flushCache();
 
@@ -297,14 +314,14 @@ class CityGrantService
             action: 'city_grant_denied',
             outcome: 'denied',
             severity: 'warning',
-            subject: $request,
+            subject: $deniedRequest,
             context: [
                 'related' => [
-                    ['type' => 'Account', 'id' => (string) $request->account_id, 'role' => 'account'],
+                    ['type' => 'Account', 'id' => (string) $deniedRequest->account_id, 'role' => 'account'],
                 ],
                 'data' => [
-                    'nation_id' => $request->nation_id,
-                    'city_number' => $request->city_number,
+                    'nation_id' => $deniedRequest->nation_id,
+                    'city_number' => $deniedRequest->city_number,
                 ],
             ],
             message: 'City grant denied.'

--- a/app/Services/GrantService.php
+++ b/app/Services/GrantService.php
@@ -283,18 +283,35 @@ class GrantService
 
     public static function denyGrant(GrantApplication $application): void
     {
-        app(SelfApprovalGuard::class)->ensureNotSelf(
-            requestNationId: $application->nation_id,
-            context: 'deny your own grant request'
-        );
+        $deniedApplication = null;
 
-        $application->update([
-            'status' => 'denied',
-            'denied_at' => now(),
-            'pending_key' => null,
-        ]);
+        DB::transaction(function () use ($application, &$deniedApplication) {
+            $lockedApplication = GrantApplication::query()
+                ->with('nation')
+                ->lockForUpdate()
+                ->findOrFail($application->id);
 
-        $application->nation->notify(new GrantNotification($application->nation_id, $application, 'denied'));
+            if ($lockedApplication->status !== 'pending') {
+                throw ValidationException::withMessages([
+                    'application' => 'Grant application is not pending.',
+                ]);
+            }
+
+            app(SelfApprovalGuard::class)->ensureNotSelf(
+                requestNationId: $lockedApplication->nation_id,
+                context: 'deny your own grant request'
+            );
+
+            $lockedApplication->update([
+                'status' => 'denied',
+                'denied_at' => now(),
+                'pending_key' => null,
+            ]);
+
+            $deniedApplication = $lockedApplication->fresh();
+        }, attempts: 3);
+
+        $deniedApplication->nation->notify(new GrantNotification($deniedApplication->nation_id, $deniedApplication, 'denied'));
 
         app(PendingRequestsService::class)->flushCache();
 
@@ -303,14 +320,14 @@ class GrantService
             action: 'grant_application_denied',
             outcome: 'denied',
             severity: 'warning',
-            subject: $application,
+            subject: $deniedApplication,
             context: [
                 'related' => [
-                    ['type' => 'Grant', 'id' => (string) $application->grant_id, 'role' => 'grant'],
-                    ['type' => 'Account', 'id' => (string) $application->account_id, 'role' => 'account'],
+                    ['type' => 'Grant', 'id' => (string) $deniedApplication->grant_id, 'role' => 'grant'],
+                    ['type' => 'Account', 'id' => (string) $deniedApplication->account_id, 'role' => 'account'],
                 ],
                 'data' => [
-                    'nation_id' => $application->nation_id,
+                    'nation_id' => $deniedApplication->nation_id,
                 ],
             ],
             message: 'Grant application denied.'

--- a/app/Services/GraphQLQueryBuilder.php
+++ b/app/Services/GraphQLQueryBuilder.php
@@ -27,6 +27,11 @@ class GraphQLQueryBuilder
         return $this->rootField;
     }
 
+    public function isMutation(): bool
+    {
+        return $this->isMutation;
+    }
+
     /**
      * Set the root field of the query (e.g., 'nations').
      */

--- a/app/Services/PageRenderer.php
+++ b/app/Services/PageRenderer.php
@@ -2,6 +2,9 @@
 
 namespace App\Services;
 
+use DOMDocument;
+use DOMElement;
+use DOMNode;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -11,139 +14,160 @@ use Illuminate\Support\Str;
 class PageRenderer
 {
     /**
+     * @var array<string, bool>
+     */
+    private const ALLOWED_TAGS = [
+        'a' => true,
+        'abbr' => true,
+        'b' => true,
+        'blockquote' => true,
+        'br' => true,
+        'caption' => true,
+        'code' => true,
+        'col' => true,
+        'colgroup' => true,
+        'del' => true,
+        'div' => true,
+        'em' => true,
+        'figcaption' => true,
+        'figure' => true,
+        'h1' => true,
+        'h2' => true,
+        'h3' => true,
+        'h4' => true,
+        'h5' => true,
+        'h6' => true,
+        'hr' => true,
+        'i' => true,
+        'iframe' => true,
+        'img' => true,
+        'input' => true,
+        'label' => true,
+        'li' => true,
+        'mark' => true,
+        'oembed' => true,
+        'ol' => true,
+        'p' => true,
+        'pre' => true,
+        's' => true,
+        'small' => true,
+        'span' => true,
+        'strong' => true,
+        'sub' => true,
+        'sup' => true,
+        'table' => true,
+        'tbody' => true,
+        'td' => true,
+        'tfoot' => true,
+        'th' => true,
+        'thead' => true,
+        'tr' => true,
+        'u' => true,
+        'ul' => true,
+    ];
+
+    /**
+     * @var array<string, bool>
+     */
+    private const DROP_WITH_CONTENT_TAGS = [
+        'base' => true,
+        'applet' => true,
+        'audio' => true,
+        'button' => true,
+        'canvas' => true,
+        'embed' => true,
+        'form' => true,
+        'frame' => true,
+        'frameset' => true,
+        'link' => true,
+        'math' => true,
+        'meta' => true,
+        'object' => true,
+        'script' => true,
+        'select' => true,
+        'style' => true,
+        'svg' => true,
+        'template' => true,
+        'textarea' => true,
+        'video' => true,
+    ];
+
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private const TAG_ATTRIBUTES = [
+        'a' => ['href', 'target', 'rel'],
+        'col' => ['span', 'width'],
+        'iframe' => ['src', 'title', 'width', 'height', 'allow', 'allowfullscreen', 'loading', 'referrerpolicy', 'frameborder'],
+        'img' => ['src', 'alt', 'width', 'height', 'loading'],
+        'input' => ['type', 'checked', 'disabled'],
+        'li' => ['value'],
+        'oembed' => ['url'],
+        'ol' => ['start', 'type'],
+        'td' => ['colspan', 'rowspan'],
+        'th' => ['colspan', 'rowspan', 'scope'],
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    private const GLOBAL_ATTRIBUTES = [
+        'aria-label',
+        'aria-labelledby',
+        'aria-describedby',
+        'class',
+        'id',
+        'role',
+        'style',
+        'title',
+    ];
+
+    /**
      * Render the stored payload into HTML.
      *
      * @param  array<int, mixed>|string  $content
      */
-    private const ALLOWED_TAGS = [
-        'p', 'br', 'b', 'i', 'u', 'strong', 'em', 'a', 'ul', 'ol', 'li',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'code',
-        'img', 'iframe', 'figure', 'figcaption', 'span', 'div',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td',
-    ];
-
-    private const ALLOWED_ATTRIBUTES = [
-        'href', 'src', 'alt', 'title', 'class', 'target', 'rel',
-        'width', 'height', 'frameborder', 'allowfullscreen', 'loading',
-        'colspan', 'rowspan',
-    ];
-
-    private const DANGEROUS_TAGS = [
-        'script', 'style', 'object', 'embed', 'applet', 'link',
-        'meta', 'base', 'form', 'button', 'input', 'select',
-        'textarea', 'svg', 'math', 'video', 'audio', 'canvas',
-    ];
-
     public function render(array|string $content): string
     {
         if (is_array($content)) {
             if (array_key_exists('html', $content) && is_string($content['html'])) {
-                return $this->normalizeHtml($content['html']);
+                return $this->sanitizeHtml($content['html']);
             }
 
             return $this->renderLegacyBlocks($content);
         }
 
-        return $this->normalizeHtml($content);
+        return $this->sanitizeHtml($content);
     }
 
-    private function normalizeHtml(string $html): string
+    private function sanitizeHtml(string $html): string
     {
-        $trimmed = trim($html);
+        $normalized = trim($html);
 
-        if ($trimmed === '') {
+        if ($normalized === '') {
             return '';
         }
 
-        $dom = new \DOMDocument;
-        $wrappedHtml = '<?xml encoding="utf-8" ?>'.$trimmed;
+        $document = new DOMDocument;
+        $previous = libxml_use_internal_errors(true);
 
-        $previousLibxmlErrorState = libxml_use_internal_errors(true);
-        $dom->loadHTML($wrappedHtml, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $document->loadHTML(
+            '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><div id="nexus-page-render-root">'.$normalized.'</div></body></html>',
+            LIBXML_HTML_NODEFDTD | LIBXML_NOERROR | LIBXML_NOWARNING
+        );
+
         libxml_clear_errors();
-        libxml_use_internal_errors($previousLibxmlErrorState);
+        libxml_use_internal_errors($previous);
 
-        $xpath = new \DOMXPath($dom);
-        $nodes = $xpath->query('//*');
+        $root = $document->getElementById('nexus-page-render-root');
 
-        if ($nodes === false) {
+        if (! $root instanceof DOMElement) {
             return '';
         }
 
-        foreach (iterator_to_array($nodes) as $node) {
-            if (! $node instanceof \DOMElement || ! $node->parentNode) {
-                continue;
-            }
+        $this->sanitizeNode($root);
 
-            $nodeName = strtolower($node->nodeName);
-
-            if (! in_array($nodeName, self::ALLOWED_TAGS, true)) {
-                if (in_array($nodeName, self::DANGEROUS_TAGS, true)) {
-                    $node->parentNode->removeChild($node);
-                } else {
-                    while ($node->hasChildNodes()) {
-                        $node->parentNode->insertBefore($node->firstChild, $node);
-                    }
-                    $node->parentNode->removeChild($node);
-                }
-
-                continue;
-            }
-
-            foreach (iterator_to_array($node->attributes) as $attr) {
-                $attrName = strtolower($attr->nodeName);
-                if (! in_array($attrName, self::ALLOWED_ATTRIBUTES, true)) {
-                    $node->removeAttribute($attr->nodeName);
-
-                    continue;
-                }
-
-                if (in_array($attrName, ['href', 'src'], true)) {
-                    $val = rawurldecode($attr->nodeValue);
-                    $val = preg_replace('/\\\\+0|[\x00-\x1F\x7F-\x9F\s]/u', '', $val);
-
-                    if (preg_match('/^(javascript|data|vbscript|file):/i', $val)) {
-                        $node->removeAttribute($attr->nodeName);
-
-                        continue;
-                    }
-
-                    if ($nodeName === 'img' && $attrName === 'src') {
-                        $normalized = $this->normalizeImageSource($attr->nodeValue);
-                        if ($normalized === null) {
-                            $node->removeAttribute($attr->nodeName);
-                        } else {
-                            $node->setAttribute($attr->nodeName, $normalized);
-                        }
-                    }
-
-                    if ($nodeName === 'iframe' && $attrName === 'src') {
-                        $normalized = $this->normalizeEmbedSource($attr->nodeValue);
-                        if ($normalized === null) {
-                            $node->removeAttribute($attr->nodeName);
-                        } else {
-                            $node->setAttribute($attr->nodeName, $normalized);
-                        }
-                    }
-                }
-            }
-        }
-
-        $output = '';
-        foreach ($dom->childNodes as $node) {
-            if ($node->nodeType === XML_PI_NODE || $this->isEncodingMarkerComment($node)) {
-                continue;
-            }
-            $output .= $dom->saveHTML($node);
-        }
-
-        return trim($output);
-    }
-
-    private function isEncodingMarkerComment(\DOMNode $node): bool
-    {
-        return $node->nodeType === XML_COMMENT_NODE
-            && str_starts_with(trim($node->nodeValue ?? ''), '?xml encoding=');
+        return trim($this->innerHtml($root));
     }
 
     /**
@@ -413,6 +437,214 @@ class PageRenderer
         $trimmed = trim($normalized);
 
         return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function sanitizeNode(DOMNode $node): void
+    {
+        foreach (iterator_to_array($node->childNodes) as $child) {
+            if (! $child instanceof DOMElement) {
+                if ($child->nodeType === XML_COMMENT_NODE) {
+                    $node->removeChild($child);
+                }
+
+                continue;
+            }
+
+            $tag = strtolower($child->tagName);
+
+            if (! isset(self::ALLOWED_TAGS[$tag])) {
+                if (isset(self::DROP_WITH_CONTENT_TAGS[$tag])) {
+                    $node->removeChild($child);
+                } else {
+                    $this->sanitizeNode($child);
+                    $this->unwrapElement($child);
+                }
+
+                continue;
+            }
+
+            $this->sanitizeElement($child, $tag);
+            $this->sanitizeNode($child);
+
+            if ($this->shouldRemoveAfterSanitizing($child, $tag)) {
+                $child->parentNode?->removeChild($child);
+            }
+        }
+    }
+
+    private function sanitizeElement(DOMElement $element, string $tag): void
+    {
+        foreach (iterator_to_array($element->attributes) as $attribute) {
+            $name = strtolower($attribute->name);
+            $value = $attribute->value;
+
+            if (str_starts_with($name, 'on') || ! $this->isAllowedAttribute($tag, $name)) {
+                $element->removeAttributeNode($attribute);
+
+                continue;
+            }
+
+            $sanitizedValue = $this->sanitizeAttributeValue($tag, $name, $value);
+
+            if ($sanitizedValue === null) {
+                $element->removeAttributeNode($attribute);
+
+                continue;
+            }
+
+            $element->setAttribute($name, $sanitizedValue);
+        }
+
+        if ($tag === 'a' && $element->getAttribute('target') === '_blank') {
+            $rel = collect(explode(' ', strtolower($element->getAttribute('rel'))))
+                ->filter()
+                ->merge(['noopener', 'noreferrer'])
+                ->unique()
+                ->implode(' ');
+
+            $element->setAttribute('rel', $rel);
+        }
+
+        if ($tag === 'input') {
+            $element->setAttribute('type', 'checkbox');
+            $element->setAttribute('disabled', 'disabled');
+        }
+    }
+
+    private function sanitizeAttributeValue(string $tag, string $name, string $value): ?string
+    {
+        $decoded = trim(html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+        if ($decoded === '' && ! in_array($name, ['alt', 'checked', 'disabled', 'allowfullscreen'], true)) {
+            return null;
+        }
+
+        if ($name === 'style') {
+            return $this->sanitizeStyle($decoded);
+        }
+
+        if ($tag === 'a' && $name === 'href') {
+            return $this->isSafeUrl($decoded) ? $decoded : null;
+        }
+
+        if ($tag === 'img' && $name === 'src') {
+            return $this->normalizeImageSource($decoded);
+        }
+
+        if ($tag === 'iframe' && $name === 'src') {
+            return $this->normalizeEmbedSource($decoded);
+        }
+
+        if ($tag === 'oembed' && $name === 'url') {
+            return $this->normalizeEmbedSource($decoded);
+        }
+
+        if ($tag === 'input' && $name === 'type') {
+            return strtolower($decoded) === 'checkbox' ? 'checkbox' : null;
+        }
+
+        if ($name === 'target') {
+            return in_array($decoded, ['_blank', '_self'], true) ? $decoded : null;
+        }
+
+        if ($name === 'loading') {
+            return in_array($decoded, ['lazy', 'eager'], true) ? $decoded : null;
+        }
+
+        if ($name === 'referrerpolicy') {
+            return in_array($decoded, ['no-referrer', 'strict-origin', 'strict-origin-when-cross-origin'], true) ? $decoded : null;
+        }
+
+        if (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F]/u', $decoded)) {
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    private function sanitizeStyle(string $style): ?string
+    {
+        $declarations = [];
+
+        foreach (explode(';', $style) as $declaration) {
+            if (! str_contains($declaration, ':')) {
+                continue;
+            }
+
+            [$property, $value] = array_map('trim', explode(':', $declaration, 2));
+            $property = strtolower($property);
+            $normalizedValue = strtolower(html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+            if ($property === '' || $value === '') {
+                continue;
+            }
+
+            if (str_starts_with($property, 'behavior') || $property === '-moz-binding') {
+                continue;
+            }
+
+            if (Str::contains($normalizedValue, ['url(', 'expression', 'javascript:', 'vbscript:', 'data:', '@import'])) {
+                continue;
+            }
+
+            $declarations[] = "{$property}: {$value}";
+        }
+
+        return $declarations === [] ? null : implode('; ', $declarations);
+    }
+
+    private function isAllowedAttribute(string $tag, string $name): bool
+    {
+        if (in_array($name, self::GLOBAL_ATTRIBUTES, true)) {
+            return true;
+        }
+
+        if (str_starts_with($name, 'aria-') || str_starts_with($name, 'data-')) {
+            return true;
+        }
+
+        return in_array($name, self::TAG_ATTRIBUTES[$tag] ?? [], true);
+    }
+
+    private function shouldRemoveAfterSanitizing(DOMElement $element, string $tag): bool
+    {
+        return ($tag === 'img' || $tag === 'iframe') && ! $element->hasAttribute('src')
+            || $tag === 'oembed' && ! $element->hasAttribute('url');
+    }
+
+    private function isSafeUrl(string $url): bool
+    {
+        if (Str::startsWith($url, ['/', '#']) && ! Str::startsWith($url, '//')) {
+            return true;
+        }
+
+        return preg_match('#^(https?://|mailto:|tel:)#i', $url) === 1;
+    }
+
+    private function unwrapElement(DOMElement $element): void
+    {
+        $parent = $element->parentNode;
+
+        if (! $parent) {
+            return;
+        }
+
+        while ($element->firstChild) {
+            $parent->insertBefore($element->firstChild, $element);
+        }
+
+        $parent->removeChild($element);
+    }
+
+    private function innerHtml(DOMElement $element): string
+    {
+        $html = '';
+
+        foreach ($element->childNodes as $child) {
+            $html .= $element->ownerDocument?->saveHTML($child) ?? '';
+        }
+
+        return $html;
     }
 
     private function normalizeImageSource(string $src): ?string

--- a/app/Services/QueryService.php
+++ b/app/Services/QueryService.php
@@ -96,6 +96,7 @@ class QueryService
         $lastPage = 1;
         $allResults = collect();
         $rootField = $builder->getRootField();
+        $allowTransientRetries = ! $builder->isMutation();
 
         if ($headers) {
             $headersArray = $this->getHeaders();
@@ -108,7 +109,8 @@ class QueryService
             $builder,
             $variables,
             $rootField,
-            $headersArray
+            $headersArray,
+            $allowTransientRetries
         );
         $paginationEnabled = isset($firstResponse['paginatorInfo']);
         $allResults = $allResults->merge($firstResponse['data']);
@@ -130,7 +132,8 @@ class QueryService
                 $variables,
                 $page,
                 $maxConcurrency,
-                $lastPage
+                $lastPage,
+                $allowTransientRetries
             );
             $responses = Utils::settle($promises)->wait();
 
@@ -169,13 +172,14 @@ class QueryService
         GraphQLQueryBuilder $builder,
         array $variables,
         string $rootField,
-        array $headers = []
+        array $headers = [],
+        bool $allowTransientRetries = true
     ): array {
         $query = $builder->build();
         $retryCount = 0;
         $delay = $this->initialDelay;
 
-        $response = $this->sendPageQuery($query, $variables, $retryCount, $delay, $headers)->wait();
+        $response = $this->sendPageQuery($query, $variables, $retryCount, $delay, $headers, $allowTransientRetries)->wait();
 
         if ($response && isset($response['data'][$rootField])) {
             if (isset($response['data'][$rootField]['data'])) {
@@ -205,13 +209,14 @@ class QueryService
         array $variables,
         int &$retryCount,
         int &$delay,
-        array $headers = []
+        array $headers = [],
+        bool $allowTransientRetries = true
     ): PromiseInterface {
         return Http::async()->withHeaders($headers)->post(
             $this->endpoint(),
             ['query' => $query, 'variables' => $variables]
         )->then(
-            function ($response) use (&$retryCount, &$delay, $query, $variables, $headers) {
+            function ($response) use (&$retryCount, &$delay, $query, $variables, $headers, $allowTransientRetries) {
                 try {
                     if ($response instanceof Response) {
                         $this->sleepForRateLimitRemaining($response);
@@ -231,10 +236,14 @@ class QueryService
                             $retryCount++;
                             $delay *= 2;
 
-                            return $this->sendPageQuery($query, $variables, $retryCount, $delay, $headers);
+                            return $this->sendPageQuery($query, $variables, $retryCount, $delay, $headers, $allowTransientRetries);
                         }
 
                         if ($this->shouldRetryResponse($response)) {
+                            if (! $allowTransientRetries) {
+                                $this->throwAmbiguousMutationResponse($response);
+                            }
+
                             return $this->retryTransientResponse(
                                 $response,
                                 $query,
@@ -275,7 +284,11 @@ class QueryService
                     throw new ConnectionException('Failed to connect to the Politics & War API.');
                 }
             },
-            function ($reason) use (&$retryCount, &$delay, $query, $variables, $headers) {
+            function ($reason) use (&$retryCount, &$delay, $query, $variables, $headers, $allowTransientRetries) {
+                if (! $allowTransientRetries) {
+                    $this->throwAmbiguousMutationRejection($reason);
+                }
+
                 return $this->retryRejectedRequest(
                     $reason,
                     $query,
@@ -291,6 +304,40 @@ class QueryService
     protected function shouldRetryResponse(Response $response): bool
     {
         return $response->serverError() || $response->status() === 408;
+    }
+
+    /**
+     * @throws PWQueryFailedException
+     */
+    protected function throwAmbiguousMutationResponse(Response $response): never
+    {
+        $message = sprintf(
+            'GraphQL mutation failed with an ambiguous upstream response and was not retried: status=%d reason=%s body=%s',
+            $response->status(),
+            $response->reason() ?: 'unknown',
+            $response->body() !== '' ? $response->body() : '[empty]'
+        );
+
+        Log::error($message, [
+            'status' => $response->status(),
+            'headers' => $response->headers(),
+        ]);
+
+        throw new PWQueryFailedException($message);
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    protected function throwAmbiguousMutationRejection(mixed $reason): never
+    {
+        $message = $reason instanceof Throwable ? $reason->getMessage() : (string) $reason;
+
+        Log::error('GraphQL mutation request was rejected and was not retried.', [
+            'reason' => $message,
+        ]);
+
+        throw new ConnectionException("GraphQL mutation request failed without retry because the side effect may have succeeded: {$message}");
     }
 
     protected function retryTransientResponse(
@@ -413,7 +460,8 @@ class QueryService
         array $variables,
         int &$page,
         int $maxConcurrency,
-        int $lastPage
+        int $lastPage,
+        bool $allowTransientRetries = true
     ): array {
         $promises = [];
         $page++; // Increment page because we can assume we are already on page 2 if we hit this function
@@ -434,7 +482,8 @@ class QueryService
                 $currentPageQuery,
                 $variables,
                 $retryCount,
-                $delay
+                $delay,
+                allowTransientRetries: $allowTransientRetries
             );
 
             // Increment page after setting it for this request
@@ -495,7 +544,8 @@ class QueryService
             $builder,
             $variables,
             $rootField,
-            $headersArray
+            $headersArray,
+            ! $builder->isMutation()
         );
 
         $results = $results->merge($firstResponse['paginatorInfo']);

--- a/app/Services/RebuildingService.php
+++ b/app/Services/RebuildingService.php
@@ -211,29 +211,37 @@ class RebuildingService
      */
     public function approveRequest(RebuildingRequest $request, ?float $overrideAmount = null, ?string $reviewNote = null): void
     {
-        if ($request->status !== 'pending') {
-            throw ValidationException::withMessages([
-                'request' => 'Only pending requests can be approved.',
-            ]);
-        }
+        $approvedRequest = null;
+        $approvedAmount = 0;
 
-        app(SelfApprovalGuard::class)->ensureNotSelf(
-            requestNationId: $request->nation_id,
-            context: 'approve your own rebuilding request'
-        );
+        DB::transaction(function () use ($request, $overrideAmount, $reviewNote, &$approvedRequest, &$approvedAmount) {
+            $lockedRequest = RebuildingRequest::query()
+                ->with(['account', 'nation'])
+                ->lockForUpdate()
+                ->findOrFail($request->id);
 
-        $nation = $request->nation()->firstOrFail();
-        $eligibility = $this->evaluateEligibility($nation, $request->cycle_id);
-        if (! $eligibility['eligible']) {
-            throw ValidationException::withMessages([
-                'request' => $eligibility['reason'] ?? 'Nation is no longer eligible.',
-            ]);
-        }
+            if ($lockedRequest->status !== 'pending') {
+                throw ValidationException::withMessages([
+                    'request' => 'Only pending requests can be approved.',
+                ]);
+            }
 
-        $approvedAmount = max(0, (int) round($overrideAmount ?? $request->estimated_amount));
+            app(SelfApprovalGuard::class)->ensureNotSelf(
+                requestNationId: $lockedRequest->nation_id,
+                context: 'approve your own rebuilding request'
+            );
 
-        DB::transaction(function () use ($request, $approvedAmount, $reviewNote) {
-            $request->update([
+            $nation = $lockedRequest->nation()->firstOrFail();
+            $eligibility = $this->evaluateEligibility($nation, $lockedRequest->cycle_id);
+            if (! $eligibility['eligible']) {
+                throw ValidationException::withMessages([
+                    'request' => $eligibility['reason'] ?? 'Nation is no longer eligible.',
+                ]);
+            }
+
+            $approvedAmount = max(0, (int) round($overrideAmount ?? $lockedRequest->estimated_amount));
+
+            $lockedRequest->update([
                 'approved_amount' => $approvedAmount,
                 'review_note' => $reviewNote,
                 'status' => 'approved',
@@ -243,17 +251,18 @@ class RebuildingService
             ]);
 
             AccountService::adjustAccountBalance(
-                account: $request->account,
+                account: $lockedRequest->account,
                 adjustment: [
                     'money' => $approvedAmount,
-                    'note' => 'Approved rebuilding request ID #'.$request->id,
+                    'note' => 'Approved rebuilding request ID #'.$lockedRequest->id,
                 ],
                 adminId: auth()->id(),
                 ipAddress: request()->ip()
             );
 
-            $request->nation->notify(new RebuildingNotification($request->nation_id, $request->fresh('account'), 'approved'));
-        });
+            $approvedRequest = $lockedRequest->fresh('account');
+            $lockedRequest->nation->notify(new RebuildingNotification($lockedRequest->nation_id, $approvedRequest, 'approved'));
+        }, attempts: 3);
 
         app(PendingRequestsService::class)->flushCache();
 
@@ -262,17 +271,17 @@ class RebuildingService
             action: 'rebuilding_approved',
             outcome: 'success',
             severity: 'info',
-            subject: $request,
+            subject: $approvedRequest,
             context: [
                 'data' => [
-                    'nation_id' => $request->nation_id,
+                    'nation_id' => $approvedRequest?->nation_id,
                     'amount' => $approvedAmount,
                 ],
             ],
             message: 'Rebuilding request approved.'
         );
 
-        $this->dispatchRebuildingExpenseEvent($request->fresh(), $approvedAmount);
+        $this->dispatchRebuildingExpenseEvent($approvedRequest, $approvedAmount);
     }
 
     /**
@@ -280,26 +289,37 @@ class RebuildingService
      */
     public function denyRequest(RebuildingRequest $request, ?string $reviewNote = null): void
     {
-        if ($request->status !== 'pending') {
-            throw ValidationException::withMessages([
-                'request' => 'Only pending requests can be denied.',
+        $deniedRequest = null;
+
+        DB::transaction(function () use ($request, $reviewNote, &$deniedRequest) {
+            $lockedRequest = RebuildingRequest::query()
+                ->with(['account', 'nation'])
+                ->lockForUpdate()
+                ->findOrFail($request->id);
+
+            if ($lockedRequest->status !== 'pending') {
+                throw ValidationException::withMessages([
+                    'request' => 'Only pending requests can be denied.',
+                ]);
+            }
+
+            app(SelfApprovalGuard::class)->ensureNotSelf(
+                requestNationId: $lockedRequest->nation_id,
+                context: 'deny your own rebuilding request'
+            );
+
+            $lockedRequest->update([
+                'review_note' => $reviewNote,
+                'status' => 'denied',
+                'pending_key' => null,
+                'denied_at' => now(),
+                'denied_by' => auth()->id(),
             ]);
-        }
 
-        app(SelfApprovalGuard::class)->ensureNotSelf(
-            requestNationId: $request->nation_id,
-            context: 'deny your own rebuilding request'
-        );
+            $deniedRequest = $lockedRequest->fresh('account');
+        }, attempts: 3);
 
-        $request->update([
-            'review_note' => $reviewNote,
-            'status' => 'denied',
-            'pending_key' => null,
-            'denied_at' => now(),
-            'denied_by' => auth()->id(),
-        ]);
-
-        $request->nation->notify(new RebuildingNotification($request->nation_id, $request->fresh('account'), 'denied'));
+        $deniedRequest->nation->notify(new RebuildingNotification($deniedRequest->nation_id, $deniedRequest, 'denied'));
         app(PendingRequestsService::class)->flushCache();
 
         app(AuditLogger::class)->recordAfterCommit(
@@ -307,10 +327,10 @@ class RebuildingService
             action: 'rebuilding_denied',
             outcome: 'denied',
             severity: 'warning',
-            subject: $request,
+            subject: $deniedRequest,
             context: [
                 'data' => [
-                    'nation_id' => $request->nation_id,
+                    'nation_id' => $deniedRequest->nation_id,
                 ],
             ],
             message: 'Rebuilding request denied.'

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Afacad+Flux:wght@500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap");
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @plugin "daisyui" {
@@ -6,6 +7,21 @@
 @source "../../vendor/robsontenorio/mary/src/View/Components/**/*.php";
 
 @layer base {
+    :root {
+        --space-2xs: 0.25rem;
+        --space-xs: 0.5rem;
+        --space-sm: 0.75rem;
+        --space-md: 1rem;
+        --space-lg: 1.5rem;
+        --space-xl: 2rem;
+        --space-2xl: 3rem;
+    }
+
+    html,
+    body {
+        font-family: "Manrope", "Segoe UI", sans-serif;
+    }
+
     img,
     video,
     iframe,
@@ -69,6 +85,493 @@
 }
 
 @layer components {
+    .font-display {
+        font-family: "Afacad Flux", "Trebuchet MS", sans-serif;
+        letter-spacing: -0.035em;
+    }
+
+    .nexus-user-shell {
+        --nexus-shell-ink: oklch(0.27 0.008 240);
+        --nexus-shell-muted: oklch(0.49 0.007 240);
+        --nexus-shell-border: oklch(0.85 0.004 240 / 0.84);
+        --nexus-shell-panel: oklch(0.978 0.001 240);
+        --nexus-shell-panel-strong: oklch(0.952 0.003 240);
+        --nexus-shell-panel-soft: oklch(0.958 0.003 240 / 0.88);
+        --nexus-shell-accent: oklch(0.56 0.01 240);
+        --nexus-shell-highlight: oklch(0.72 0.004 240 / 0.18);
+        --nexus-shell-line: oklch(0.76 0.008 240 / 0.3);
+        --nexus-chart-primary: #586274;
+        --nexus-chart-success: #6a7485;
+        --nexus-chart-info: #7b8595;
+        --nexus-chart-warning: #8c95a4;
+        --nexus-chart-danger: #4a5363;
+        --nexus-chart-neutral: #9ca3af;
+        --nexus-chart-text: #4b5564;
+        --nexus-chart-grid: rgba(107, 114, 128, 0.16);
+        --nexus-chart-tooltip: rgba(24, 29, 38, 0.95);
+        --nexus-chart-tooltip-border: rgba(148, 163, 184, 0.18);
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        color: var(--nexus-shell-ink);
+    }
+
+    [data-theme="night"] .nexus-user-shell,
+    .night .nexus-user-shell {
+        --nexus-shell-ink: oklch(0.92 0.006 240);
+        --nexus-shell-muted: oklch(0.75 0.007 240);
+        --nexus-shell-border: oklch(0.35 0.006 240 / 0.88);
+        --nexus-shell-panel: oklch(0.22 0.003 240);
+        --nexus-shell-panel-strong: oklch(0.25 0.004 240);
+        --nexus-shell-panel-soft: oklch(0.28 0.004 240 / 0.9);
+        --nexus-shell-accent: oklch(0.72 0.012 240);
+        --nexus-shell-highlight: oklch(0.62 0.005 240 / 0.14);
+        --nexus-shell-line: oklch(0.56 0.01 240 / 0.22);
+        --nexus-chart-primary: #b2bac6;
+        --nexus-chart-success: #9ea7b4;
+        --nexus-chart-info: #8d97a4;
+        --nexus-chart-warning: #c4ccd7;
+        --nexus-chart-danger: #d7dde6;
+        --nexus-chart-neutral: #7a8595;
+        --nexus-chart-text: #d7dfeb;
+        --nexus-chart-grid: rgba(148, 163, 184, 0.16);
+        --nexus-chart-tooltip: rgba(12, 16, 23, 0.95);
+        --nexus-chart-tooltip-border: rgba(148, 163, 184, 0.18);
+    }
+
+    .nexus-user-shell::before,
+    .nexus-user-shell::after {
+        content: "";
+        pointer-events: none;
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+    }
+
+    .nexus-user-shell::before {
+        background:
+            radial-gradient(circle at top right, color-mix(in oklab, var(--nexus-shell-accent) 12%, transparent) 0, transparent 30%),
+            radial-gradient(circle at 8% 36%, color-mix(in oklab, var(--nexus-shell-highlight) 76%, transparent) 0, transparent 24%);
+        opacity: 0.78;
+    }
+
+    .nexus-user-shell::after {
+        background-image:
+            linear-gradient(to right, color-mix(in oklab, var(--nexus-shell-line) 86%, transparent) 1px, transparent 1px),
+            linear-gradient(to bottom, color-mix(in oklab, var(--nexus-shell-line) 78%, transparent) 1px, transparent 1px);
+        background-position: top left;
+        background-size: 132px 132px;
+        mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.32), transparent 78%);
+        opacity: 0.14;
+    }
+
+    .nexus-user-panel {
+        border: 1px solid var(--nexus-shell-border);
+        background: linear-gradient(180deg, var(--nexus-shell-panel), var(--nexus-shell-panel-strong));
+        box-shadow: 0 16px 32px rgba(28, 20, 13, 0.045);
+        border-radius: 1.4rem;
+    }
+
+    .nexus-user-panel-soft {
+        border: 1px solid color-mix(in oklab, var(--nexus-shell-border) 86%, transparent);
+        background: color-mix(in oklab, var(--nexus-shell-panel-soft) 90%, transparent);
+        border-radius: 1.1rem;
+    }
+
+    .nexus-user-masthead {
+        position: relative;
+        overflow: hidden;
+        padding: 1.4rem;
+    }
+
+    .nexus-user-masthead::before,
+    .nexus-user-masthead::after {
+        content: "";
+        position: absolute;
+        border-radius: 9999px;
+        filter: blur(28px);
+        opacity: 0.72;
+    }
+
+    .nexus-user-masthead::before {
+        width: 13rem;
+        height: 13rem;
+        right: -4rem;
+        top: -4rem;
+        background: color-mix(in oklab, var(--nexus-shell-accent) 14%, transparent);
+    }
+
+    .nexus-user-masthead::after {
+        width: 9rem;
+        height: 9rem;
+        left: -2rem;
+        bottom: -4rem;
+        background: color-mix(in oklab, var(--nexus-shell-highlight) 82%, transparent);
+    }
+
+    .nexus-user-eyebrow {
+        color: var(--nexus-shell-muted);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+    }
+
+    .nexus-user-title {
+        color: var(--nexus-shell-ink);
+        font-family: "Afacad Flux", "Trebuchet MS", sans-serif;
+        font-size: 2.35rem;
+        font-weight: 800;
+        line-height: 0.9;
+        max-width: 10ch;
+        overflow-wrap: anywhere;
+    }
+
+    .nexus-user-body {
+        color: var(--nexus-shell-muted);
+        font-size: 0.95rem;
+        line-height: 1.72;
+        max-width: 60ch;
+    }
+
+    .nexus-user-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-xs);
+        border: 1px solid color-mix(in oklab, var(--nexus-shell-border) 90%, transparent);
+        background: color-mix(in oklab, var(--nexus-shell-panel) 96%, transparent);
+        border-radius: 9999px;
+        padding: 0.42rem 0.72rem;
+        color: var(--nexus-shell-ink);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .nexus-user-ribbon {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 0;
+    }
+
+    .nexus-user-ribbon-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+        min-width: 0;
+        padding: 1.2rem 1.25rem;
+    }
+
+    .nexus-user-ribbon-item + .nexus-user-ribbon-item {
+        border-left: 1px solid color-mix(in oklab, var(--nexus-shell-border) 82%, transparent);
+    }
+
+    .nexus-user-stat-label {
+        color: var(--nexus-shell-muted);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+    }
+
+    .nexus-user-stat-value {
+        color: var(--nexus-shell-ink);
+        font-family: "Afacad Flux", "Trebuchet MS", sans-serif;
+        font-size: 2rem;
+        font-weight: 800;
+        line-height: 0.95;
+        overflow-wrap: anywhere;
+    }
+
+    .nexus-user-stat-copy {
+        color: var(--nexus-shell-muted);
+        font-size: 0.85rem;
+        line-height: 1.55;
+        max-width: 28ch;
+    }
+
+    .nexus-user-command-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .nexus-user-command-row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 1rem;
+        align-items: start;
+        min-width: 0;
+        padding: 1rem 0;
+        border-top: 1px solid color-mix(in oklab, var(--nexus-shell-border) 82%, transparent);
+    }
+
+    .nexus-user-command-row:first-child {
+        border-top: 0;
+        padding-top: 0.2rem;
+    }
+
+    .nexus-user-command-row:last-child {
+        padding-bottom: 0.2rem;
+    }
+
+    .nexus-user-section-head {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.9rem;
+    }
+
+    .nexus-user-section-title {
+        color: var(--nexus-shell-ink);
+        font-family: "Afacad Flux", "Trebuchet MS", sans-serif;
+        font-size: 1.45rem;
+        font-weight: 700;
+        line-height: 1;
+    }
+
+    .nexus-user-section-copy {
+        color: var(--nexus-shell-muted);
+        font-size: 0.92rem;
+        line-height: 1.65;
+        max-width: 60ch;
+    }
+
+    .nexus-user-status-dot {
+        width: 0.55rem;
+        height: 0.55rem;
+        border-radius: 9999px;
+        background: currentColor;
+        box-shadow: 0 0 0 0.22rem color-mix(in oklab, currentColor 22%, transparent);
+    }
+
+    .nexus-user-status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.55rem;
+        border-radius: 9999px;
+        padding: 0.45rem 0.78rem;
+        font-size: 0.77rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .nexus-user-status-pill-success {
+        background: color-mix(in oklab, oklch(0.77 0.08 155) 14%, transparent);
+        color: oklch(0.49 0.11 155);
+    }
+
+    .nexus-user-status-pill-warning {
+        background: color-mix(in oklab, oklch(0.78 0.12 78) 16%, transparent);
+        color: oklch(0.5 0.11 70);
+    }
+
+    .nexus-user-status-pill-error {
+        background: color-mix(in oklab, oklch(0.73 0.12 28) 14%, transparent);
+        color: oklch(0.5 0.12 28);
+    }
+
+    .nexus-user-status-pill-neutral {
+        background: color-mix(in oklab, var(--nexus-shell-muted) 11%, transparent);
+        color: var(--nexus-shell-muted);
+    }
+
+    .nexus-user-ledger {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+    }
+
+    .nexus-user-ledger-item {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.9rem;
+        align-items: start;
+        border-top: 1px solid color-mix(in oklab, var(--nexus-shell-border) 82%, transparent);
+        padding: 0.95rem 0;
+    }
+
+    .nexus-user-ledger-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.35rem;
+        height: 2.35rem;
+        border-radius: 9999px;
+        background: color-mix(in oklab, var(--nexus-shell-accent) 10%, transparent);
+        color: var(--nexus-shell-accent);
+    }
+
+    .nexus-user-data-grid {
+        display: grid;
+        gap: 0.7rem;
+    }
+
+    .nexus-user-data-grid-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .nexus-user-data-tile {
+        border-top: 1px solid color-mix(in oklab, var(--nexus-shell-border) 74%, transparent);
+        padding-top: 0.6rem;
+    }
+
+    .nexus-user-data-label {
+        color: var(--nexus-shell-muted);
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .nexus-user-data-value {
+        color: var(--nexus-shell-ink);
+        font-size: 1rem;
+        font-weight: 800;
+        line-height: 1.3;
+        margin-top: 0.22rem;
+        overflow-wrap: anywhere;
+    }
+
+    .nexus-user-progress {
+        overflow: hidden;
+        height: 0.52rem;
+        border-radius: 9999px;
+        background: color-mix(in oklab, var(--nexus-shell-border) 45%, transparent);
+    }
+
+    .nexus-user-progress > span {
+        display: block;
+        height: 100%;
+        border-radius: inherit;
+        background: linear-gradient(90deg, var(--nexus-shell-accent), color-mix(in oklab, var(--nexus-shell-highlight) 86%, white));
+    }
+
+    .nexus-user-chart-card {
+        overflow: hidden;
+    }
+
+    .nexus-user-chart-tab {
+        border-bottom-width: 2px;
+        padding: 0.85rem 0.3rem 0.7rem;
+        color: var(--nexus-shell-muted);
+        font-size: 0.76rem;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        transition: color 180ms ease, border-color 180ms ease;
+    }
+
+    .nexus-user-chart-tab-active {
+        border-color: var(--nexus-shell-accent);
+        color: var(--nexus-shell-ink);
+    }
+
+    .nexus-user-table thead tr {
+        color: var(--nexus-shell-muted);
+        font-size: 0.72rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+    }
+
+    .nexus-user-table tbody tr {
+        border-top: 1px solid color-mix(in oklab, var(--nexus-shell-border) 78%, transparent);
+    }
+
+    .nexus-user-table tbody tr:hover {
+        background: color-mix(in oklab, var(--nexus-shell-panel-soft) 66%, transparent);
+    }
+
+    .nexus-user-table :where(th, td) {
+        padding: 0.95rem 1rem;
+        white-space: nowrap;
+    }
+
+    .nexus-user-empty {
+        display: flex;
+        min-height: 16rem;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.6rem;
+        color: var(--nexus-shell-muted);
+        text-align: center;
+    }
+
+    .nexus-user-divider-y {
+        border-top: 1px solid color-mix(in oklab, var(--nexus-shell-border) 82%, transparent);
+    }
+
+    .nexus-user-kicker-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+    }
+
+    .nexus-user-side-rail {
+        background: color-mix(in oklab, var(--nexus-shell-panel-soft) 56%, transparent);
+    }
+
+    .nexus-user-microcopy {
+        color: var(--nexus-shell-muted);
+        font-size: 0.82rem;
+        line-height: 1.6;
+        max-width: 28ch;
+    }
+
+    @media (max-width: 767.98px) {
+        .nexus-user-masthead {
+            padding: 1.1rem;
+        }
+
+        .nexus-user-title {
+            font-size: 1.95rem;
+        }
+
+        .nexus-user-ribbon {
+            grid-template-columns: 1fr;
+        }
+
+        .nexus-user-ribbon-item + .nexus-user-ribbon-item {
+            border-left: 0;
+            border-top: 1px solid color-mix(in oklab, var(--nexus-shell-border) 82%, transparent);
+        }
+
+        .nexus-user-command-row {
+            grid-template-columns: 1fr;
+        }
+
+        .nexus-user-ledger-item {
+            grid-template-columns: 1fr;
+        }
+
+        .nexus-user-data-grid-2 {
+            grid-template-columns: 1fr;
+        }
+
+        .nexus-user-table :where(th, td) {
+            padding-inline: 0.8rem;
+        }
+    }
+
+    @media (min-width: 768px) {
+        .nexus-user-shell {
+            gap: 1.4rem;
+        }
+
+        .nexus-user-masthead {
+            padding: 1.6rem;
+        }
+
+        .nexus-user-title {
+            font-size: 2.85rem;
+        }
+    }
+
     .row {
         @apply grid grid-cols-12 gap-4;
     }

--- a/resources/views/components/admin/sync-card.blade.php
+++ b/resources/views/components/admin/sync-card.blade.php
@@ -4,11 +4,10 @@
     <x-slot:menu>
         @if($batch && !$batch->finished())
             <div class="flex items-center gap-2">
-                <x-button label="Syncing..." icon="o-arrow-path" class="btn-sm btn-ghost" disabled>
-                    <x-slot:icon>
-                        <span class="loading loading-spinner loading-xs"></span>
-                    </x-slot:icon>
-                </x-button>
+                <button type="button" class="btn btn-sm btn-ghost" disabled>
+                    <span class="loading loading-spinner loading-xs"></span>
+                    <span>Syncing...</span>
+                </button>
                 <form method="POST" action="{{ route('admin.settings.sync.cancel') }}"
                       onsubmit="return confirm('Are you sure you want to cancel this sync?')">
                     @csrf

--- a/resources/views/components/user/military-comparison.blade.php
+++ b/resources/views/components/user/military-comparison.blade.php
@@ -1,66 +1,70 @@
 @props(['nation', 'latestSignIn' => null, 'requirements' => [], 'meets' => false])
 
-<div class="card bg-base-100 shadow">
-    <div class="card-body">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-            <div>
-                <h3 class="card-title">Military vs Required</h3>
-                <p class="text-sm text-base-content/70">Minimum counts based on your current city tier.</p>
-            </div>
-            <span class="badge {{ $meets ? 'badge-success badge-outline badge-nowrap' : 'badge-warning badge-outline badge-nowrap' }}">
-                {{ $meets ? 'Ready for duty' : 'Needs build' }}
-            </span>
+<div>
+    <div class="nexus-user-section-head">
+        <div>
+            <p class="nexus-user-eyebrow">Force posture</p>
+            <h3 class="nexus-user-section-title">Military compliance</h3>
+            <p class="nexus-user-section-copy">Minimum counts are derived from your current city tier and latest sync.</p>
         </div>
+        <span class="nexus-user-status-pill {{ $meets ? 'nexus-user-status-pill-success' : 'nexus-user-status-pill-warning' }}">
+            {{ $meets ? 'Ready for ops' : 'Needs build' }}
+        </span>
+    </div>
 
-        @php
-            $units = ['soldiers', 'tanks', 'aircraft', 'ships', 'missiles', 'nukes', 'spies'];
-        @endphp
+    @php
+        $units = ['soldiers', 'tanks', 'aircraft', 'ships', 'missiles', 'nukes', 'spies'];
+    @endphp
 
-        <div class="mt-3 space-y-3 xl:hidden">
-            @foreach ($units as $unit)
-                @php
-                    $current = $latestSignIn->$unit ?? $nation->$unit ?? 0;
-                    $required = $requirements[$unit] ?? 0;
-                    $percent = $required > 0 ? min(100, round(($current / $required) * 100, 1)) : 100;
-                    $met = $required === 0 ? true : $current >= $required;
-                @endphp
-                <div class="rounded-xl border border-base-200 p-3">
-                    <div class="flex items-center justify-between gap-2">
-                        <p class="text-sm font-semibold capitalize">{{ $unit }}</p>
-                        <span class="badge {{ $met ? 'badge-success badge-outline badge-nowrap' : 'badge-warning badge-outline badge-nowrap' }}">
-                            {{ $met ? 'On target' : 'Needs build' }}
-                        </span>
-                    </div>
-                    <div class="mt-2 grid grid-cols-2 gap-2 text-xs">
-                        <div class="rounded-lg bg-base-200/60 px-2 py-1">
-                            <p class="text-base-content/60">Current</p>
-                            <p class="font-semibold text-sm">{{ number_format($current) }}</p>
-                        </div>
-                        <div class="rounded-lg bg-base-200/60 px-2 py-1">
-                            <p class="text-base-content/60">Required</p>
-                            <p class="font-semibold text-sm">{{ number_format($required) }}</p>
-                        </div>
-                        <div class="col-span-2 rounded-lg bg-base-200/60 px-2 py-1">
-                            <p class="text-base-content/60">Progress</p>
-                            <p class="font-semibold text-sm">{{ $percent }}%</p>
-                        </div>
-                    </div>
-                    <progress class="progress {{ $met ? 'progress-primary' : 'progress-warning' }} mt-2 w-full" value="{{ $percent }}" max="100"></progress>
+    <div class="mt-5 space-y-4 xl:hidden">
+        @foreach ($units as $unit)
+            @php
+                $current = $latestSignIn->$unit ?? $nation->$unit ?? 0;
+                $required = $requirements[$unit] ?? 0;
+                $percent = $required > 0 ? min(100, round(($current / $required) * 100, 1)) : 100;
+                $met = $required === 0 ? true : $current >= $required;
+            @endphp
+            <div class="nexus-user-divider-y pt-4 first:border-t-0 first:pt-0">
+                <div class="flex items-center justify-between gap-3">
+                    <p class="font-semibold capitalize text-base-content">{{ $unit }}</p>
+                    <span class="nexus-user-status-pill {{ $met ? 'nexus-user-status-pill-success' : 'nexus-user-status-pill-warning' }}">
+                        {{ $met ? 'On target' : 'Needs build' }}
+                    </span>
                 </div>
-            @endforeach
-        </div>
 
-        <div class="mt-3 hidden overflow-x-auto xl:block">
-            <table class="table table-zebra md:table-fixed">
-                <thead>
+                <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                        <p class="nexus-user-data-label">Current</p>
+                        <p class="mt-1 font-semibold text-base-content">{{ number_format($current) }}</p>
+                    </div>
+                    <div>
+                        <p class="nexus-user-data-label">Required</p>
+                        <p class="mt-1 font-semibold text-base-content">{{ number_format($required) }}</p>
+                    </div>
+                    <div class="col-span-2">
+                        <p class="nexus-user-data-label">Progress</p>
+                        <p class="mt-1 font-semibold text-base-content">{{ $percent }}%</p>
+                    </div>
+                </div>
+
+                <div class="mt-3 nexus-user-progress">
+                    <span style="width: {{ $percent }}%"></span>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="mt-5 hidden overflow-x-auto xl:block">
+        <table class="table nexus-user-table">
+            <thead>
                 <tr>
                     <th>Unit</th>
-                    <th>Current</th>
-                    <th>Required</th>
-                    <th>Status</th>
+                    <th class="text-right">Current</th>
+                    <th class="text-right">Required</th>
+                    <th class="w-56">Status</th>
                 </tr>
-                </thead>
-                <tbody>
+            </thead>
+            <tbody>
                 @foreach ($units as $unit)
                     @php
                         $current = $latestSignIn->$unit ?? $nation->$unit ?? 0;
@@ -69,24 +73,25 @@
                         $met = $required === 0 ? true : $current >= $required;
                     @endphp
                     <tr>
-                        <td class="capitalize">{{ $unit }}</td>
-                        <td>{{ number_format($current) }}</td>
-                        <td>{{ number_format($required) }}</td>
-                        <td>
-                            <div class="flex flex-col gap-1">
-                                <div class="flex items-center justify-between text-sm">
-                                    <span class="font-semibold">{{ $percent }}%</span>
-                                    <span class="badge {{ $met ? 'badge-success badge-outline badge-nowrap' : 'badge-warning badge-outline badge-nowrap' }}">
+                        <td class="font-semibold capitalize text-base-content">{{ $unit }}</td>
+                        <td class="text-right tabular-nums">{{ number_format($current) }}</td>
+                        <td class="text-right tabular-nums">{{ number_format($required) }}</td>
+                        <td class="w-56">
+                            <div class="flex flex-col gap-2">
+                                <div class="flex items-center justify-between gap-3 text-sm">
+                                    <span class="font-semibold text-base-content">{{ $percent }}%</span>
+                                    <span class="nexus-user-status-pill {{ $met ? 'nexus-user-status-pill-success' : 'nexus-user-status-pill-warning' }}">
                                         {{ $met ? 'On target' : 'Needs build' }}
                                     </span>
                                 </div>
-                                <progress class="progress {{ $met ? 'progress-primary' : 'progress-warning' }} w-full" value="{{ $percent }}" max="100"></progress>
+                                <div class="nexus-user-progress">
+                                    <span style="width: {{ $percent }}%"></span>
+                                </div>
                             </div>
                         </td>
                     </tr>
                 @endforeach
-                </tbody>
-            </table>
-        </div>
+            </tbody>
+        </table>
     </div>
 </div>

--- a/resources/views/components/user/resource-comparison.blade.php
+++ b/resources/views/components/user/resource-comparison.blade.php
@@ -1,108 +1,117 @@
 @props(['resources' => [], 'weights' => []])
 
-<div class="card bg-base-100 shadow">
-    <div class="card-body">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-            <div>
-                <h3 class="card-title">Resources vs Required</h3>
-                <p class="text-sm text-base-content/70">Totals include per-city requirements multiplied by your city count.</p>
-            </div>
-            @if(!empty($resources))
-                <div class="badge badge-outline">
-                    Weighted total {{ number_format(array_sum($weights ?? []), 0) }}%
+<div>
+    <div class="nexus-user-section-head">
+        <div>
+            <p class="nexus-user-eyebrow">Stockpile</p>
+            <h3 class="nexus-user-section-title">Resource compliance</h3>
+            <p class="nexus-user-section-copy">Totals reflect current reserves against your doctrine requirement.</p>
+        </div>
+        @if(! empty($resources))
+            <span class="nexus-user-status-pill nexus-user-status-pill-neutral">
+                Weighted total {{ number_format(array_sum($weights ?? []), 0) }}%
+            </span>
+        @endif
+    </div>
+
+    @if(empty($resources))
+        <div class="mt-5 text-sm text-base-content/60">
+            No MMR snapshot is available yet. Sign in to Politics &amp; War to generate a stockpile comparison.
+        </div>
+    @else
+        @php
+            $resourceOrder = ['money', 'steel', 'aluminum', 'munitions', 'gasoline', 'uranium', 'food'];
+        @endphp
+
+        <div class="mt-5 space-y-4 xl:hidden">
+            @foreach ($resourceOrder as $resource)
+                @php
+                    $row = $resources[$resource] ?? [];
+                    $have = $row['have'] ?? 0;
+                    $required = $row['required'] ?? 0;
+                    $progress = $row['progress'] ?? 0;
+                    $percent = $required <= 0 ? 100 : min(100, round($progress * 100, 1));
+                    $met = $row['met'] ?? false;
+                    $weight = $row['weight'] ?? ($weights[$resource] ?? 0);
+                @endphp
+                <div class="nexus-user-divider-y pt-4 first:border-t-0 first:pt-0">
+                    <div class="flex items-center justify-between gap-3">
+                        <p class="font-semibold capitalize text-base-content">{{ $resource }}</p>
+                        <span class="nexus-user-status-pill {{ $met ? 'nexus-user-status-pill-success' : 'nexus-user-status-pill-warning' }}">
+                            {{ $met ? 'On target' : 'Needs stockpile' }}
+                        </span>
+                    </div>
+
+                    <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
+                        <div>
+                            <p class="nexus-user-data-label">Current</p>
+                            <p class="mt-1 font-semibold text-base-content">{{ number_format($have) }}</p>
+                        </div>
+                        <div>
+                            <p class="nexus-user-data-label">Required</p>
+                            <p class="mt-1 font-semibold text-base-content">{{ number_format($required) }}</p>
+                        </div>
+                        <div>
+                            <p class="nexus-user-data-label">Weight</p>
+                            <p class="mt-1 font-semibold text-base-content">{{ number_format($weight, 2) }}%</p>
+                        </div>
+                        <div>
+                            <p class="nexus-user-data-label">Progress</p>
+                            <p class="mt-1 font-semibold text-base-content">{{ $percent }}%</p>
+                        </div>
+                    </div>
+
+                    <div class="mt-3 nexus-user-progress">
+                        <span style="width: {{ $percent }}%"></span>
+                    </div>
                 </div>
-            @endif
+            @endforeach
         </div>
 
-        @if(empty($resources))
-            <p class="text-sm text-base-content/70 mt-2">No MMR snapshot yet. Sign in to see your resource compliance.</p>
-        @else
-            @php
-                $resourceOrder = ['money', 'steel', 'aluminum', 'munitions', 'gasoline', 'uranium', 'food'];
-            @endphp
-            <div class="mt-3 space-y-3 xl:hidden">
-                @foreach ($resourceOrder as $res)
-                    @php
-                        $row = $resources[$res] ?? [];
-                        $have = $row['have'] ?? 0;
-                        $required = $row['required'] ?? 0;
-                        $progress = $row['progress'] ?? 0;
-                        $percent = $required <= 0 ? 100 : min(100, round($progress * 100, 1));
-                        $met = $row['met'] ?? false;
-                        $weight = $row['weight'] ?? ($weights[$res] ?? 0);
-                    @endphp
-                    <div class="rounded-xl border border-base-200 p-3">
-                        <div class="flex items-center justify-between gap-2">
-                            <p class="text-sm font-semibold capitalize">{{ $res }}</p>
-                            <span class="badge {{ $met ? 'badge-success badge-outline badge-nowrap' : 'badge-warning badge-outline badge-nowrap' }}">
-                                {{ $met ? 'On target' : 'Needs build' }}
-                            </span>
-                        </div>
-                        <div class="mt-2 grid grid-cols-2 gap-2 text-xs">
-                            <div class="rounded-lg bg-base-200/60 px-2 py-1">
-                                <p class="text-base-content/60">Current</p>
-                                <p class="font-semibold text-sm">{{ number_format($have) }}</p>
-                            </div>
-                            <div class="rounded-lg bg-base-200/60 px-2 py-1">
-                                <p class="text-base-content/60">Required</p>
-                                <p class="font-semibold text-sm">{{ number_format($required) }}</p>
-                            </div>
-                            <div class="rounded-lg bg-base-200/60 px-2 py-1">
-                                <p class="text-base-content/60">Weight</p>
-                                <p class="font-semibold text-sm">{{ number_format($weight, 2) }}%</p>
-                            </div>
-                            <div class="rounded-lg bg-base-200/60 px-2 py-1">
-                                <p class="text-base-content/60">Progress</p>
-                                <p class="font-semibold text-sm">{{ $percent }}%</p>
-                            </div>
-                        </div>
-                        <progress class="progress {{ $met ? 'progress-primary' : 'progress-warning' }} mt-2 w-full" value="{{ $percent }}" max="100"></progress>
-                    </div>
-                @endforeach
-            </div>
-            <div class="mt-3 hidden overflow-x-auto xl:block">
-                <table class="table table-zebra md:table-fixed">
-                    <thead>
+        <div class="mt-5 hidden overflow-x-auto xl:block">
+            <table class="table nexus-user-table">
+                <thead>
                     <tr>
-                        <th class="whitespace-nowrap">Resource</th>
-                        <th class="whitespace-nowrap text-right">Current</th>
-                        <th class="whitespace-nowrap text-right">Required</th>
-                        <th class="whitespace-nowrap text-right">Weight</th>
-                        <th class="w-48">Status</th>
+                        <th>Resource</th>
+                        <th class="text-right">Current</th>
+                        <th class="text-right">Required</th>
+                        <th class="text-right">Weight</th>
+                        <th class="w-56">Status</th>
                     </tr>
-                    </thead>
-                    <tbody>
-                    @foreach ($resourceOrder as $res)
+                </thead>
+                <tbody>
+                    @foreach ($resourceOrder as $resource)
                         @php
-                            $row = $resources[$res] ?? [];
+                            $row = $resources[$resource] ?? [];
                             $have = $row['have'] ?? 0;
                             $required = $row['required'] ?? 0;
                             $progress = $row['progress'] ?? 0;
                             $percent = $required <= 0 ? 100 : min(100, round($progress * 100, 1));
                             $met = $row['met'] ?? false;
-                            $weight = $row['weight'] ?? ($weights[$res] ?? 0);
+                            $weight = $row['weight'] ?? ($weights[$resource] ?? 0);
                         @endphp
                         <tr>
-                            <td class="capitalize whitespace-nowrap">{{ $res }}</td>
-                            <td class="text-right tabular-nums whitespace-nowrap">{{ number_format($have) }}</td>
-                            <td class="text-right tabular-nums whitespace-nowrap">{{ number_format($required) }}</td>
-                            <td class="text-right tabular-nums whitespace-nowrap">{{ number_format($weight, 2) }}%</td>
-                            <td class="w-48">
-                                <div class="flex flex-col gap-1">
-                                    <div class="flex items-center justify-between text-sm">
-                                        <span class="font-semibold">{{ $percent }}%</span>
-                                        <span class="badge {{ $met ? 'badge-success badge-outline badge-nowrap' : 'badge-warning badge-outline badge-nowrap' }}">
-                                            {{ $met ? 'On target' : 'Needs build' }}
+                            <td class="font-semibold capitalize text-base-content">{{ $resource }}</td>
+                            <td class="text-right tabular-nums">{{ number_format($have) }}</td>
+                            <td class="text-right tabular-nums">{{ number_format($required) }}</td>
+                            <td class="text-right tabular-nums">{{ number_format($weight, 2) }}%</td>
+                            <td class="w-56">
+                                <div class="flex flex-col gap-2">
+                                    <div class="flex items-center justify-between gap-3 text-sm">
+                                        <span class="font-semibold text-base-content">{{ $percent }}%</span>
+                                        <span class="nexus-user-status-pill {{ $met ? 'nexus-user-status-pill-success' : 'nexus-user-status-pill-warning' }}">
+                                            {{ $met ? 'On target' : 'Needs stockpile' }}
                                         </span>
                                     </div>
-                                    <progress class="progress {{ $met ? 'progress-primary' : 'progress-warning' }} w-full" value="{{ $percent }}" max="100"></progress>
+                                    <div class="nexus-user-progress">
+                                        <span style="width: {{ $percent }}%"></span>
+                                    </div>
                                 </div>
                             </td>
                         </tr>
                     @endforeach
-                    </tbody>
-                </table>
-            </div>
-        @endif
-    </div>
+                </tbody>
+            </table>
+        </div>
+    @endif
 </div>

--- a/resources/views/user/dashboard.blade.php
+++ b/resources/views/user/dashboard.blade.php
@@ -7,241 +7,413 @@
             now()->hour < 17 => 'Good afternoon',
             default => 'Good evening',
         };
-        $accountIds = $nation->accounts->pluck('id')->all();
 
-        $statCards = [
+        $accountIds = $nation->accounts->pluck('id')->all();
+        $allianceName = data_get($nation, 'alliance.name', 'Unaffiliated');
+        $scoreHistory = collect($scoreChart['data'] ?? []);
+        $scoreDelta = $scoreHistory->count() > 1 ? round((float) $scoreHistory->last() - (float) $scoreHistory->first(), 2) : 0;
+        $scorePulse = match (true) {
+            $scoreDelta > 0 => '+' . number_format($scoreDelta, 2),
+            $scoreDelta < 0 => number_format($scoreDelta, 2),
+            default => 'Flat',
+        };
+        $syncAgeMinutes = $latestSignIn?->created_at?->diffInMinutes(now());
+        $syncTone = match (true) {
+            ! $latestSignIn => [
+                'label' => 'Awaiting first sync',
+                'copy' => 'Sign in to Politics & War to establish your first snapshot.',
+                'pill' => 'nexus-user-status-pill-neutral',
+            ],
+            $syncAgeMinutes <= 60 => [
+                'label' => 'Live sync window',
+                'copy' => 'Your nation snapshot is fresh and ready for planning.',
+                'pill' => 'nexus-user-status-pill-success',
+            ],
+            $syncAgeMinutes <= 360 => [
+                'label' => 'Check sync cadence',
+                'copy' => 'Data is still usable, but another sync would sharpen the picture.',
+                'pill' => 'nexus-user-status-pill-warning',
+            ],
+            default => [
+                'label' => 'Snapshot is stale',
+                'copy' => 'Refresh your nation data before making large operational decisions.',
+                'pill' => 'nexus-user-status-pill-error',
+            ],
+        };
+
+        $readinessTone = match (true) {
+            ($mmrScore ?? 0) >= 100 => [
+                'label' => 'Doctrine locked',
+                'copy' => 'Stockpile and force posture align with the current alliance target.',
+                'pill' => 'nexus-user-status-pill-success',
+            ],
+            ($mmrScore ?? 0) >= 70 => [
+                'label' => 'Close to target',
+                'copy' => 'A few disciplined upgrades will move you fully into compliance.',
+                'pill' => 'nexus-user-status-pill-warning',
+            ],
+            default => [
+                'label' => 'Readiness gap',
+                'copy' => 'Use the doctrine section below to decide the next build cycle.',
+                'pill' => 'nexus-user-status-pill-error',
+            ],
+        };
+
+        $resourceGaps = collect($mmrResourceBreakdown)
+            ->filter(fn ($resource) => ! ($resource['met'] ?? false))
+            ->sortByDesc(fn ($resource) => $resource['weight'] ?? 0)
+            ->take(3)
+            ->map(function ($resource, $key) {
+                return [
+                    'name' => str((string) $key)->headline()->toString(),
+                    'have' => $resource['have'] ?? 0,
+                    'required' => $resource['required'] ?? 0,
+                    'weight' => $resource['weight'] ?? 0,
+                ];
+            })
+            ->values();
+
+        $unitLabels = [
+            'soldiers' => 'Soldiers',
+            'tanks' => 'Tanks',
+            'aircraft' => 'Aircraft',
+            'ships' => 'Ships',
+            'missiles' => 'Missiles',
+            'nukes' => 'Nukes',
+            'spies' => 'Spies',
+        ];
+
+        $unitGaps = collect($unitLabels)
+            ->map(function ($label, $unit) use ($latestSignIn, $nation, $mmrUnitRequirements) {
+                $current = (int) ($latestSignIn?->$unit ?? $nation->$unit ?? 0);
+                $required = (int) ($mmrUnitRequirements[$unit] ?? 0);
+
+                return [
+                    'label' => $label,
+                    'current' => $current,
+                    'required' => $required,
+                    'gap' => max($required - $current, 0),
+                ];
+            })
+            ->filter(fn ($unit) => $unit['gap'] > 0)
+            ->sortByDesc('gap')
+            ->take(3)
+            ->values();
+
+        $metrics = [
             [
-                'title' => 'Direct Deposit',
+                'label' => 'Direct deposit',
                 'value' => '$' . number_format($afterTaxIncomeTotal ?? 0),
-                'desc' => 'Net cash (30 days)',
-                'icon' => 'o-banknotes',
-                'glow_class' => 'bg-primary/10',
-                'icon_bg_class' => 'bg-primary/10',
-                'icon_text_class' => 'text-primary',
+                'copy' => 'Last 30 days',
             ],
             [
-                'title' => 'Total Taxed',
+                'label' => 'Tax contribution',
                 'value' => '$' . number_format($taxTotal ?? 0),
-                'desc' => 'After deposits',
-                'icon' => 'o-building-library',
-                'glow_class' => 'bg-accent/10',
-                'icon_bg_class' => 'bg-accent/10',
-                'icon_text_class' => 'text-accent',
+                'copy' => 'Captured after deposits',
             ],
             [
-                'title' => 'Grants Received',
-                'value' => '$' . number_format($grantTotal ?? 0),
-                'desc' => 'Approved to date',
+                'label' => 'Score per city',
+                'value' => number_format($scorePerCity ?? 0, 2),
+                'copy' => 'Build efficiency pulse',
+            ],
+            [
+                'label' => 'Cities online',
+                'value' => number_format($nation->num_cities ?? 0),
+                'copy' => 'Current operating tier',
+            ],
+        ];
+
+        $commandDeck = [
+            [
+                'title' => 'Treasury lane',
+                'copy' => 'Move money, confirm transfers, and keep your accounts from becoming a backlog.',
+                'meta' => count($accountIds) . ' account' . (count($accountIds) === 1 ? '' : 's'),
+                'route' => route('accounts'),
+                'action' => 'Open treasury',
+                'icon' => 'o-banknotes',
+            ],
+            [
+                'title' => 'Growth lane',
+                'copy' => 'Manage grants, loans, and the funding needed for your next city or project move.',
+                'meta' => '$' . number_format(($grantTotal ?? 0) + ($loanTotal ?? 0), 0) . ' lifetime support',
+                'route' => route('grants.city'),
+                'action' => 'Review support',
                 'icon' => 'o-gift',
-                'glow_class' => 'bg-success/10',
-                'icon_bg_class' => 'bg-success/10',
-                'icon_text_class' => 'text-success',
             ],
             [
-                'title' => 'Loans',
-                'value' => '$' . number_format($loanTotal ?? 0),
-                'desc' => 'Outstanding',
-                'icon' => 'o-credit-card',
-                'glow_class' => 'bg-warning/10',
-                'icon_bg_class' => 'bg-warning/10',
-                'icon_text_class' => 'text-warning',
+                'title' => 'Defense lane',
+                'copy' => 'Jump into counters, simulators, intel, and the alliance tools that matter when pressure rises.',
+                'meta' => ($mmrScore ?? 0) . '% readiness',
+                'route' => route('defense.counters'),
+                'action' => 'Open defense',
+                'icon' => 'o-shield-check',
             ],
+        ];
+
+        $missionTiles = [
+            ['label' => 'Alliance', 'value' => $allianceName],
+            ['label' => 'Nation age', 'value' => number_format($nationAge ?? 0) . ' days'],
+            ['label' => 'Score pulse', 'value' => $scorePulse],
+            ['label' => 'Last sync', 'value' => $latestSignIn?->created_at?->diffForHumans() ?? 'Not captured'],
+        ];
+
+        $signalDesk = [
             [
-                'title' => 'City Count',
-                'value' => $nation->num_cities ?? 0,
-                'desc' => 'Built and online',
-                'icon' => 'o-building-office-2',
-                'glow_class' => 'bg-info/10',
-                'icon_bg_class' => 'bg-info/10',
-                'icon_text_class' => 'text-info',
-            ],
-            [
-                'title' => 'Last Sync',
-                'value' => $latestSignIn?->created_at?->diffForHumans() ?? 'N/A',
-                'desc' => 'PW data sync',
+                'title' => 'Sync cadence',
+                'copy' => $syncTone['copy'],
+                'meta' => $latestSignIn?->created_at?->diffForHumans() ?? 'No data',
+                'pill' => $syncTone['pill'],
                 'icon' => 'o-clock',
-                'glow_class' => 'bg-neutral/10',
-                'icon_bg_class' => 'bg-neutral/10',
-                'icon_text_class' => 'text-neutral',
             ],
+            [
+                'title' => 'Doctrine watch',
+                'copy' => $readinessTone['copy'],
+                'meta' => ($mmrScore ?? 0) . '%',
+                'pill' => $readinessTone['pill'],
+                'icon' => 'o-rocket-launch',
+            ],
+            [
+                'title' => 'Funding posture',
+                'copy' => $payrollIsActive
+                    ? 'Payroll is active and recent funding is landing in your ledger.'
+                    : 'No active payroll track is attached; use support tools manually when needed.',
+                'meta' => $payrollIsActive ? 'Active' : 'Manual',
+                'pill' => $payrollIsActive ? 'nexus-user-status-pill-success' : 'nexus-user-status-pill-neutral',
+                'icon' => 'o-credit-card',
+            ],
+        ];
+
+        $chartTabs = [
+            'score' => 'Score',
+            'tax' => 'Tax flow',
+            'resources' => 'Resource tax',
+            'military' => 'Military',
+            'holdings' => 'Holdings',
         ];
     @endphp
 
-    <div class="mx-auto max-w-7xl space-y-6 xl:max-w-6xl 2xl:max-w-[1400px]">
-        <div class="relative overflow-hidden rounded-3xl border border-base-300/60 bg-base-100 shadow-lg">
-            <div class="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded-full bg-primary/10 blur-3xl"></div>
-            <div class="pointer-events-none absolute -left-16 bottom-0 h-48 w-48 rounded-full bg-secondary/10 blur-3xl"></div>
+    <div class="nexus-user-shell" data-dashboard-theme>
+        <section class="nexus-user-panel nexus-user-masthead">
+            <div class="relative z-10 grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+                <div class="flex flex-col gap-5 min-w-0">
+                    <div class="flex flex-wrap items-start justify-between gap-4">
+                        <div class="flex min-w-0 items-start gap-4">
+                            <div class="avatar hidden sm:block">
+                                <div class="w-20 rounded-[1.2rem] border border-base-300/70 bg-base-100/80 p-1">
+                                    <img src="{{ $nation->flag ?? 'https://politicsandwar.com/img/flags/default.png' }}" alt="Nation flag" />
+                                </div>
+                            </div>
 
-            <div class="relative flex flex-col gap-6 p-6 sm:p-8 lg:flex-row lg:items-center lg:justify-between">
-                <div class="flex min-w-0 items-start gap-5">
-                    <div class="avatar">
-                        <div class="w-[4.5rem] rounded-2xl ring-2 ring-primary/20 ring-offset-2 ring-offset-base-100">
-                            <img src="{{ $nation->flag ?? 'https://politicsandwar.com/img/flags/default.png' }}" alt="Nation flag" />
+                            <div class="min-w-0 space-y-3">
+                                <p class="nexus-user-eyebrow">{{ $greeting }} / member operations</p>
+                                <div class="space-y-2">
+                                    <h1 class="nexus-user-title">{{ $nation->leader_name }}</h1>
+                                    <div class="min-w-0">
+                                        <p class="text-lg font-semibold text-base-content break-words">{{ $nation->nation_name }}</p>
+                                        <p class="text-sm text-base-content/60">A cleaner operating surface for alliance money, doctrine, and action routing.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap gap-2">
+                            <a href="{{ route('accounts') }}" class="btn btn-sm rounded-full border border-base-300 bg-base-100 text-base-content hover:bg-base-200">Treasury</a>
+                            <a href="{{ route('defense.counters') }}" class="btn btn-sm rounded-full border border-base-300 bg-base-100 text-base-content hover:bg-base-200">Defense</a>
+                            <a href="https://politicsandwar.com/nation/id={{ $nation->id }}" target="_blank" rel="noreferrer" class="btn btn-sm rounded-full btn-ghost">P&amp;W profile</a>
                         </div>
                     </div>
 
-                    <div class="min-w-0 space-y-1.5">
-                        <p class="text-xs font-medium uppercase tracking-widest text-base-content/50">{{ $greeting }}</p>
-                        <h1 class="break-words text-2xl font-extrabold leading-tight sm:text-3xl">
-                            {{ $nation->leader_name }}
-                        </h1>
-                        <p class="text-base font-medium text-base-content/60">{{ $nation->nation_name }}</p>
+                    <p class="nexus-user-body">
+                        The goal here is simple: reduce the noise, keep the high-trust signals visible, and make the
+                        next useful action obvious without burying you under a wall of decorative boxes.
+                    </p>
 
-                        <div class="flex flex-wrap gap-1.5 pt-1">
-                            <span class="badge badge-soft badge-primary badge-sm">{{ $nation->alliance->name ?? 'Unaffiliated' }}</span>
-                            <span class="badge badge-soft badge-sm">{{ $nation->num_cities }} cities</span>
-                            <span class="badge badge-soft badge-sm">Score {{ number_format($nation->score, 2) }}</span>
-                            @if($latestSignIn && $latestSignIn->created_at)
-                                <span class="badge badge-ghost badge-sm">Synced {{ $nation->updated_at->diffForHumans() }}</span>
-                            @endif
+                    <div class="nexus-user-kicker-list">
+                        @foreach($missionTiles as $tile)
+                            <span class="nexus-user-pill">{{ $tile['label'] }}: {{ $tile['value'] }}</span>
+                        @endforeach
+                    </div>
+                </div>
+
+                <aside class="nexus-user-side-rail rounded-[1rem] border border-base-300/70 p-4 sm:p-5">
+                    <div class="nexus-user-section-head">
+                        <div>
+                            <p class="nexus-user-eyebrow">Status brief</p>
+                            <h2 class="nexus-user-section-title">What needs attention</h2>
                         </div>
-                    </div>
-                </div>
-
-                <div class="flex flex-shrink-0 flex-wrap gap-2 lg:flex-col lg:items-end">
-                    <a href="https://politicsandwar.com/nation/id={{ $nation->id }}" target="_blank"
-                       class="btn btn-primary btn-sm gap-1.5 rounded-xl shadow-sm shadow-primary/20">
-                        <x-icon name="o-arrow-top-right-on-square" class="size-3.5" />
-                        View on P&amp;W
-                    </a>
-                    <div class="flex flex-wrap gap-2">
-                        <a href="{{ route('accounts') }}" class="btn btn-ghost btn-sm rounded-xl">Accounts</a>
-                        <a href="{{ route('grants.city') }}" class="btn btn-ghost btn-sm rounded-xl">Grants</a>
-                        <a href="{{ route('loans.index') }}" class="btn btn-ghost btn-sm rounded-xl">Loans</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/5 via-base-100 to-base-100 p-5 shadow-md sm:p-6">
-            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div class="space-y-1">
-                    <div class="flex items-center gap-2">
-                        <h2 class="text-lg font-bold">MMR Readiness</h2>
-                        <span class="badge badge-sm {{ ($mmrScore ?? 0) >= 100 ? 'badge-success' : (($mmrScore ?? 0) >= 50 ? 'badge-warning' : 'badge-error') }}">
-                            {{ $mmrScore ?? 0 }}%
+                        <span class="nexus-user-status-pill {{ $readinessTone['pill'] }}">
+                            <span class="nexus-user-status-dot"></span>
+                            {{ $readinessTone['label'] }}
                         </span>
                     </div>
-                    <p class="text-sm text-base-content/60">Tier {{ $mmrTier->city_count ?? 0 }} requirements</p>
-                </div>
 
-                <div class="flex flex-wrap gap-2">
-                    <div class="flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-sm
-                        {{ $mmrResourcesMet ? 'border-success/30 bg-success/5 text-success' : 'border-warning/30 bg-warning/5 text-warning' }}">
-                        <x-icon name="{{ $mmrResourcesMet ? 'o-check-circle' : 'o-exclamation-triangle' }}" class="size-4" />
-                        {{ $mmrResourcesMet ? 'Resources met' : 'Resources low' }}
-                    </div>
-                    <div class="flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-sm
-                        {{ $mmrUnitsMet ? 'border-success/30 bg-success/5 text-success' : 'border-warning/30 bg-warning/5 text-warning' }}">
-                        <x-icon name="{{ $mmrUnitsMet ? 'o-check-circle' : 'o-exclamation-triangle' }}" class="size-4" />
-                        {{ $mmrUnitsMet ? 'Units ready' : 'Units low' }}
-                    </div>
-                </div>
-            </div>
-
-            <div class="mt-4 overflow-hidden rounded-full bg-base-300/40">
-                <div class="h-2.5 rounded-full transition-all duration-700
-                    {{ ($mmrScore ?? 0) >= 100 ? 'bg-success' : (($mmrScore ?? 0) >= 50 ? 'bg-warning' : 'bg-error') }}"
-                    style="width: {{ min($mmrScore ?? 0, 100) }}%"></div>
-            </div>
-
-            @if(!$mmrResourcesMet || !$mmrUnitsMet)
-                <p class="mt-3 text-xs text-base-content/50">
-                    Top off the gaps in the comparison tables below to hit full compliance for your tier.
-                </p>
-            @else
-                <p class="mt-3 text-xs text-success/80">
-                    You are meeting all current MMR expectations. Nice work!
-                </p>
-            @endif
-        </div>
-
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            @foreach($statCards as $card)
-                <div class="group relative overflow-hidden rounded-2xl border border-base-300/60 bg-base-100 p-4 shadow-sm transition hover:shadow-md sm:p-5">
-                    <div class="pointer-events-none absolute -right-4 -top-4 h-16 w-16 rounded-full {{ $card['glow_class'] }} blur-2xl transition-transform group-hover:scale-150"></div>
-                    <div class="relative">
-                        <div class="mb-3 flex items-center gap-2">
-                            <div class="flex h-8 w-8 items-center justify-center rounded-lg {{ $card['icon_bg_class'] }}">
-                                <x-icon name="{{ $card['icon'] }}" class="size-4 {{ $card['icon_text_class'] }}" />
+                    <div class="mt-5 nexus-user-ledger">
+                        <div class="nexus-user-ledger-item">
+                            <div class="nexus-user-ledger-icon">
+                                <x-icon name="o-clock" class="size-4" />
                             </div>
-                            <p class="text-xs font-semibold uppercase tracking-wide text-base-content/50">{{ $card['title'] }}</p>
+                            <div class="min-w-0">
+                                <p class="text-sm font-semibold text-base-content">{{ $syncTone['label'] }}</p>
+                                <p class="mt-1 nexus-user-microcopy">{{ $syncTone['copy'] }}</p>
+                            </div>
                         </div>
-                        <p class="text-xl font-extrabold sm:text-2xl">{{ $card['value'] }}</p>
-                        <p class="mt-0.5 text-xs text-base-content/50">{{ $card['desc'] }}</p>
+
+                        <div class="nexus-user-ledger-item">
+                            <div class="nexus-user-ledger-icon">
+                                <x-icon name="o-shield-check" class="size-4" />
+                            </div>
+                            <div class="min-w-0">
+                                <p class="text-sm font-semibold text-base-content">MMR posture at {{ $mmrScore ?? 0 }}%</p>
+                                <p class="mt-1 nexus-user-microcopy">{{ $readinessTone['copy'] }}</p>
+                            </div>
+                        </div>
+
+                        <div class="nexus-user-ledger-item">
+                            <div class="nexus-user-ledger-icon">
+                                <x-icon name="o-currency-dollar" class="size-4" />
+                            </div>
+                            <div class="min-w-0">
+                                <p class="text-sm font-semibold text-base-content">
+                                    {{ $payrollIsActive ? 'Payroll active' : 'Payroll inactive' }}
+                                </p>
+                                <p class="mt-1 nexus-user-microcopy">
+                                    {{ $payrollIsActive && $payrollGrade
+                                        ? $payrollGrade->name . ' at $' . number_format((float) $payrollDailyAmount, 2) . ' daily.'
+                                        : 'No recurring payroll lane is attached to your nation right now.' }}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </aside>
+            </div>
+        </section>
+
+        <section class="nexus-user-panel overflow-hidden">
+            <div class="nexus-user-ribbon">
+                @foreach($metrics as $metric)
+                    <div class="nexus-user-ribbon-item">
+                        <p class="nexus-user-stat-label">{{ $metric['label'] }}</p>
+                        <p class="nexus-user-stat-value">{{ $metric['value'] }}</p>
+                        <p class="nexus-user-stat-copy">{{ $metric['copy'] }}</p>
+                    </div>
+                @endforeach
+            </div>
+        </section>
+
+        <section class="nexus-user-panel overflow-hidden">
+            <div class="grid xl:grid-cols-[minmax(0,1.12fr)_minmax(300px,0.88fr)]">
+                <div class="p-5 sm:p-6">
+                    <div class="nexus-user-section-head">
+                        <div>
+                            <p class="nexus-user-eyebrow">Command lanes</p>
+                            <h2 class="nexus-user-section-title">Move to the right tool quickly</h2>
+                            <p class="nexus-user-section-copy">The user side should route you into a workflow, not force you to visually parse twelve decorated cards first.</p>
+                        </div>
+                    </div>
+
+                    <div class="mt-5 nexus-user-command-list">
+                        @foreach($commandDeck as $command)
+                            <div class="nexus-user-command-row">
+                                <div class="nexus-user-ledger-icon">
+                                    <x-icon name="{{ $command['icon'] }}" class="size-4" />
+                                </div>
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <p class="text-base font-semibold text-base-content">{{ $command['title'] }}</p>
+                                        <span class="nexus-user-status-pill nexus-user-status-pill-neutral">{{ $command['meta'] }}</span>
+                                    </div>
+                                    <p class="mt-2 text-sm leading-6 text-base-content/65 max-w-[54ch]">{{ $command['copy'] }}</p>
+                                </div>
+                                <div class="pt-1">
+                                    <a href="{{ $command['route'] }}" class="btn btn-ghost btn-sm rounded-full whitespace-nowrap">{{ $command['action'] }}</a>
+                                </div>
+                            </div>
+                        @endforeach
                     </div>
                 </div>
-            @endforeach
-        </div>
 
-        <div class="rounded-2xl border border-base-300/60 bg-base-100 p-5 shadow-sm sm:p-6">
-            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div class="flex items-start gap-4">
-                    <div class="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-secondary/10">
-                        <x-icon name="o-currency-dollar" class="size-5 text-secondary" />
-                    </div>
-                    <div>
-                        <div class="flex flex-wrap items-center gap-2">
-                            <h3 class="font-bold">Payroll</h3>
-                            <span class="badge badge-sm {{ $payrollIsActive ? 'badge-success' : 'badge-ghost' }}">
-                                {{ $payrollIsActive ? 'Active' : 'Inactive' }}
-                            </span>
+                <aside class="nexus-user-side-rail border-t border-base-300/70 p-5 sm:p-6 xl:border-l xl:border-t-0">
+                    <div class="nexus-user-section-head">
+                        <div>
+                            <p class="nexus-user-eyebrow">Doctrine brief</p>
+                            <h2 class="nexus-user-section-title">Top gaps, not every detail</h2>
                         </div>
-                        @if($payrollMember && $payrollGrade)
-                            <p class="mt-0.5 text-sm font-semibold text-base-content/80">{{ $payrollGrade->name }}</p>
-                            <p class="text-xs text-base-content/50">
-                                ${{ number_format((float) $payrollGrade->weekly_amount, 2) }}/week &middot;
-                                ${{ number_format((float) $payrollDailyAmount, 2) }}/day
-                            </p>
-                        @else
-                            <p class="mt-0.5 text-sm text-base-content/50">You are not enrolled in payroll.</p>
-                        @endif
                     </div>
-                </div>
 
-                <div class="flex-shrink-0 rounded-2xl border border-base-200 bg-base-200/30 px-5 py-3 text-center">
-                    <p class="text-[10px] font-semibold uppercase tracking-widest text-base-content/40">Last 30 days</p>
-                    <p class="text-2xl font-extrabold">${{ number_format($payrollMonthlyTotal ?? 0, 2) }}</p>
+                    <div class="mt-5 space-y-5">
+                        <div>
+                            <div class="flex items-end justify-between gap-3">
+                                <div>
+                                    <p class="nexus-user-stat-label">Readiness</p>
+                                    <p class="nexus-user-stat-value">{{ $mmrScore ?? 0 }}%</p>
+                                </div>
+                                <span class="nexus-user-status-pill {{ $readinessTone['pill'] }}">{{ $readinessTone['label'] }}</span>
+                            </div>
+                            <div class="mt-3 nexus-user-progress">
+                                <span style="width: {{ min($mmrScore ?? 0, 100) }}%"></span>
+                            </div>
+                        </div>
+
+                        <div class="space-y-3">
+                            @forelse($resourceGaps as $gap)
+                                <div class="nexus-user-data-tile">
+                                    <p class="nexus-user-data-label">{{ $gap['name'] }}</p>
+                                    <p class="nexus-user-data-value">{{ number_format($gap['have']) }} / {{ number_format($gap['required']) }}</p>
+                                    <p class="mt-1 text-sm text-base-content/60">{{ number_format($gap['weight'], 2) }}% doctrine weight</p>
+                                </div>
+                            @empty
+                                @forelse($unitGaps as $gap)
+                                    <div class="nexus-user-data-tile">
+                                        <p class="nexus-user-data-label">{{ $gap['label'] }}</p>
+                                        <p class="nexus-user-data-value">+{{ number_format($gap['gap']) }}</p>
+                                        <p class="mt-1 text-sm text-base-content/60">{{ number_format($gap['current']) }} current vs {{ number_format($gap['required']) }} required</p>
+                                    </div>
+                                @empty
+                                    <div class="nexus-user-data-tile">
+                                        <p class="nexus-user-data-label">Shortfalls</p>
+                                        <p class="nexus-user-data-value">None</p>
+                                        <p class="mt-1 text-sm text-base-content/60">Your current snapshot is aligned with alliance doctrine.</p>
+                                    </div>
+                                @endforelse
+                            @endforelse
+                        </div>
+                    </div>
+                </aside>
+            </div>
+        </section>
+
+        <section class="nexus-user-panel overflow-hidden">
+            <div class="grid xl:grid-cols-2">
+                <div class="p-5 sm:p-6">
+                    <x-user.resource-comparison :resources="$mmrResourceBreakdown" :weights="$mmrWeights" />
+                </div>
+                <div class="border-t border-base-300/70 p-5 sm:p-6 xl:border-l xl:border-t-0">
+                    <x-user.military-comparison
+                        :nation="$nation"
+                        :latestSignIn="$latestSignIn"
+                        :requirements="$mmrUnitRequirements"
+                        :meets="$mmrUnitsMet"
+                    />
                 </div>
             </div>
-        </div>
+        </section>
 
-        <div class="grid gap-5 xl:grid-cols-2">
-            <x-user.resource-comparison :resources="$mmrResourceBreakdown" :weights="$mmrWeights" />
-            <x-user.military-comparison
-                :nation="$nation"
-                :latestSignIn="$latestSignIn"
-                :requirements="$mmrUnitRequirements"
-                :meets="$mmrUnitsMet"
-            />
-        </div>
-
-        <div x-data="{ activeTab: 'score' }" class="rounded-3xl border border-base-300/60 bg-base-100 shadow-md">
-            <div class="border-b border-base-200 px-5 pt-5 sm:px-6 sm:pt-6">
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <section x-data="{ activeTab: 'score' }" class="nexus-user-panel nexus-user-chart-card overflow-hidden">
+            <div class="border-b border-base-300/70 px-5 pt-5 sm:px-6 sm:pt-6">
+                <div class="nexus-user-section-head">
                     <div>
-                        <h3 class="text-lg font-bold">Nation Charts</h3>
-                        <p class="text-sm text-base-content/50">Live snapshots from your synced data.</p>
+                        <p class="nexus-user-eyebrow">Telemetry</p>
+                        <h2 class="nexus-user-section-title">Nation trendlines</h2>
+                        <p class="nexus-user-section-copy">The visual layer stays quiet here so the actual movement in your data can carry the page.</p>
                     </div>
                 </div>
 
-                <div class="mt-4 flex gap-1 overflow-x-auto pb-px">
-                    @php
-                        $tabs = [
-                            'score' => 'Score',
-                            'tax' => 'Tax Revenue',
-                            'resources' => 'Resource Tax',
-                            'military' => 'Military',
-                            'holdings' => 'Holdings',
-                        ];
-                    @endphp
-                    @foreach($tabs as $key => $label)
+                <div class="mt-4 flex gap-4 overflow-x-auto pb-px">
+                    @foreach($chartTabs as $key => $label)
                         <button
                             @click="activeTab = '{{ $key }}'; $nextTick(() => window.dispatchEvent(new Event('resize')))"
-                            :class="activeTab === '{{ $key }}'
-                                ? 'border-primary text-primary font-semibold'
-                                : 'border-transparent text-base-content/50 hover:text-base-content/80'"
-                            class="whitespace-nowrap border-b-2 px-3 py-2.5 text-sm transition-colors"
+                            :class="activeTab === '{{ $key }}' ? 'nexus-user-chart-tab-active' : 'border-transparent'"
+                            class="nexus-user-chart-tab whitespace-nowrap"
                             type="button"
                         >
                             {{ $label }}
@@ -252,74 +424,109 @@
 
             <div class="p-5 sm:p-6">
                 <div x-show="activeTab === 'score'" x-transition.opacity>
-                    <canvas id="scoreChart" class="w-full" style="height: 280px"></canvas>
+                    <canvas id="scoreChart" class="w-full" style="height: 320px"></canvas>
                 </div>
                 <div x-show="activeTab === 'tax'" x-cloak x-transition.opacity>
-                    <canvas id="moneyTaxChart" class="w-full" style="height: 280px"></canvas>
+                    <canvas id="moneyTaxChart" class="w-full" style="height: 320px"></canvas>
                 </div>
                 <div x-show="activeTab === 'resources'" x-cloak x-transition.opacity>
-                    <canvas id="resourceTaxChart" class="w-full" style="height: 280px"></canvas>
+                    <canvas id="resourceTaxChart" class="w-full" style="height: 320px"></canvas>
                 </div>
                 <div x-show="activeTab === 'military'" x-cloak x-transition.opacity>
-                    <canvas id="militaryChart" class="w-full" style="height: 280px"></canvas>
+                    <canvas id="militaryChart" class="w-full" style="height: 320px"></canvas>
                 </div>
                 <div x-show="activeTab === 'holdings'" x-cloak x-transition.opacity>
-                    <canvas id="resourceHoldingsChart" class="w-full" style="height: 280px"></canvas>
+                    <canvas id="resourceHoldingsChart" class="w-full" style="height: 320px"></canvas>
                 </div>
             </div>
-        </div>
+        </section>
 
-        <div class="rounded-3xl border border-base-300/60 bg-base-100 shadow-md">
-            <div class="flex flex-wrap items-center justify-between gap-3 border-b border-base-200 px-5 py-4 sm:px-6">
-                <h3 class="text-lg font-bold">Recent Transactions</h3>
-                <a href="{{ route('accounts') }}" class="btn btn-ghost btn-sm gap-1 rounded-xl">
-                    Open accounts
-                    <x-icon name="o-arrow-right" class="size-3.5" />
-                </a>
-            </div>
+        <section class="nexus-user-panel overflow-hidden">
+            <div class="grid xl:grid-cols-[minmax(0,1.15fr)_minmax(300px,0.85fr)]">
+                <div class="min-w-0">
+                    <div class="flex flex-wrap items-center justify-between gap-3 border-b border-base-300/70 px-5 py-4 sm:px-6">
+                        <div>
+                            <p class="nexus-user-eyebrow">Ledger</p>
+                            <h2 class="nexus-user-section-title">Recent transactions</h2>
+                        </div>
+                        <a href="{{ route('accounts') }}" class="btn btn-ghost btn-sm rounded-full">Open accounts</a>
+                    </div>
 
-            <div class="overflow-x-auto">
-                <table class="table">
-                    <thead>
-                    <tr class="text-xs uppercase tracking-wider text-base-content/40">
-                        <th class="font-semibold">Date</th>
-                        <th class="font-semibold">Direction</th>
-                        <th class="font-semibold">Amount</th>
-                        <th class="font-semibold">Note</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @forelse ($recentTransactions as $tx)
-                        @php
-                            $direction = in_array($tx->from_account_id, $accountIds, true) ? 'Sent' : 'Received';
-                            $isSent = $direction === 'Sent';
-                        @endphp
-                        <tr class="transition-colors hover:bg-base-200/30">
-                            <td class="text-sm text-base-content/70">{{ $tx->created_at->format('M d, Y H:i') }}</td>
-                            <td>
-                                <span class="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-semibold
-                                    {{ $isSent ? 'bg-base-200/60 text-base-content/60' : 'bg-success/10 text-success' }}">
-                                    <x-icon name="{{ $isSent ? 'o-arrow-up-right' : 'o-arrow-down-left' }}" class="size-3" />
-                                    {{ $direction }}
-                                </span>
-                            </td>
-                            <td class="font-bold tabular-nums {{ $isSent ? 'text-base-content/70' : 'text-success' }}">
-                                {{ $isSent ? '-' : '+' }}${{ number_format($tx->money, 2) }}
-                            </td>
-                            <td class="max-w-xs truncate text-sm text-base-content/60">{{ $tx->note ?? 'No note' }}</td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="4" class="py-12 text-center">
-                                <x-icon name="o-inbox" class="mx-auto size-8 text-base-content/20" />
-                                <p class="mt-2 text-sm text-base-content/40">No transactions yet</p>
-                            </td>
-                        </tr>
-                    @endforelse
-                    </tbody>
-                </table>
+                    <div class="overflow-x-auto">
+                        <table class="table nexus-user-table">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Direction</th>
+                                    <th>Amount</th>
+                                    <th>Note</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse ($recentTransactions as $tx)
+                                    @php
+                                        $direction = in_array($tx->from_account_id, $accountIds, true) ? 'Sent' : 'Received';
+                                        $isSent = $direction === 'Sent';
+                                    @endphp
+                                    <tr>
+                                        <td class="text-sm text-base-content/70">{{ $tx->created_at->format('M d, Y H:i') }}</td>
+                                        <td>
+                                            <span class="nexus-user-status-pill {{ $isSent ? 'nexus-user-status-pill-neutral' : 'nexus-user-status-pill-success' }}">
+                                                <span class="nexus-user-status-dot"></span>
+                                                {{ $direction }}
+                                            </span>
+                                        </td>
+                                        <td class="font-extrabold tabular-nums {{ $isSent ? 'text-base-content/75' : 'text-success' }}">
+                                            {{ $isSent ? '-' : '+' }}${{ number_format($tx->money, 2) }}
+                                        </td>
+                                        <td class="max-w-sm truncate text-sm text-base-content/60">{{ $tx->note ?? 'No note' }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4">
+                                            <div class="nexus-user-empty">
+                                                <x-icon name="o-inbox" class="size-10 text-base-content/25" />
+                                                <div>
+                                                    <p class="font-semibold text-base-content/70">No transactions recorded yet</p>
+                                                    <p class="mt-1 text-sm">Treasury movement will appear here once you start using alliance accounts.</p>
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <aside class="nexus-user-side-rail border-t border-base-300/70 p-5 sm:p-6 xl:border-l xl:border-t-0">
+                    <div class="nexus-user-section-head">
+                        <div>
+                            <p class="nexus-user-eyebrow">Signal desk</p>
+                            <h2 class="nexus-user-section-title">Operational notes</h2>
+                        </div>
+                        <a href="{{ route('user.settings') }}" class="btn btn-ghost btn-xs rounded-full">Settings</a>
+                    </div>
+
+                    <div class="mt-5 nexus-user-ledger">
+                        @foreach($signalDesk as $signal)
+                            <div class="nexus-user-ledger-item">
+                                <div class="nexus-user-ledger-icon">
+                                    <x-icon name="{{ $signal['icon'] }}" class="size-4" />
+                                </div>
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <p class="text-sm font-semibold text-base-content">{{ $signal['title'] }}</p>
+                                        <span class="nexus-user-status-pill {{ $signal['pill'] }}">{{ $signal['meta'] }}</span>
+                                    </div>
+                                    <p class="mt-2 text-sm leading-6 text-base-content/65">{{ $signal['copy'] }}</p>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </aside>
             </div>
-        </div>
+        </section>
     </div>
 
     @push('scripts')
@@ -329,10 +536,30 @@
                     return;
                 }
 
+                const dashboardRoot = document.querySelector('[data-dashboard-theme]');
+
+                if (! dashboardRoot) {
+                    return;
+                }
+
+                const styles = getComputedStyle(dashboardRoot);
+                const chartColors = {
+                    primary: styles.getPropertyValue('--nexus-chart-primary').trim() || '#7b5f2a',
+                    success: styles.getPropertyValue('--nexus-chart-success').trim() || '#2f6f4e',
+                    info: styles.getPropertyValue('--nexus-chart-info').trim() || '#3b6f7b',
+                    warning: styles.getPropertyValue('--nexus-chart-warning').trim() || '#b8741a',
+                    danger: styles.getPropertyValue('--nexus-chart-danger').trim() || '#ab504a',
+                    neutral: styles.getPropertyValue('--nexus-chart-neutral').trim() || '#686257',
+                    text: styles.getPropertyValue('--nexus-chart-text').trim() || '#504a40',
+                    grid: styles.getPropertyValue('--nexus-chart-grid').trim() || 'rgba(120, 107, 88, 0.16)',
+                    tooltipBackground: styles.getPropertyValue('--nexus-chart-tooltip').trim() || 'rgba(42, 34, 28, 0.95)',
+                    tooltipBorder: styles.getPropertyValue('--nexus-chart-tooltip-border').trim() || 'rgba(194, 174, 145, 0.18)',
+                };
+
                 const baseFont = {
-                    family: "'Inter', 'system-ui', sans-serif",
+                    family: "'Manrope', 'Segoe UI', sans-serif",
                     size: 11,
-                    weight: 500,
+                    weight: 600,
                 };
 
                 const rgba = (hex, alpha) => {
@@ -348,24 +575,6 @@
                     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
                 };
 
-                const chartColors = {
-                    primary: '#2563eb',
-                    success: '#16a34a',
-                    info: '#0891b2',
-                    warning: '#d97706',
-                    danger: '#dc2626',
-                    neutral: '#64748b',
-                    accent: '#7c3aed',
-                    text: '#475569',
-                    grid: 'rgba(148, 163, 184, 0.16)',
-                    tooltipBackground: 'rgba(15, 23, 42, 0.92)',
-                    tooltipBorder: 'rgba(148, 163, 184, 0.22)',
-                };
-
-                const gridColor = chartColors.grid;
-                const tickColor = chartColors.text;
-                const tooltipBackground = chartColors.tooltipBackground;
-                const tooltipBorder = chartColors.tooltipBorder;
                 const seriesPalette = [
                     chartColors.primary,
                     chartColors.success,
@@ -389,24 +598,24 @@
                             },
                         },
                         tooltip: {
-                            backgroundColor: tooltipBackground,
+                            backgroundColor: chartColors.tooltipBackground,
                             titleColor: '#f8fafc',
-                            bodyColor: '#e2e8f0',
-                            borderColor: tooltipBorder,
+                            bodyColor: '#f5efe6',
+                            borderColor: chartColors.tooltipBorder,
                             borderWidth: 1,
-                            padding: 10,
-                            cornerRadius: 10,
+                            padding: 12,
+                            cornerRadius: 12,
                             boxPadding: 4,
                         },
                     },
                     scales: {
                         x: {
                             grid: { display: false },
-                            ticks: { color: tickColor, font: baseFont },
+                            ticks: { color: chartColors.text, font: baseFont },
                         },
                         y: {
-                            grid: { color: gridColor },
-                            ticks: { color: tickColor, font: baseFont },
+                            grid: { color: chartColors.grid },
+                            ticks: { color: chartColors.text, font: baseFont },
                             beginAtZero: true,
                         },
                     },
@@ -422,10 +631,10 @@
                             borderColor: chartColors.primary,
                             backgroundColor: rgba(chartColors.primary, 0.12),
                             fill: true,
-                            tension: 0.4,
+                            tension: 0.34,
                             pointRadius: 2,
                             pointHoverRadius: 5,
-                            borderWidth: 2,
+                            borderWidth: 2.2,
                         }],
                     },
                     options: {
@@ -444,9 +653,9 @@
                         datasets: [{
                             label: 'Money',
                             data: @json($moneyTaxChart['data']),
-                            backgroundColor: rgba(chartColors.success, 0.7),
+                            backgroundColor: rgba(chartColors.success, 0.74),
                             hoverBackgroundColor: rgba(chartColors.success, 0.88),
-                            borderRadius: 6,
+                            borderRadius: 8,
                             borderSkipped: false,
                         }],
                     },
@@ -490,11 +699,12 @@
                 });
 
                 const militaryDatasets = @json($militaryChart['datasets']);
+
                 militaryDatasets.forEach((dataset, index) => {
                     dataset.borderColor = seriesPalette[index % seriesPalette.length];
                     dataset.backgroundColor = seriesPalette[index % seriesPalette.length];
                     dataset.fill = false;
-                    dataset.tension = 0.4;
+                    dataset.tension = 0.34;
                     dataset.borderWidth = 2;
                     dataset.pointRadius = 1.5;
                     dataset.pointHoverRadius = 4;
@@ -516,11 +726,12 @@
                 });
 
                 const holdingsDatasets = @json($resourceHoldingsChart['datasets']);
+
                 holdingsDatasets.forEach((dataset, index) => {
                     dataset.borderColor = seriesPalette[index % seriesPalette.length];
                     dataset.backgroundColor = seriesPalette[index % seriesPalette.length];
                     dataset.fill = false;
-                    dataset.tension = 0.4;
+                    dataset.tension = 0.32;
                     dataset.borderWidth = 2;
                     dataset.pointRadius = 1.5;
                     dataset.pointHoverRadius = 4;

--- a/routes/console.php
+++ b/routes/console.php
@@ -34,7 +34,12 @@ Schedule::command('sync:wars')->hourlyAt(10)->runInBackground()
     ->when($whenPWUp);
 
 // Deposits
-Schedule::command(ProcessDeposits::class)->everyMinute()->runInBackground()->when($whenPWUp);
+Schedule::command(ProcessDeposits::class)
+    ->everyMinute()
+    ->runInBackground()
+    ->withoutOverlapping(10)
+    ->onOneServer()
+    ->when($whenPWUp);
 
 // Loan
 Schedule::command('loans:process-payments')->dailyAt('00:15');
@@ -65,7 +70,11 @@ Schedule::command('backup:clean')
     ->when(fn () => SettingService::isBackupsEnabled());
 
 // Taxes
-Schedule::command('taxes:collect')->hourlyAt('15')->when($whenPWUp);
+Schedule::command('taxes:collect')
+    ->hourlyAt('15')
+    ->withoutOverlapping(55)
+    ->onOneServer()
+    ->when($whenPWUp);
 
 Schedule::command('pw:sync-city-average')->dailyAt('00:05')->when($whenPWUp);
 

--- a/tests/Feature/UserDashboardTest.php
+++ b/tests/Feature/UserDashboardTest.php
@@ -13,6 +13,8 @@ class UserDashboardTest extends FeatureTestCase
 
     public function test_verified_member_can_view_the_dashboard(): void
     {
+        $this->withoutVite();
+
         $nation = Nation::factory()->create([
             'leader_name' => 'Dashboard Leader',
             'nation_name' => 'Dashboard Nation',

--- a/tests/Feature/UserDashboardTest.php
+++ b/tests/Feature/UserDashboardTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Nation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\FeatureTestCase;
+
+class UserDashboardTest extends FeatureTestCase
+{
+    use RefreshDatabase;
+
+    public function test_verified_member_can_view_the_dashboard(): void
+    {
+        $nation = Nation::factory()->create([
+            'leader_name' => 'Dashboard Leader',
+            'nation_name' => 'Dashboard Nation',
+            'num_cities' => 8,
+        ]);
+
+        $user = User::factory()->verified()->create([
+            'nation_id' => $nation->id,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('user.dashboard'));
+
+        $response
+            ->assertOk()
+            ->assertSee('Dashboard Leader')
+            ->assertSee('Treasury lane')
+            ->assertSee('Nation trendlines')
+            ->assertSee('Recent transactions');
+    }
+}

--- a/tests/Unit/Services/CityGrantServiceTest.php
+++ b/tests/Unit/Services/CityGrantServiceTest.php
@@ -10,6 +10,7 @@ use App\Services\CityGrantService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
 use ReflectionMethod;
 use Tests\FeatureTestCase;
@@ -90,6 +91,44 @@ class CityGrantServiceTest extends FeatureTestCase
 
         Log::shouldHaveReceived('warning')->withArgs(fn (string $message, array $context): bool => $message === 'City grant approval exceeds configured alert threshold.'
             && $context['request_id'] === $request->id);
+    }
+
+    public function test_deny_grant_rechecks_pending_state_before_updating_status(): void
+    {
+        Notification::fake();
+
+        $nation = $this->createNation();
+        $account = $this->createAccount($nation);
+        $request = CityGrantRequest::query()->create([
+            'city_number' => 6,
+            'grant_amount' => 320000,
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'status' => 'pending',
+            'pending_key' => 1,
+        ]);
+        $staleRequest = CityGrantRequest::query()->findOrFail($request->id);
+
+        CityGrantRequest::query()
+            ->whereKey($request->id)
+            ->update([
+                'status' => 'approved',
+                'pending_key' => null,
+                'approved_at' => now(),
+            ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Grant is not pending.');
+
+        try {
+            CityGrantService::denyGrant($staleRequest);
+        } finally {
+            $request->refresh();
+
+            $this->assertSame('approved', $request->status);
+            $this->assertNull($request->denied_at);
+            Notification::assertNothingSent();
+        }
     }
 
     private function createNation(): Nation

--- a/tests/Unit/Services/GrantServiceTest.php
+++ b/tests/Unit/Services/GrantServiceTest.php
@@ -10,6 +10,7 @@ use App\Services\GrantService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
 use ReflectionMethod;
 use Tests\FeatureTestCase;
@@ -75,6 +76,44 @@ class GrantServiceTest extends FeatureTestCase
 
         Log::shouldHaveReceived('warning')->withArgs(fn (string $message, array $context): bool => $message === 'Grant approval exceeds configured money alert threshold.'
             && $context['grant_id'] === $grant->id);
+    }
+
+    public function test_deny_grant_rechecks_pending_state_before_updating_status(): void
+    {
+        Notification::fake();
+
+        $grant = $this->createGrant();
+        $nation = $this->createNation();
+        $account = $this->createAccount($nation);
+        $application = GrantApplication::query()->create([
+            'grant_id' => $grant->id,
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'status' => 'pending',
+            'pending_key' => 1,
+        ]);
+        $staleApplication = GrantApplication::query()->findOrFail($application->id);
+
+        GrantApplication::query()
+            ->whereKey($application->id)
+            ->update([
+                'status' => 'approved',
+                'pending_key' => null,
+                'approved_at' => now(),
+            ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Grant application is not pending.');
+
+        try {
+            GrantService::denyGrant($staleApplication);
+        } finally {
+            $application->refresh();
+
+            $this->assertSame('approved', $application->status);
+            $this->assertNull($application->denied_at);
+            Notification::assertNothingSent();
+        }
     }
 
     private function createNation(): Nation

--- a/tests/Unit/Services/PageRendererSecurityTest.php
+++ b/tests/Unit/Services/PageRendererSecurityTest.php
@@ -75,4 +75,37 @@ class PageRendererSecurityTest extends UnitTestCase
         $this->assertStringContainsString('https://www.youtube.com/embed/abc123', $html);
         $this->assertSame(1, substr_count($html, '<iframe '));
     }
+
+    public function test_render_raw_html_preserves_safe_admin_formatting_and_strips_dangerous_output(): void
+    {
+        $html = (new PageRenderer)->render([
+            'html' => <<<'HTML'
+                <h2 class="ck-heading_heading2" onclick="alert(1)">Apply Today</h2>
+                <script>alert(1)</script>
+                <p style="color: red; background-image: url(javascript:alert(1)); text-align: center">
+                    <a href="javascript:alert(1)">Bad</a>
+                    <a href="/apply" target="_blank">Safe</a>
+                </p>
+                <figure class="table"><table><tbody><tr><td colspan="2">Details</td></tr></tbody></table></figure>
+                <iframe src="https://evil.example/embed/1"></iframe>
+                <iframe src="https://www.youtube.com/embed/abc123" onload="alert(1)" allowfullscreen></iframe>
+            HTML,
+        ]);
+
+        $this->assertStringContainsString('class="ck-heading_heading2"', $html);
+        $this->assertStringContainsString('<table>', $html);
+        $this->assertStringContainsString('colspan="2"', $html);
+        $this->assertStringContainsString('color: red', $html);
+        $this->assertStringContainsString('text-align: center', $html);
+        $this->assertStringContainsString('href="/apply"', $html);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $html);
+        $this->assertStringContainsString('https://www.youtube.com/embed/abc123', $html);
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringNotContainsString('onclick=', $html);
+        $this->assertStringNotContainsString('onload=', $html);
+        $this->assertStringNotContainsString('javascript:', $html);
+        $this->assertStringNotContainsString('evil.example', $html);
+        $this->assertSame(1, substr_count($html, '<iframe '));
+    }
 }

--- a/tests/Unit/Services/QueryServiceTest.php
+++ b/tests/Unit/Services/QueryServiceTest.php
@@ -117,4 +117,34 @@ class QueryServiceTest extends FeatureTestCase
             Http::assertSentCount(3);
         }
     }
+
+    public function test_send_query_does_not_retry_mutations_after_ambiguous_server_error(): void
+    {
+        Http::fake([
+            '*' => Http::sequence()
+                ->push('temporary upstream failure', 503)
+                ->push([
+                    'data' => [
+                        'bankWithdraw' => [
+                            'id' => 987,
+                        ],
+                    ],
+                ], 200),
+        ]);
+
+        $service = new QueryService;
+        $builder = (new GraphQLQueryBuilder)
+            ->setRootField('bankWithdraw')
+            ->setMutation()
+            ->addFields(['id']);
+
+        $this->expectException(PWQueryFailedException::class);
+        $this->expectExceptionMessage('GraphQL mutation failed with an ambiguous upstream response and was not retried');
+
+        try {
+            $service->sendQuery($builder);
+        } finally {
+            Http::assertSentCount(1);
+        }
+    }
 }

--- a/tests/Unit/Services/RebuildingServiceTest.php
+++ b/tests/Unit/Services/RebuildingServiceTest.php
@@ -190,6 +190,58 @@ class RebuildingServiceTest extends FeatureTestCase
         $this->makeService()->denyRequest($request);
     }
 
+    public function test_approve_request_rechecks_pending_state_before_crediting_account(): void
+    {
+        $tier = $this->createTier();
+        $nation = Nation::factory()->create([
+            'alliance_id' => 777,
+            'alliance_position' => 'MEMBER',
+            'num_cities' => 5,
+        ]);
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Primary';
+        $account->save();
+
+        $request = RebuildingRequest::query()->create([
+            'cycle_id' => 7,
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'tier_id' => $tier->id,
+            'city_count_snapshot' => 5,
+            'target_infrastructure_snapshot' => 1700,
+            'estimated_amount' => 1000,
+            'status' => 'pending',
+            'pending_key' => 1,
+        ]);
+        $staleRequest = RebuildingRequest::query()->findOrFail($request->id);
+
+        RebuildingRequest::query()
+            ->whereKey($request->id)
+            ->update([
+                'status' => 'denied',
+                'pending_key' => null,
+                'denied_at' => now(),
+            ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Only pending requests can be approved.');
+
+        try {
+            $this->makeService()->approveRequest($staleRequest);
+        } finally {
+            $request->refresh();
+            $account->refresh();
+
+            $this->assertSame('denied', $request->status);
+            $this->assertSame(0.0, (float) $account->money);
+            $this->assertDatabaseMissing('manual_transactions', [
+                'account_id' => $account->id,
+                'money' => 1000,
+            ]);
+        }
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
## Summary
- Harden grant, city grant, rebuilding, and GraphQL mutation workflows against stale state, duplicate pending actions, and ambiguous retries.
- Sanitize admin-authored custom page HTML while preserving supported rich formatting and embeds.
- Refresh the user dashboard presentation, comparison components, chart theming, sync card markup, and scheduler overlap guards.
- Add focused PHPUnit coverage for workflow races, renderer security, mutation retry handling, and dashboard rendering.

## Operational Notes
- Scheduled deposits and tax collection now use `withoutOverlapping()` and `onOneServer()`, so production scheduler cache/lock backend behavior should be healthy.
- Existing published custom page cached HTML may need to be republished or cache-cleared if maintainers want previously cached content rebuilt through the new sanitizer immediately.

## Validation
- `./vendor/bin/pint --dirty`
- `php artisan test tests/Unit/Services/CityGrantServiceTest.php tests/Unit/Services/GrantServiceTest.php tests/Unit/Services/PageRendererSecurityTest.php tests/Unit/Services/QueryServiceTest.php tests/Unit/Services/RebuildingServiceTest.php tests/Feature/UserDashboardTest.php tests/Feature/Workflows/RebuildingWorkflowTest.php tests/Feature/Workflows/CityGrantWorkflowTest.php tests/Feature/Workflows/GrantWorkflowTest.php`
- `npm run build`
- `git diff --check`