### PR TITLE
Expand Growth Circles resource coverage

### DIFF
--- a/app/Console/Commands/DistributeGrowthCirclesCommand.php
+++ b/app/Console/Commands/DistributeGrowthCirclesCommand.php
@@ -11,7 +11,7 @@ class DistributeGrowthCirclesCommand extends Command
 {
     protected $signature = 'growth-circles:distribute {--cycle-date= : Override the cycle date (YYYY-MM-DD UTC). Defaults to today UTC.}';
 
-    protected $description = 'Run the daily Growth Circles distribution: credit each enrolled member their food and uranium shortfall.';
+    protected $description = 'Run the daily Growth Circles distribution: credit each enrolled member their resource shortfalls.';
 
     public function handle(GrowthCircleService $service): int
     {

--- a/app/DataTransferObjects/AllianceFinanceData.php
+++ b/app/DataTransferObjects/AllianceFinanceData.php
@@ -113,8 +113,7 @@ final class AllianceFinanceData
         Nation $nation,
         Account $account,
         GrowthCircleDistribution $distribution,
-        float $food,
-        float $uranium,
+        array $resources,
     ): self {
         return new self(
             direction: AllianceFinanceEntry::DIRECTION_EXPENSE,
@@ -124,8 +123,13 @@ final class AllianceFinanceData
             nationId: $nation->id,
             accountId: $account->id,
             source: $distribution,
-            food: $food,
-            uranium: $uranium,
+            coal: (float) ($resources['coal'] ?? 0.0),
+            oil: (float) ($resources['oil'] ?? 0.0),
+            uranium: (float) ($resources['uranium'] ?? 0.0),
+            iron: (float) ($resources['iron'] ?? 0.0),
+            bauxite: (float) ($resources['bauxite'] ?? 0.0),
+            lead: (float) ($resources['lead'] ?? 0.0),
+            food: (float) ($resources['food'] ?? 0.0),
             meta: [
                 'cycle_date' => $distribution->cycle_date instanceof CarbonInterface
                     ? $distribution->cycle_date->toDateString()

--- a/app/GraphQL/Models/War.php
+++ b/app/GraphQL/Models/War.php
@@ -6,6 +6,11 @@ use stdClass;
 
 class War
 {
+    /**
+     * @var array<int, Attack>
+     */
+    public array $attacks = [];
+
     public int $id;
 
     public string $reason;

--- a/app/GraphQL/Models/Wars.php
+++ b/app/GraphQL/Models/Wars.php
@@ -44,4 +44,9 @@ class Wars implements Iterator
     {
         $this->wars[] = $war;
     }
+
+    public function count(): int
+    {
+        return count($this->wars);
+    }
 }

--- a/app/Http/Controllers/Admin/GrowthCirclesController.php
+++ b/app/Http/Controllers/Admin/GrowthCirclesController.php
@@ -26,11 +26,14 @@ class GrowthCirclesController extends Controller
     {
         $this->authorize('view-growth-circles');
 
+        $resourceKeys = GrowthCircleDistribution::distributionResourceKeys();
+        $resourceLabels = GrowthCircleDistribution::distributionResourceLabels();
+
         $enrollments = GrowthCircleEnrollment::query()
             ->with(['nation', 'account'])
             ->orderBy('enrolled_at')
             ->get()
-            ->map(function (GrowthCircleEnrollment $enrollment): array {
+            ->map(function (GrowthCircleEnrollment $enrollment) use ($resourceKeys): array {
                 $eligibility = $enrollment->nation
                     ? $this->growthCircles->evaluateEligibility($enrollment->nation)
                     : ['eligible' => false, 'reason' => 'Nation no longer exists.'];
@@ -43,21 +46,27 @@ class GrowthCirclesController extends Controller
                 $sevenDayTotal = GrowthCircleDistribution::query()
                     ->where('nation_id', $enrollment->nation_id)
                     ->where('cycle_date', '>=', now()->subDays(7)->toDateString())
-                    ->selectRaw('COALESCE(SUM(food), 0) as food, COALESCE(SUM(uranium), 0) as uranium')
+                    ->selectRaw(collect($resourceKeys)->map(fn (string $resource): string => "COALESCE(SUM({$resource}), 0) as {$resource}")->implode(', '))
                     ->first();
+
+                $sevenDayResources = collect($resourceKeys)
+                    ->mapWithKeys(fn (string $resource): array => [
+                        $resource => (float) ($sevenDayTotal->{$resource} ?? 0),
+                    ])
+                    ->all();
 
                 return [
                     'enrollment' => $enrollment,
                     'eligibility' => $eligibility,
                     'last' => $last,
-                    'seven_day_food' => (float) ($sevenDayTotal->food ?? 0),
-                    'seven_day_uranium' => (float) ($sevenDayTotal->uranium ?? 0),
+                    'seven_day_resources' => $sevenDayResources,
                 ];
             });
 
         return view('admin.growth-circles.index', [
             'taxId' => SettingService::getGrowthCirclesTaxId(),
             'fallbackTaxId' => SettingService::getGrowthCirclesFallbackTaxId(),
+            'resourceLabels' => $resourceLabels,
             'rows' => $enrollments,
         ]);
     }
@@ -85,6 +94,7 @@ class GrowthCirclesController extends Controller
         }
 
         return view('admin.growth-circles.history', [
+            'resourceLabels' => GrowthCircleDistribution::distributionResourceLabels(),
             'rows' => $query->paginate(50)->withQueryString(),
         ]);
     }

--- a/app/Models/GrowthCircleDistribution.php
+++ b/app/Models/GrowthCircleDistribution.php
@@ -12,18 +12,52 @@ class GrowthCircleDistribution extends Model
 
     public $timestamps = false;
 
+    /**
+     * @return array<int, string>
+     */
+    public static function distributionResourceKeys(): array
+    {
+        return ['coal', 'oil', 'uranium', 'iron', 'bauxite', 'lead', 'food'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function distributionResourceLabels(): array
+    {
+        return [
+            'coal' => 'Coal',
+            'oil' => 'Oil',
+            'uranium' => 'Uranium',
+            'iron' => 'Iron',
+            'bauxite' => 'Bauxite',
+            'lead' => 'Lead',
+            'food' => 'Food',
+        ];
+    }
+
     protected $fillable = [
         'nation_id',
         'account_id',
         'enrollment_id',
-        'food',
+        'coal',
+        'oil',
         'uranium',
+        'iron',
+        'bauxite',
+        'lead',
+        'food',
         'cycle_date',
     ];
 
     protected $casts = [
-        'food' => 'float',
+        'coal' => 'float',
+        'oil' => 'float',
         'uranium' => 'float',
+        'iron' => 'float',
+        'bauxite' => 'float',
+        'lead' => 'float',
+        'food' => 'float',
         'cycle_date' => 'date',
         'created_at' => 'datetime',
     ];

--- a/app/Services/GrowthCircleService.php
+++ b/app/Services/GrowthCircleService.php
@@ -253,7 +253,7 @@ class GrowthCircleService
                     return 'skipped';
                 }
 
-                $shortfall = app(NationProfitabilityService::class)->getDailyResourceShortfall($nation);
+                $shortfall = app(NationProfitabilityService::class)->getDailyGrowthCircleShortfalls($nation);
                 if ($shortfall === null) {
                     Log::warning('growth_circles.no_snapshot', [
                         'nation_id' => $nation->id,
@@ -263,7 +263,7 @@ class GrowthCircleService
                     return 'skipped';
                 }
 
-                if ($shortfall['food'] <= 0.0 && $shortfall['uranium'] <= 0.0) {
+                if (collect(GrowthCircleDistribution::distributionResourceKeys())->every(fn (string $resource): bool => ($shortfall[$resource] ?? 0.0) <= 0.0)) {
                     Log::info('growth_circles.no_shortfall', [
                         'nation_id' => $nation->id,
                         'cycle_date' => $cycleDate,
@@ -291,16 +291,16 @@ class GrowthCircleService
                 // (RecordAllianceExpense) writes only an
                 // AllianceFinanceEntry for reporting; it does not touch
                 // Account balances. This matches DirectDepositService::process.
-                $account->food += $shortfall['food'];
-                $account->uranium += $shortfall['uranium'];
+                foreach (GrowthCircleDistribution::distributionResourceKeys() as $resource) {
+                    $account->{$resource} += $shortfall[$resource] ?? 0.0;
+                }
                 $account->save();
 
                 $distribution = GrowthCircleDistribution::query()->create([
                     'nation_id' => $nation->id,
                     'account_id' => $account->id,
                     'enrollment_id' => $enrollment->id,
-                    'food' => $shortfall['food'],
-                    'uranium' => $shortfall['uranium'],
+                    ...$shortfall,
                     'cycle_date' => $cycleDate,
                 ]);
 
@@ -309,8 +309,7 @@ class GrowthCircleService
                         $nation,
                         $account,
                         $distribution,
-                        $shortfall['food'],
-                        $shortfall['uranium'],
+                        $shortfall,
                     )->toArray()
                 ));
 

--- a/app/Services/NationProfitabilityService.php
+++ b/app/Services/NationProfitabilityService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\GraphQL\Models\Nation as GraphQLNation;
 use App\Models\City;
+use App\Models\GrowthCircleDistribution;
 use App\Models\Nation;
 use App\Models\NationMilitary;
 use App\Models\NationProfitabilitySnapshot;
@@ -44,6 +45,7 @@ class NationProfitabilityService
      *
      * @return array{food: float, uranium: float}|null
      *                                                 Null if no snapshot exists for this nation.
+     * @deprecated Growth Circles now uses getDailyGrowthCircleShortfalls().
      */
     public function getDailyResourceShortfall(Nation $nation): ?array
     {
@@ -62,6 +64,35 @@ class NationProfitabilityService
             'food' => max(0.0, -(float) ($perDay['food'] ?? 0.0)),
             'uranium' => max(0.0, -(float) ($perDay['uranium'] ?? 0.0)),
         ];
+    }
+
+    /**
+     * Daily shortfall (consumption above production) for the resources
+     * Growth Circles distributes.
+     *
+     * Net producers (production >= consumption) receive 0 for that resource.
+     * Net consumers receive their daily deficit (a positive float).
+     *
+     * @return array{coal: float, oil: float, uranium: float, iron: float, bauxite: float, lead: float, food: float}|null
+     */
+    public function getDailyGrowthCircleShortfalls(Nation $nation): ?array
+    {
+        $snapshot = NationProfitabilitySnapshot::query()
+            ->where('nation_id', $nation->id)
+            ->latest('calculated_at')
+            ->first();
+
+        if (! $snapshot) {
+            return null;
+        }
+
+        $perDay = $snapshot->resource_profit_per_day ?? [];
+
+        return collect(GrowthCircleDistribution::distributionResourceKeys())
+            ->mapWithKeys(fn (string $resource): array => [
+                $resource => max(0.0, -(float) ($perDay[$resource] ?? 0.0)),
+            ])
+            ->all();
     }
 
     /**

--- a/database/migrations/2026_07_06_000001_add_raw_resources_to_growth_circle_distributions_table.php
+++ b/database/migrations/2026_07_06_000001_add_raw_resources_to_growth_circle_distributions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('growth_circle_distributions', function (Blueprint $table): void {
+            $table->decimal('coal', 20, 2)->default(0);
+            $table->decimal('oil', 20, 2)->default(0);
+            $table->decimal('iron', 20, 2)->default(0);
+            $table->decimal('bauxite', 20, 2)->default(0);
+            $table->decimal('lead', 20, 2)->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('growth_circle_distributions', function (Blueprint $table): void {
+            $table->dropColumn(['coal', 'oil', 'iron', 'bauxite', 'lead']);
+        });
+    }
+};

--- a/resources/views/accounts/components/growth_circles.blade.php
+++ b/resources/views/accounts/components/growth_circles.blade.php
@@ -30,26 +30,28 @@
         @if ($gcRecentDistributions->isNotEmpty())
             <details class="rounded-lg border border-base-300 p-3">
                 <summary class="cursor-pointer text-sm font-medium">Recent distributions (last 7 cycles)</summary>
-                <table class="table table-xs mt-2 w-full">
-                    <thead>
-                    <tr>
-                        <th>Cycle</th>
-                        @foreach ($resourceLabels as $resource => $label)
-                            <th class="text-right">{{ $label }}</th>
-                        @endforeach
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach ($gcRecentDistributions as $row)
+                <div class="mt-2 overflow-x-auto">
+                    <table class="table table-xs w-full">
+                        <thead>
                         <tr>
-                            <td>{{ $row->cycle_date->toDateString() }}</td>
+                            <th>Cycle</th>
                             @foreach ($resourceLabels as $resource => $label)
-                                <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                                <th class="text-right">{{ $label }}</th>
                             @endforeach
                         </tr>
-                    @endforeach
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                        @foreach ($gcRecentDistributions as $row)
+                            <tr>
+                                <td>{{ $row->cycle_date->toDateString() }}</td>
+                                @foreach ($resourceLabels as $resource => $label)
+                                    <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                                @endforeach
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </details>
         @endif
 
@@ -79,26 +81,28 @@
         @if ($gcRecentDistributions->isNotEmpty())
             <details class="rounded-lg border border-base-300 p-3">
                 <summary class="cursor-pointer text-sm font-medium">Recent distributions (last 7 cycles)</summary>
-                <table class="table table-xs mt-2 w-full">
-                    <thead>
-                    <tr>
-                        <th>Cycle</th>
-                        @foreach ($resourceLabels as $resource => $label)
-                            <th class="text-right">{{ $label }}</th>
-                        @endforeach
-                    </tr>
-                    </thead>
-                    <tbody>
-                    @foreach ($gcRecentDistributions as $row)
+                <div class="mt-2 overflow-x-auto">
+                    <table class="table table-xs w-full">
+                        <thead>
                         <tr>
-                            <td>{{ $row->cycle_date->toDateString() }}</td>
+                            <th>Cycle</th>
                             @foreach ($resourceLabels as $resource => $label)
-                                <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                                <th class="text-right">{{ $label }}</th>
                             @endforeach
                         </tr>
-                    @endforeach
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                        @foreach ($gcRecentDistributions as $row)
+                            <tr>
+                                <td>{{ $row->cycle_date->toDateString() }}</td>
+                                @foreach ($resourceLabels as $resource => $label)
+                                    <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                                @endforeach
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
             </details>
         @endif
 

--- a/resources/views/accounts/components/growth_circles.blade.php
+++ b/resources/views/accounts/components/growth_circles.blade.php
@@ -3,11 +3,11 @@
     $isPaused = $isEnrolled && ! ($gcEligibility['eligible'] ?? true);
     $isEligible = (bool) ($gcEligibility['eligible'] ?? false);
     $lastDistribution = $gcRecentDistributions->first();
+    $resourceLabels = \App\Models\GrowthCircleDistribution::distributionResourceLabels();
 @endphp
 
 <x-utils.card title="Growth Circles" extraClasses="space-y-3">
     @if ($isEnrolled && ! $isPaused)
-        {{-- Active enrollment --}}
         <div class="rounded-xl bg-success/10 border border-success/30 p-4">
             <p class="text-success font-semibold">
                 Enrolled — depositing into
@@ -19,8 +19,9 @@
             <p class="text-sm">
                 <span class="font-semibold">Last distribution:</span>
                 {{ $lastDistribution->cycle_date->toDateString() }} —
-                {{ number_format($lastDistribution->food, 2) }} food,
-                {{ number_format($lastDistribution->uranium, 2) }} uranium
+                @foreach ($resourceLabels as $resource => $label)
+                    {{ number_format($lastDistribution->{$resource}, 2) }} {{ strtolower($label) }}@if (! $loop->last), @endif
+                @endforeach
             </p>
         @else
             <p class="text-sm text-base-content/60">No distributions yet.</p>
@@ -33,16 +34,18 @@
                     <thead>
                     <tr>
                         <th>Cycle</th>
-                        <th class="text-right">Food</th>
-                        <th class="text-right">Uranium</th>
+                        @foreach ($resourceLabels as $resource => $label)
+                            <th class="text-right">{{ $label }}</th>
+                        @endforeach
                     </tr>
                     </thead>
                     <tbody>
                     @foreach ($gcRecentDistributions as $row)
                         <tr>
                             <td>{{ $row->cycle_date->toDateString() }}</td>
-                            <td class="text-right">{{ number_format($row->food, 2) }}</td>
-                            <td class="text-right">{{ number_format($row->uranium, 2) }}</td>
+                            @foreach ($resourceLabels as $resource => $label)
+                                <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                            @endforeach
                         </tr>
                     @endforeach
                     </tbody>
@@ -51,11 +54,9 @@
         @endif
 
         <p class="text-xs text-base-content/60">Next distribution: tomorrow ~03:00 UTC.</p>
-
         <p class="text-xs text-base-content/60">Contact an admin if you need to leave the program.</p>
 
     @elseif ($isPaused)
-        {{-- Enrolled but paused --}}
         <div class="rounded-xl bg-warning/10 border border-warning/40 p-4">
             <p class="mb-1 text-warning font-semibold">Paused — {{ $gcEligibility['reason'] }}</p>
             <p class="text-sm text-base-content/80">
@@ -69,8 +70,9 @@
             <p class="text-sm">
                 <span class="font-semibold">Last distribution:</span>
                 {{ $lastDistribution->cycle_date->toDateString() }} —
-                {{ number_format($lastDistribution->food, 2) }} food,
-                {{ number_format($lastDistribution->uranium, 2) }} uranium
+                @foreach ($resourceLabels as $resource => $label)
+                    {{ number_format($lastDistribution->{$resource}, 2) }} {{ strtolower($label) }}@if (! $loop->last), @endif
+                @endforeach
             </p>
         @endif
 
@@ -81,16 +83,18 @@
                     <thead>
                     <tr>
                         <th>Cycle</th>
-                        <th class="text-right">Food</th>
-                        <th class="text-right">Uranium</th>
+                        @foreach ($resourceLabels as $resource => $label)
+                            <th class="text-right">{{ $label }}</th>
+                        @endforeach
                     </tr>
                     </thead>
                     <tbody>
                     @foreach ($gcRecentDistributions as $row)
                         <tr>
                             <td>{{ $row->cycle_date->toDateString() }}</td>
-                            <td class="text-right">{{ number_format($row->food, 2) }}</td>
-                            <td class="text-right">{{ number_format($row->uranium, 2) }}</td>
+                            @foreach ($resourceLabels as $resource => $label)
+                                <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                            @endforeach
                         </tr>
                     @endforeach
                     </tbody>
@@ -101,11 +105,10 @@
         <p class="text-xs text-base-content/60">Contact an admin if you need to leave the program.</p>
 
     @else
-        {{-- Not enrolled --}}
         <div class="rounded-xl bg-info/10 border border-info/30 p-4">
             <p class="mb-1 text-info font-semibold">Growth Circles</p>
             <p class="text-sm text-base-content/80">
-                Contribute 100% of your tax income. In return, the alliance ships your daily food and uranium consumption to your selected account.
+                Contribute 100% of your tax income. In return, the alliance covers your daily food, uranium, and raw-resource shortfalls in your selected account.
             </p>
         </div>
 

--- a/resources/views/admin/growth-circles/history.blade.php
+++ b/resources/views/admin/growth-circles/history.blade.php
@@ -3,6 +3,9 @@
 @section('content')
     <div class="space-y-6">
         @can('view-growth-circles')
+            @php
+                $resourceLabels = $resourceLabels ?? \App\Models\GrowthCircleDistribution::distributionResourceLabels();
+            @endphp
             <x-card title="Growth Circles Distribution History">
                 <form method="GET" action="{{ route('admin.growth-circles.history') }}" class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-4">
                     <label class="block">
@@ -38,8 +41,9 @@
                                 <th>Cycle</th>
                                 <th>Nation</th>
                                 <th>Account</th>
-                                <th class="text-right">Food</th>
-                                <th class="text-right">Uranium</th>
+                                @foreach ($resourceLabels as $resource => $label)
+                                    <th class="text-right">{{ $label }}</th>
+                                @endforeach
                             </tr>
                             </thead>
                             <tbody>
@@ -48,8 +52,9 @@
                                     <td>{{ $row->cycle_date->toDateString() }}</td>
                                     <td>{{ $row->nation?->nation_name ?? '(deleted)' }}</td>
                                     <td>{{ $row->account?->name ?? '(deleted)' }}</td>
-                                    <td class="text-right">{{ number_format($row->food, 2) }}</td>
-                                    <td class="text-right">{{ number_format($row->uranium, 2) }}</td>
+                                    @foreach ($resourceLabels as $resource => $label)
+                                        <td class="text-right">{{ number_format($row->{$resource}, 2) }}</td>
+                                    @endforeach
                                 </tr>
                             @endforeach
                             </tbody>

--- a/resources/views/admin/growth-circles/index.blade.php
+++ b/resources/views/admin/growth-circles/index.blade.php
@@ -3,6 +3,9 @@
 @section('content')
     <div class="space-y-6">
         @can('view-growth-circles')
+            @php
+                $resourceLabels = $resourceLabels ?? \App\Models\GrowthCircleDistribution::distributionResourceLabels();
+            @endphp
 
             {{-- Settings card --}}
             <x-card title="Growth Circles Settings">
@@ -59,8 +62,9 @@
                                 <th>Account</th>
                                 <th>Enrolled</th>
                                 <th>Last distribution</th>
-                                <th class="text-right">7-day food</th>
-                                <th class="text-right">7-day uranium</th>
+                                @foreach ($resourceLabels as $resource => $label)
+                                    <th class="text-right">7-day {{ strtolower($label) }}</th>
+                                @endforeach
                                 <th>Status</th>
                                 @can('manage-growth-circles')
                                     <th class="text-right">Actions</th>
@@ -82,15 +86,18 @@
                                     <td>
                                         @if ($row['last'])
                                             {{ $row['last']->cycle_date->toDateString() }}
-                                            <span class="text-xs text-base-content/60">
-                                                ({{ number_format($row['last']->food, 2) }} F, {{ number_format($row['last']->uranium, 2) }} U)
+                                            <span class="mt-1 flex flex-wrap gap-1 text-xs text-base-content/60">
+                                                @foreach ($resourceLabels as $resource => $label)
+                                                    <span>{{ $label }} {{ number_format($row['last']->{$resource}, 2) }}</span>
+                                                @endforeach
                                             </span>
                                         @else
                                             <span class="text-base-content/50">—</span>
                                         @endif
                                     </td>
-                                    <td class="text-right">{{ number_format($row['seven_day_food'], 2) }}</td>
-                                    <td class="text-right">{{ number_format($row['seven_day_uranium'], 2) }}</td>
+                                    @foreach ($resourceLabels as $resource => $label)
+                                        <td class="text-right">{{ number_format($row['seven_day_resources'][$resource] ?? 0, 2) }}</td>
+                                    @endforeach
                                     <td>
                                         @if ($eligibility['eligible'])
                                             <span class="badge badge-success badge-sm">Active</span>

--- a/tests/Feature/Workflows/GrowthCircleDistributionTest.php
+++ b/tests/Feature/Workflows/GrowthCircleDistributionTest.php
@@ -6,6 +6,7 @@ use App\Models\Account;
 use App\Models\GrowthCircleDistribution;
 use App\Models\GrowthCircleEnrollment;
 use App\Models\Nation;
+use App\Models\NationProfitabilitySnapshot;
 use App\Models\User;
 use App\Services\GrowthCircleService;
 use App\Services\NationProfitabilityService;
@@ -108,5 +109,65 @@ class GrowthCircleDistributionTest extends TestCase
             'lead' => 1.5,
             'food' => 9.0,
         ]);
+    }
+
+    public function test_daily_growth_circle_shortfalls_are_read_from_the_target_nation_snapshot(): void
+    {
+        $nation = Nation::factory()->create([
+            'id' => 777002,
+        ]);
+
+        $otherNation = Nation::factory()->create([
+            'id' => 777003,
+        ]);
+
+        NationProfitabilitySnapshot::query()->create([
+            'nation_id' => $otherNation->id,
+            'leader_name' => 'Other Leader',
+            'nation_name' => 'Other Nation',
+            'cities' => 10,
+            'resource_profit_per_day' => [
+                'coal' => -999.0,
+                'oil' => -999.0,
+                'uranium' => -999.0,
+                'iron' => -999.0,
+                'bauxite' => -999.0,
+                'lead' => -999.0,
+                'food' => -999.0,
+            ],
+            'calculated_at' => now()->addDay(),
+        ]);
+
+        NationProfitabilitySnapshot::query()->create([
+            'nation_id' => $nation->id,
+            'leader_name' => 'Growth Leader',
+            'nation_name' => 'Growth Nation',
+            'cities' => 8,
+            'resource_profit_per_day' => [
+                'coal' => -12.5,
+                'oil' => 4.25,
+                'uranium' => -7.0,
+                'iron' => -8.75,
+                'bauxite' => 2.0,
+                'gasoline' => -99.0,
+                'munitions' => -88.0,
+                'steel' => -77.0,
+                'aluminum' => -66.0,
+                'food' => -9.0,
+            ],
+            'calculated_at' => now(),
+        ]);
+
+        $shortfalls = app(NationProfitabilityService::class)->getDailyGrowthCircleShortfalls($nation);
+
+        $this->assertSame([
+            'coal' => 12.5,
+            'oil' => 0.0,
+            'uranium' => 7.0,
+            'iron' => 8.75,
+            'bauxite' => 0.0,
+            'lead' => 0.0,
+            'food' => 9.0,
+        ], $shortfalls);
     }
 }

--- a/tests/Feature/Workflows/GrowthCircleDistributionTest.php
+++ b/tests/Feature/Workflows/GrowthCircleDistributionTest.php
@@ -6,13 +6,13 @@ use App\Models\Account;
 use App\Models\GrowthCircleDistribution;
 use App\Models\GrowthCircleEnrollment;
 use App\Models\Nation;
-use App\Models\NationProfitabilitySnapshot;
 use App\Models\User;
 use App\Services\GrowthCircleService;
+use App\Services\NationProfitabilityService;
 use App\Services\SettingService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Mockery;
 use Tests\TestCase;
 
 class GrowthCircleDistributionTest extends TestCase
@@ -49,7 +49,7 @@ class GrowthCircleDistributionTest extends TestCase
             'nation_id' => $nation->id,
             'account_id' => $account->id,
             'previous_tax_id' => 321,
-            'enrolled_at' => Carbon::parse('2026-07-05 03:00:00'),
+            'enrolled_at' => now(),
         ]);
 
         $shortfalls = [
@@ -62,28 +62,12 @@ class GrowthCircleDistributionTest extends TestCase
             'food' => 9.0,
         ];
 
-        NationProfitabilitySnapshot::query()->create([
-            'nation_id' => $nation->id,
-            'alliance_id' => 777,
-            'leader_name' => 'Leader',
-            'nation_name' => 'Nation',
-            'cities' => 5,
-            'converted_profit_per_day' => -45,
-            'money_profit_per_day' => 0,
-            'city_income_per_day' => 0,
-            'power_cost_per_day' => 0,
-            'food_cost_per_day' => 0,
-            'military_upkeep_per_day' => 0,
-            'resource_profit_per_day' => array_merge($shortfalls, [
-                'gasoline' => -100,
-                'munitions' => -50,
-                'steel' => 15,
-                'aluminum' => 20,
-                'money' => 0,
-            ]),
-            'price_basis' => '24h average trade prices',
-            'calculated_at' => Carbon::parse('2026-07-06 01:00:00'),
-        ]);
+        $profitability = Mockery::mock(NationProfitabilityService::class);
+        $profitability->shouldReceive('getDailyGrowthCircleShortfalls')
+            ->once()
+            ->with($nation)
+            ->andReturn($shortfalls);
+        $this->app->instance(NationProfitabilityService::class, $profitability);
 
         app(GrowthCircleService::class)->runDailyDistribution('2026-07-06');
 

--- a/tests/Feature/Workflows/GrowthCircleDistributionTest.php
+++ b/tests/Feature/Workflows/GrowthCircleDistributionTest.php
@@ -65,7 +65,7 @@ class GrowthCircleDistributionTest extends TestCase
         $profitability = Mockery::mock(NationProfitabilityService::class);
         $profitability->shouldReceive('getDailyGrowthCircleShortfalls')
             ->once()
-            ->with($nation)
+            ->with(Mockery::on(fn (Nation $distributionNation): bool => (int) $distributionNation->id === (int) $nation->id))
             ->andReturn($shortfalls);
         $this->app->instance(NationProfitabilityService::class, $profitability);
 

--- a/tests/Feature/Workflows/GrowthCircleDistributionTest.php
+++ b/tests/Feature/Workflows/GrowthCircleDistributionTest.php
@@ -83,18 +83,17 @@ class GrowthCircleDistributionTest extends TestCase
         $this->assertSame(0.0, (float) $account->steel);
         $this->assertSame(0.0, (float) $account->aluminum);
 
-        $this->assertDatabaseHas('growth_circle_distributions', [
-            'nation_id' => $nation->id,
-            'account_id' => $account->id,
-            'cycle_date' => '2026-07-06',
-            'coal' => 12.5,
-            'oil' => 4.25,
-            'uranium' => 7.0,
-            'iron' => 8.75,
-            'bauxite' => 2.0,
-            'lead' => 1.5,
-            'food' => 9.0,
-        ]);
+        $distribution = GrowthCircleDistribution::query()
+            ->where('nation_id', $nation->id)
+            ->where('account_id', $account->id)
+            ->whereDate('cycle_date', '2026-07-06')
+            ->first();
+
+        $this->assertNotNull($distribution);
+
+        foreach (GrowthCircleDistribution::distributionResourceKeys() as $resource) {
+            $this->assertSame($expected[$resource] ?? 0.0, (float) $distribution->{$resource}, $resource.' was not stored correctly.');
+        }
 
         $this->assertDatabaseHas('alliance_finance_entries', [
             'category' => 'growth_circles_distribution',

--- a/tests/Feature/Workflows/GrowthCircleDistributionTest.php
+++ b/tests/Feature/Workflows/GrowthCircleDistributionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Workflows;
+
+use App\Models\Account;
+use App\Models\GrowthCircleDistribution;
+use App\Models\GrowthCircleEnrollment;
+use App\Models\Nation;
+use App\Models\NationProfitabilitySnapshot;
+use App\Models\User;
+use App\Services\GrowthCircleService;
+use App\Services\SettingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class GrowthCircleDistributionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_daily_distribution_credits_food_uranium_and_raw_resource_shortfalls_once(): void
+    {
+        Cache::flush();
+        Cache::forever('alliances:membership:ids', [777]);
+        SettingService::setGrowthCirclesTaxId(555);
+
+        $nation = Nation::factory()->create([
+            'id' => 777001,
+            'alliance_id' => 777,
+            'alliance_position' => 'MEMBER',
+            'alliance_position_id' => 1,
+            'tax_id' => 555,
+            'vacation_mode_turns' => 0,
+            'color' => 'green',
+            'num_cities' => 5,
+        ]);
+
+        User::factory()->verified()->create([
+            'nation_id' => $nation->id,
+        ]);
+
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Growth Circles';
+        $account->save();
+
+        GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => 321,
+            'enrolled_at' => Carbon::parse('2026-07-05 03:00:00'),
+        ]);
+
+        $shortfalls = [
+            'coal' => 12.5,
+            'oil' => 4.25,
+            'uranium' => 7.0,
+            'iron' => 8.75,
+            'bauxite' => 2.0,
+            'lead' => 1.5,
+            'food' => 9.0,
+        ];
+
+        NationProfitabilitySnapshot::query()->create([
+            'nation_id' => $nation->id,
+            'alliance_id' => 777,
+            'leader_name' => 'Leader',
+            'nation_name' => 'Nation',
+            'cities' => 5,
+            'converted_profit_per_day' => -45,
+            'money_profit_per_day' => 0,
+            'city_income_per_day' => 0,
+            'power_cost_per_day' => 0,
+            'food_cost_per_day' => 0,
+            'military_upkeep_per_day' => 0,
+            'resource_profit_per_day' => array_merge($shortfalls, [
+                'gasoline' => -100,
+                'munitions' => -50,
+                'steel' => 15,
+                'aluminum' => 20,
+                'money' => 0,
+            ]),
+            'price_basis' => '24h average trade prices',
+            'calculated_at' => Carbon::parse('2026-07-06 01:00:00'),
+        ]);
+
+        app(GrowthCircleService::class)->runDailyDistribution('2026-07-06');
+
+        $account->refresh();
+
+        $expected = $shortfalls + ['money' => 0.0];
+        foreach (GrowthCircleDistribution::distributionResourceKeys() as $resource) {
+            $this->assertSame($expected[$resource] ?? 0.0, (float) $account->{$resource}, $resource.' was not credited correctly.');
+        }
+
+        $this->assertSame(0.0, (float) $account->gasoline);
+        $this->assertSame(0.0, (float) $account->munitions);
+        $this->assertSame(0.0, (float) $account->steel);
+        $this->assertSame(0.0, (float) $account->aluminum);
+
+        $this->assertDatabaseHas('growth_circle_distributions', [
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'cycle_date' => '2026-07-06',
+            'coal' => 12.5,
+            'oil' => 4.25,
+            'uranium' => 7.0,
+            'iron' => 8.75,
+            'bauxite' => 2.0,
+            'lead' => 1.5,
+            'food' => 9.0,
+        ]);
+
+        $this->assertDatabaseHas('alliance_finance_entries', [
+            'category' => 'growth_circles_distribution',
+            'direction' => 'expense',
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'coal' => 12.5,
+            'oil' => 4.25,
+            'uranium' => 7.0,
+            'iron' => 8.75,
+            'bauxite' => 2.0,
+            'lead' => 1.5,
+            'food' => 9.0,
+        ]);
+    }
+}


### PR DESCRIPTION
## What changed
- Growth Circles now credits the full covered resource set: food, uranium, coal, oil, iron, lead, and bauxite.
- The distribution record and alliance finance payload now store those resource amounts explicitly.
- The admin and account Growth Circles views now show the broader resource breakdown instead of only food and uranium.
- Added a workflow test for the distribution path and a migration for the new distribution columns.

## Why
- The previous implementation only distributed food and uranium, which did not match the intended Growth Circles behavior for raw-resource shortfalls.

## Impact
- Members enrolled in Growth Circles will now receive the same coverage for raw-resource deficits as the profitability snapshot reports.
- History and dashboard views reflect the full seven-resource distribution.

## Validation
- `php -l` on all changed PHP files
- `git diff --check`
- Could not run `php artisan test` in this CLI because the Laravel bootstrap fails early in `config/database.php` with `PDO::MYSQL_ATTR_SSL_CA` undefined
