### PR TITLE
Fix Growth Circles and Direct Deposit enrollment race

### DIFF
--- a/app/Services/DirectDepositService.php
+++ b/app/Services/DirectDepositService.php
@@ -211,27 +211,33 @@ class DirectDepositService
 
     public function enroll(Nation $nation, Account $account): void
     {
-        if (GrowthCircleEnrollment::query()->where('nation_id', $nation->id)->exists()) {
-            throw new UserErrorException(
-                'You are currently enrolled in Growth Circles. Contact an admin to disenroll before joining DirectDeposit.'
-            );
-        }
-
         $ddTaxId = $this->ddTaxId;
-        $currentTaxId = $nation->tax_id;
 
-        $previousTaxId = ($currentTaxId === $ddTaxId)
-            ? SettingService::getDirectDepositFallbackId()
-            : $currentTaxId;
+        DB::transaction(function () use ($nation, $account, $ddTaxId): void {
+            $lockedNation = Nation::query()->whereKey($nation->id)->lockForUpdate()->first();
+            if (! $lockedNation) {
+                throw new UserErrorException('Nation was not found.');
+            }
 
-        DirectDepositEnrollment::updateOrCreate(
-            ['nation_id' => $nation->id],
-            [
-                'account_id' => $account->id,
-                'previous_tax_id' => $previousTaxId,
-                'enrolled_at' => now(),
-            ]
-        );
+            if (GrowthCircleEnrollment::query()->where('nation_id', $lockedNation->id)->exists()) {
+                throw new UserErrorException(
+                    'You are currently enrolled in Growth Circles. Contact an admin to disenroll before joining DirectDeposit.'
+                );
+            }
+
+            $previousTaxId = ((int) $lockedNation->tax_id === $ddTaxId)
+                ? SettingService::getDirectDepositFallbackId()
+                : (int) $lockedNation->tax_id;
+
+            DirectDepositEnrollment::query()->updateOrCreate(
+                ['nation_id' => $lockedNation->id],
+                [
+                    'account_id' => $account->id,
+                    'previous_tax_id' => $previousTaxId,
+                    'enrolled_at' => now(),
+                ]
+            );
+        });
 
         $mutation = new TaxBracketService;
         $mutation->id = $ddTaxId;

--- a/app/Services/GrowthCircleService.php
+++ b/app/Services/GrowthCircleService.php
@@ -72,27 +72,34 @@ class GrowthCircleService
             throw new UserErrorException('Growth Circles is not configured. Contact an admin.');
         }
 
-        if ($ddEnrollment = DirectDepositEnrollment::query()->where('nation_id', $nation->id)->first()) {
-            $previousTaxId = (int) $ddEnrollment->previous_tax_id;
-            app(DirectDepositService::class)->disenroll($nation);
-            $auditAction = 'switched_from_dd';
-        } elseif ($existing = GrowthCircleEnrollment::query()->where('nation_id', $nation->id)->first()) {
-            $previousTaxId = (int) $existing->previous_tax_id;
-            $auditAction = 'enrolled';
-        } else {
-            $previousTaxId = (int) $nation->tax_id;
-            $auditAction = 'enrolled';
-        }
+        [$enrollment, $previousTaxId, $auditAction] = DB::transaction(function () use ($nation, $account): array {
+            $lockedNation = Nation::query()->whereKey($nation->id)->lockForUpdate()->first();
+            if (! $lockedNation) {
+                throw new UserErrorException('Nation was not found.');
+            }
 
-        $enrollment = DB::transaction(function () use ($nation, $account, $previousTaxId): GrowthCircleEnrollment {
-            return GrowthCircleEnrollment::query()->updateOrCreate(
-                ['nation_id' => $nation->id],
+            $auditAction = 'enrolled';
+
+            if ($ddEnrollment = DirectDepositEnrollment::query()->where('nation_id', $lockedNation->id)->first()) {
+                $previousTaxId = (int) $ddEnrollment->previous_tax_id;
+                $ddEnrollment->delete();
+                $auditAction = 'switched_from_dd';
+            } elseif ($existing = GrowthCircleEnrollment::query()->where('nation_id', $lockedNation->id)->first()) {
+                $previousTaxId = (int) $existing->previous_tax_id;
+            } else {
+                $previousTaxId = (int) $lockedNation->tax_id;
+            }
+
+            $enrollment = GrowthCircleEnrollment::query()->updateOrCreate(
+                ['nation_id' => $lockedNation->id],
                 [
                     'account_id' => $account->id,
                     'previous_tax_id' => $previousTaxId,
                     'enrolled_at' => now(),
                 ],
             );
+
+            return [$enrollment, $previousTaxId, $auditAction];
         });
 
         $mutation = new TaxBracketService;
@@ -217,6 +224,29 @@ class GrowthCircleService
                     Log::info('growth_circles.skip', [
                         'nation_id' => $nation->id,
                         'reason' => $eligibility['reason'],
+                        'cycle_date' => $cycleDate,
+                    ]);
+
+                    return 'skipped';
+                }
+
+                $growthCirclesTaxId = SettingService::getGrowthCirclesTaxId();
+                if ((int) $nation->tax_id !== $growthCirclesTaxId) {
+                    Log::warning('growth_circles.skip', [
+                        'nation_id' => $nation->id,
+                        'reason' => 'tax_mismatch',
+                        'cycle_date' => $cycleDate,
+                        'expected_tax_id' => $growthCirclesTaxId,
+                        'actual_tax_id' => (int) $nation->tax_id,
+                    ]);
+
+                    return 'skipped';
+                }
+
+                if (DirectDepositEnrollment::query()->where('nation_id', $nation->id)->exists()) {
+                    Log::warning('growth_circles.skip', [
+                        'nation_id' => $nation->id,
+                        'reason' => 'direct_deposit_enrolled',
                         'cycle_date' => $cycleDate,
                     ]);
 


### PR DESCRIPTION
### Motivation
- Close a high-severity race that allowed a nation to become enrolled in both Growth Circles and Direct Deposit concurrently and then continue receiving Growth Circles resource credits after restoring a non-Growth tax bracket.
- Ensure mutual-exclusion and tax-bracket consistency are enforced atomically to protect alliance ledger integrity and prevent recurring unauthorized resource credits.

### Description
- Serialize Direct Deposit enrollment by acquiring a `Nation` row lock inside a DB transaction and performing the Growth Circles conflict check and DD `updateOrCreate` while locked (changes in `app/Services/DirectDepositService.php`).
- Serialize Growth Circles enrollment by acquiring the same `Nation` row lock inside a DB transaction, remove any existing Direct Deposit enrollment in-transaction, then upsert the Growth Circles enrollment so the switch is atomic (changes in `app/Services/GrowthCircleService.php`).
- Harden Growth Circles daily `distributeOne` to skip payouts when the nation's current `tax_id` does not match the configured Growth Circles tax or when a `DirectDepositEnrollment` still exists, preventing distributions from inconsistent states (changes in `app/Services/GrowthCircleService.php`).
- Kept the outward audit/messages behavior intact while making the enrollment/disenroll transitions atomic and deterministic.

### Testing
- Ran PHP syntax checks with `php -l app/Services/DirectDepositService.php` and `php -l app/Services/GrowthCircleService.php`, both succeeded. 
- Attempted to run `./vendor/bin/pint --dirty` but it failed because `vendor/bin/pint` is not present in the execution environment. 
- Confirmed files were updated and committed locally; no automated PHPUnit or feature tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e1fb6518832394edbb196b514be1)