### PR TITLE
Fix Growth Circles admin URL and add sidebar link

### DIFF
--- a/resources/views/livewire/admin/app-sidebar.blade.php
+++ b/resources/views/livewire/admin/app-sidebar.blade.php
@@ -129,6 +129,14 @@
             :hidden="! auth()->user()?->can('view-taxes')"
         />
 
+        <x-menu-item no-wire-navigate
+            title="Growth Circles"
+            icon="o-arrow-trending-up"
+            :link="route('admin.growth-circles.index')"
+            :active="request()->routeIs('admin.growth-circles.*')"
+            :hidden="! auth()->user()?->can('view-growth-circles')"
+        />
+
         <x-menu-sub
             title="Finance"
             icon="o-currency-dollar"

--- a/routes/web.php
+++ b/routes/web.php
@@ -343,20 +343,20 @@ Route::middleware(['auth', EnsureUserIsVerified::class, DiscordVerifiedMiddlewar
             ->name('admin.dd.brackets.delete');
 
         // Growth Circles
-        Route::get('/admin/growth-circles', [AdminGrowthCirclesController::class, 'index'])
+        Route::get('/growth-circles', [AdminGrowthCirclesController::class, 'index'])
             ->name('admin.growth-circles.index');
 
-        Route::get('/admin/growth-circles/history', [AdminGrowthCirclesController::class, 'history'])
+        Route::get('/growth-circles/history', [AdminGrowthCirclesController::class, 'history'])
             ->name('admin.growth-circles.history');
 
-        Route::post('/admin/growth-circles/settings', [AdminGrowthCirclesController::class, 'saveSettings'])
+        Route::post('/growth-circles/settings', [AdminGrowthCirclesController::class, 'saveSettings'])
             ->name('admin.growth-circles.settings');
 
-        Route::post('/admin/growth-circles/enrollments/{nation}/disenroll', [AdminGrowthCirclesController::class, 'forceDisenroll'])
+        Route::post('/growth-circles/enrollments/{nation}/disenroll', [AdminGrowthCirclesController::class, 'forceDisenroll'])
             ->name('admin.growth-circles.force-disenroll')
             ->middleware(BlockWhenPWDown::class);
 
-        Route::post('/admin/growth-circles/enrollments/{nation}/reapply-bracket', [AdminGrowthCirclesController::class, 'reapplyBracket'])
+        Route::post('/growth-circles/enrollments/{nation}/reapply-bracket', [AdminGrowthCirclesController::class, 'reapplyBracket'])
             ->name('admin.growth-circles.reapply-bracket')
             ->middleware(BlockWhenPWDown::class);
 


### PR DESCRIPTION
## Summary
- **Fix:** Growth Circles admin routes were defined with a hard-coded `/admin/` prefix while already inside the `->prefix('admin')` group, registering them at `/admin/admin/growth-circles` instead of `/admin/growth-circles`. The named-route references work, but the page was unreachable at the documented URL. Stripped the doubled prefix.
- **Add:** Surfaces the admin Growth Circles page in the sidebar under Economics (between Taxes and Finance), gated on the existing `view-growth-circles` permission.

Note: the four `/admin/admin/direct-deposit/*` POST routes added just above have the same doubled-prefix bug. Not fixing them here since they're outside the scope of this work — worth a follow-up.

## Test plan
- [ ] `/admin/growth-circles` loads (currently 404s on main; should return the index page after this PR).
- [ ] Sidebar shows "Growth Circles" under Economics for users with `view-growth-circles`; hidden otherwise.
- [ ] History link works (`/admin/growth-circles/history`).
- [ ] Force-disenroll and reapply-bracket POSTs still submit successfully (they use `route()` helper so the named-route resolution keeps working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)