### PR TITLE
Add weekly member lottery system

### DIFF
--- a/app/Console/Commands/DrawWeeklyLottery.php
+++ b/app/Console/Commands/DrawWeeklyLottery.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\LotteryService;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('lottery:draw')]
+#[Description('Draw all weekly lotteries whose sales windows have closed')]
+class DrawWeeklyLottery extends Command
+{
+    public function __construct(private readonly LotteryService $lotteryService)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $drawings = $this->lotteryService->drawExpiredDrawings();
+
+        $this->components->info(sprintf(
+            'Completed %d expired lottery %s.',
+            $drawings->count(),
+            str('drawing')->plural($drawings->count()),
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/LotteryController.php
+++ b/app/Http/Controllers/LotteryController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Exceptions\UserErrorException;
+use App\Http\Requests\PurchaseLotteryTicketsRequest;
+use App\Models\Account;
+use App\Models\LotteryDrawing;
+use App\Models\LotteryTicket;
+use App\Services\AccountService;
+use App\Services\AllianceMembershipService;
+use App\Services\LotteryRandomizer;
+use App\Services\LotteryService;
+use Exception;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+
+class LotteryController extends Controller
+{
+    public function index(
+        LotteryService $lotteryService,
+        AllianceMembershipService $membershipService,
+    ): View {
+        $user = request()->user();
+
+        if (! $user || ! $membershipService->contains($user->nation?->alliance_id)) {
+            abort(403);
+        }
+
+        $drawing = $lotteryService->currentDrawing();
+        $accounts = AccountService::getAccountsByUser($user);
+        $myTickets = LotteryTicket::query()
+            ->where('lottery_drawing_id', $drawing->id)
+            ->where('user_id', $user->id)
+            ->with('account')
+            ->latest()
+            ->get();
+        $recentDrawings = LotteryDrawing::query()
+            ->where('status', LotteryDrawing::STATUS_DRAWN)
+            ->with(['winningTicket.user.nation', 'winningTicket.account'])
+            ->latest('ends_at')
+            ->limit(10)
+            ->get();
+
+        return view('lottery.index', [
+            'drawing' => $drawing,
+            'accounts' => $accounts,
+            'myTickets' => $myTickets,
+            'recentDrawings' => $recentDrawings,
+            'remainingTicketCount' => max(
+                0,
+                LotteryRandomizer::CODE_SPACE_SIZE - $drawing->next_ticket_sequence,
+            ),
+        ]);
+    }
+
+    public function store(
+        PurchaseLotteryTicketsRequest $request,
+        LotteryService $lotteryService,
+    ): RedirectResponse {
+        try {
+            $account = Account::query()->findOrFail($request->integer('account_id'));
+            $tickets = $lotteryService->purchaseTickets(
+                $request->user(),
+                $account,
+                $request->integer('quantity'),
+                $request->ip(),
+            );
+
+            return redirect()->back()->with([
+                'alert-message' => sprintf(
+                    'Purchased %d %s: %s',
+                    $tickets->count(),
+                    str('ticket')->plural($tickets->count()),
+                    $tickets->pluck('code')->join(', '),
+                ),
+                'alert-type' => 'success',
+            ]);
+        } catch (ValidationException $exception) {
+            return redirect()->back()->withErrors($exception->errors())->withInput()->with('alert-type', 'error');
+        } catch (UserErrorException $exception) {
+            return redirect()->back()->withErrors($exception->getMessage())->withInput()->with('alert-type', 'error');
+        } catch (Exception $exception) {
+            Log::error('Lottery ticket purchase failed', [
+                'message' => $exception->getMessage(),
+                'user_id' => $request->user()?->id,
+                'account_id' => $request->input('account_id'),
+                'quantity' => $request->input('quantity'),
+            ]);
+
+            return redirect()->back()->withErrors('There was an error purchasing tickets. No money was moved.');
+        }
+    }
+}

--- a/app/Http/Requests/PurchaseLotteryTicketsRequest.php
+++ b/app/Http/Requests/PurchaseLotteryTicketsRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\LotteryService;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PurchaseLotteryTicketsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $accountRule = Rule::exists('accounts', 'id')->whereNull('deleted_at');
+
+        if ($this->user()) {
+            $accountRule = $accountRule->where('nation_id', $this->user()->nation_id);
+        }
+
+        return [
+            'account_id' => ['required', 'integer', $accountRule],
+            'quantity' => ['required', 'integer', 'min:1', 'max:'.LotteryService::MAX_TICKETS_PER_PURCHASE],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'account_id.exists' => 'Select one of your active accounts.',
+            'quantity.min' => 'Purchase at least one ticket.',
+            'quantity.max' => 'You may purchase at most '.LotteryService::MAX_TICKETS_PER_PURCHASE.' tickets at a time.',
+        ];
+    }
+}

--- a/app/Livewire/AppHeader.php
+++ b/app/Livewire/AppHeader.php
@@ -79,10 +79,11 @@ class AppHeader extends Component
             [
                 'label' => 'Finance',
                 'icon' => 'o-banknotes',
-                'active' => request()->routeIs('accounts*', 'member-transfers.*', 'market.*', 'loans.*'),
+                'active' => request()->routeIs('accounts*', 'member-transfers.*', 'market.*', 'lottery.*', 'loans.*'),
                 'items' => [
                     ['label' => 'Accounts', 'route' => route('accounts'), 'active' => request()->routeIs('accounts*', 'member-transfers.*')],
                     ['label' => 'Alliance market', 'route' => route('market.index'), 'active' => request()->routeIs('market.*')],
+                    ['label' => 'Weekly lottery', 'route' => route('lottery.index'), 'active' => request()->routeIs('lottery.*')],
                     ['label' => 'Loans', 'route' => route('loans.index'), 'active' => request()->routeIs('loans.*')],
                 ],
             ],

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -63,6 +63,11 @@ class Account extends Model
         return $this->hasMany(MMRAssistantPurchase::class);
     }
 
+    public function lotteryTickets(): HasMany
+    {
+        return $this->hasMany(LotteryTicket::class);
+    }
+
     /**
      * Checks if the account is completely empty.
      */

--- a/app/Models/LotteryDrawing.php
+++ b/app/Models/LotteryDrawing.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\LotteryDrawingFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class LotteryDrawing extends Model
+{
+    public const STATUS_DRAWN = 'drawn';
+
+    public const STATUS_OPEN = 'open';
+
+    /** @use HasFactory<LotteryDrawingFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'starts_at',
+        'ends_at',
+        'status',
+        'ticket_price',
+        'ticket_count',
+        'allocation_seed',
+        'next_ticket_sequence',
+        'rollover_amount',
+        'jackpot_amount',
+        'winning_code',
+        'winning_ticket_id',
+        'drawn_at',
+    ];
+
+    protected $hidden = [
+        'allocation_seed',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => 'immutable_datetime',
+            'ends_at' => 'immutable_datetime',
+            'ticket_price' => 'decimal:2',
+            'ticket_count' => 'integer',
+            'next_ticket_sequence' => 'integer',
+            'rollover_amount' => 'decimal:2',
+            'jackpot_amount' => 'decimal:2',
+            'drawn_at' => 'immutable_datetime',
+        ];
+    }
+
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(LotteryTicket::class);
+    }
+
+    public function winningTicket(): BelongsTo
+    {
+        return $this->belongsTo(LotteryTicket::class, 'winning_ticket_id');
+    }
+}

--- a/app/Models/LotteryTicket.php
+++ b/app/Models/LotteryTicket.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\LotteryTicketFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LotteryTicket extends Model
+{
+    public const PRICE = 50000;
+
+    public const JACKPOT_PERCENTAGE = 90;
+
+    public const JACKPOT_CONTRIBUTION = 45000;
+
+    /** @use HasFactory<LotteryTicketFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'lottery_drawing_id',
+        'user_id',
+        'account_id',
+        'code',
+        'price_paid',
+        'jackpot_contribution',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'price_paid' => 'decimal:2',
+            'jackpot_contribution' => 'decimal:2',
+        ];
+    }
+
+    public function drawing(): BelongsTo
+    {
+        return $this->belongsTo(LotteryDrawing::class, 'lottery_drawing_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -77,6 +77,11 @@ class User extends Authenticatable
         return $this->hasMany(Account::class, 'nation_id', 'nation_id');
     }
 
+    public function lotteryTickets(): HasMany
+    {
+        return $this->hasMany(LotteryTicket::class);
+    }
+
     public function isVerified(): bool
     {
         return ! is_null($this->verified_at);

--- a/app/Services/AccountService.php
+++ b/app/Services/AccountService.php
@@ -9,6 +9,7 @@ use App\Models\Account;
 use App\Models\DepositRequest;
 use App\Models\DiscordActionIntent;
 use App\Models\GrantApplication;
+use App\Models\LotteryDrawing;
 use App\Models\ManualTransaction;
 use App\Models\MemberTransfer;
 use App\Models\Nation;
@@ -202,6 +203,12 @@ class AccountService
 
         if ($hasPendingMemberTransfers) {
             throw new UserErrorException('The account has pending member transfers.');
+        }
+
+        if ($account->lotteryTickets()->whereHas('drawing', function ($query): void {
+            $query->where('status', LotteryDrawing::STATUS_OPEN);
+        })->exists()) {
+            throw new UserErrorException('The account has tickets in an open lottery drawing.');
         }
 
         if (! $account->isEmpty()) {

--- a/app/Services/LotteryRandomizer.php
+++ b/app/Services/LotteryRandomizer.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services;
+
+use InvalidArgumentException;
+
+class LotteryRandomizer
+{
+    public const CODE_LENGTH = 3;
+
+    public const CODE_SPACE_SIZE = 46656;
+
+    private const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    private const ALPHABET_SIZE = 36;
+
+    private const FEISTEL_ROUNDS = 8;
+
+    private const HALF_DOMAIN_SIZE = 216;
+
+    private const SEED_BYTES = 32;
+
+    public function permutationSeed(): string
+    {
+        return bin2hex(random_bytes(self::SEED_BYTES));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function ticketCodesForRange(string $seed, int $startingSequence, int $quantity): array
+    {
+        if ($quantity < 0 || $startingSequence < 0 || $startingSequence + $quantity > self::CODE_SPACE_SIZE) {
+            throw new InvalidArgumentException('The requested lottery ticket range is outside the available code space.');
+        }
+
+        $seedBytes = $this->seedBytes($seed);
+        $codes = [];
+
+        for ($sequence = $startingSequence; $sequence < $startingSequence + $quantity; $sequence++) {
+            $codes[] = $this->ticketCodeForSequenceAndSeed($sequence, $seedBytes);
+        }
+
+        return $codes;
+    }
+
+    public function ticketCodeForSequence(string $seed, int $sequence): string
+    {
+        if ($sequence < 0 || $sequence >= self::CODE_SPACE_SIZE) {
+            throw new InvalidArgumentException('The lottery ticket sequence is outside the available code space.');
+        }
+
+        return $this->ticketCodeForSequenceAndSeed($sequence, $this->seedBytes($seed));
+    }
+
+    public function ticketCode(): string
+    {
+        $code = '';
+
+        for ($position = 0; $position < self::CODE_LENGTH; $position++) {
+            $code .= self::ALPHABET[random_int(0, self::ALPHABET_SIZE - 1)];
+        }
+
+        return $code;
+    }
+
+    private function roundValue(string $seed, int $round, int $right): int
+    {
+        $digest = hash_hmac('sha256', pack('N2', $round, $right), $seed, true);
+        $value = unpack('Nvalue', $digest);
+
+        return $value['value'] % self::HALF_DOMAIN_SIZE;
+    }
+
+    private function seedBytes(string $seed): string
+    {
+        if (strlen($seed) !== self::SEED_BYTES * 2 || ! ctype_xdigit($seed)) {
+            throw new InvalidArgumentException('The lottery permutation seed must be a 64-character hexadecimal string.');
+        }
+
+        $seedBytes = hex2bin($seed);
+
+        if ($seedBytes === false) {
+            throw new InvalidArgumentException('The lottery permutation seed is invalid.');
+        }
+
+        return $seedBytes;
+    }
+
+    private function ticketCodeForSequenceAndSeed(int $sequence, string $seed): string
+    {
+        $left = intdiv($sequence, self::HALF_DOMAIN_SIZE);
+        $right = $sequence % self::HALF_DOMAIN_SIZE;
+
+        for ($round = 0; $round < self::FEISTEL_ROUNDS; $round++) {
+            $nextLeft = $right;
+            $nextRight = ($left + $this->roundValue($seed, $round, $right)) % self::HALF_DOMAIN_SIZE;
+            $left = $nextLeft;
+            $right = $nextRight;
+        }
+
+        return $this->encode($left * self::HALF_DOMAIN_SIZE + $right);
+    }
+
+    private function encode(int $value): string
+    {
+        $code = '';
+
+        for ($position = 0; $position < self::CODE_LENGTH; $position++) {
+            $code = self::ALPHABET[$value % self::ALPHABET_SIZE].$code;
+            $value = intdiv($value, self::ALPHABET_SIZE);
+        }
+
+        return $code;
+    }
+}

--- a/app/Services/LotteryService.php
+++ b/app/Services/LotteryService.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\UserErrorException;
+use App\Models\Account;
+use App\Models\LotteryDrawing;
+use App\Models\LotteryTicket;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class LotteryService
+{
+    public const MAX_TICKETS_PER_PURCHASE = 100;
+
+    public function __construct(
+        private readonly AllianceMembershipService $membershipService,
+        private readonly AuditLogger $auditLogger,
+        private readonly LotteryRandomizer $randomizer,
+    ) {}
+
+    public function currentDrawing(?CarbonInterface $at = null): LotteryDrawing
+    {
+        $now = $this->utc($at);
+        $startsAt = $now->startOfWeek(CarbonInterface::SUNDAY)->startOfDay();
+
+        return $this->drawingStartingAt($startsAt);
+    }
+
+    private function drawingStartingAt(CarbonImmutable $startsAt): LotteryDrawing
+    {
+        return LotteryDrawing::query()->firstOrCreate(
+            ['starts_at' => $startsAt],
+            [
+                'ends_at' => $startsAt->addWeek(),
+                'status' => LotteryDrawing::STATUS_OPEN,
+                'ticket_price' => LotteryTicket::PRICE,
+                'ticket_count' => 0,
+                'allocation_seed' => $this->randomizer->permutationSeed(),
+                'next_ticket_sequence' => 0,
+                'rollover_amount' => 0,
+                'jackpot_amount' => 0,
+            ],
+        );
+    }
+
+    /**
+     * @return EloquentCollection<int, LotteryTicket>
+     *
+     * @throws UserErrorException
+     * @throws ValidationException
+     */
+    public function purchaseTickets(
+        User $user,
+        Account $account,
+        int $quantity,
+        ?string $ipAddress = null,
+    ): EloquentCollection {
+        if ($quantity < 1 || $quantity > self::MAX_TICKETS_PER_PURCHASE) {
+            throw ValidationException::withMessages([
+                'quantity' => 'You may purchase between 1 and '.self::MAX_TICKETS_PER_PURCHASE.' tickets at a time.',
+            ]);
+        }
+
+        $user->loadMissing('nation');
+
+        if (! $this->membershipService->contains($user->nation?->alliance_id)) {
+            throw new UserErrorException('Only current alliance members may buy lottery tickets.');
+        }
+
+        if ((int) $account->nation_id !== (int) $user->nation_id) {
+            throw ValidationException::withMessages([
+                'account_id' => 'You do not own this account.',
+            ]);
+        }
+
+        $drawing = $this->currentDrawing();
+        $totalCost = LotteryTicket::PRICE * $quantity;
+        $jackpotContribution = LotteryTicket::JACKPOT_CONTRIBUTION * $quantity;
+
+        return DB::transaction(function () use ($user, $account, $quantity, $ipAddress, $drawing, $totalCost, $jackpotContribution): EloquentCollection {
+            $lockedDrawing = LotteryDrawing::query()->lockForUpdate()->findOrFail($drawing->id);
+
+            if ($lockedDrawing->status !== LotteryDrawing::STATUS_OPEN || $lockedDrawing->ends_at->isPast()) {
+                throw new UserErrorException('This lottery drawing is closed. Please refresh for the new drawing.');
+            }
+
+            $remainingTickets = LotteryRandomizer::CODE_SPACE_SIZE - $lockedDrawing->next_ticket_sequence;
+
+            if ($quantity > $remainingTickets) {
+                throw ValidationException::withMessages([
+                    'quantity' => $remainingTickets === 0
+                        ? 'This lottery drawing is sold out.'
+                        : 'Only '.number_format($remainingTickets).' tickets remain in this drawing.',
+                ]);
+            }
+
+            $lockedAccount = Account::query()->lockForUpdate()->findOrFail($account->id);
+
+            if ((int) $lockedAccount->nation_id !== (int) $user->nation_id) {
+                throw ValidationException::withMessages([
+                    'account_id' => 'You do not own this account.',
+                ]);
+            }
+
+            if ($lockedAccount->frozen) {
+                throw new UserErrorException('Frozen accounts cannot be used to buy lottery tickets.');
+            }
+
+            if ((float) $lockedAccount->money < $totalCost) {
+                throw ValidationException::withMessages([
+                    'account_id' => 'The selected account does not have enough money for this purchase.',
+                ]);
+            }
+
+            $codes = $this->randomizer->ticketCodesForRange(
+                $lockedDrawing->allocation_seed,
+                $lockedDrawing->next_ticket_sequence,
+                $quantity,
+            );
+            $timestamp = now();
+            $ticketRows = collect($codes)
+                ->map(fn (string $code): array => [
+                    'lottery_drawing_id' => $lockedDrawing->id,
+                    'user_id' => $user->id,
+                    'account_id' => $lockedAccount->id,
+                    'code' => $code,
+                    'price_paid' => LotteryTicket::PRICE,
+                    'jackpot_contribution' => LotteryTicket::JACKPOT_CONTRIBUTION,
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
+                ])
+                ->all();
+
+            LotteryTicket::query()->insert($ticketRows);
+
+            $ticketsByCode = LotteryTicket::query()
+                ->where('lottery_drawing_id', $lockedDrawing->id)
+                ->whereIn('code', $codes)
+                ->get()
+                ->keyBy('code');
+            $tickets = new EloquentCollection(
+                collect($codes)->map(fn (string $code): LotteryTicket => $ticketsByCode->get($code))->all(),
+            );
+
+            AccountService::adjustAccountBalance(
+                $lockedAccount,
+                [
+                    'money' => -$totalCost,
+                    'note' => 'Weekly lottery ticket purchase',
+                ],
+                $user->id,
+                $ipAddress,
+                [
+                    'lottery_drawing_id' => $lockedDrawing->id,
+                    'lottery_ticket_ids' => $tickets->modelKeys(),
+                    'ticket_quantity' => $quantity,
+                    'jackpot_contribution' => $jackpotContribution,
+                    'amount_excluded_from_jackpot' => $totalCost - $jackpotContribution,
+                ],
+            );
+
+            $lockedDrawing->ticket_count += $quantity;
+            $lockedDrawing->next_ticket_sequence += $quantity;
+            $lockedDrawing->jackpot_amount = (float) $lockedDrawing->jackpot_amount + $jackpotContribution;
+            $lockedDrawing->save();
+
+            $this->auditLogger->recordAfterCommit(
+                category: 'lottery',
+                action: 'tickets_purchased',
+                subject: $lockedDrawing,
+                context: [
+                    'account_id' => $lockedAccount->id,
+                    'ticket_ids' => $tickets->modelKeys(),
+                    'quantity' => $quantity,
+                    'total_cost' => $totalCost,
+                    'jackpot_contribution' => $jackpotContribution,
+                    'amount_excluded_from_jackpot' => $totalCost - $jackpotContribution,
+                ],
+            );
+
+            return $tickets;
+        }, attempts: 3);
+    }
+
+    /**
+     * @return EloquentCollection<int, LotteryDrawing>
+     */
+    public function drawExpiredDrawings(?CarbonInterface $at = null): EloquentCollection
+    {
+        $drawnAt = $this->utc($at);
+        $drawings = new EloquentCollection;
+
+        while (true) {
+            $drawingId = LotteryDrawing::query()
+                ->where('status', LotteryDrawing::STATUS_OPEN)
+                ->where('ends_at', '<=', $drawnAt)
+                ->orderBy('ends_at')
+                ->value('id');
+
+            if (! $drawingId) {
+                break;
+            }
+
+            $drawing = LotteryDrawing::query()->find($drawingId);
+
+            if ($drawing) {
+                $drawings->push($this->draw($drawing, $drawnAt));
+            }
+        }
+
+        return $drawings;
+    }
+
+    /**
+     * @throws UserErrorException
+     */
+    public function draw(LotteryDrawing $drawing, ?CarbonInterface $at = null): LotteryDrawing
+    {
+        $drawnAt = $this->utc($at);
+
+        $drawnDrawing = DB::transaction(function () use ($drawing, $drawnAt): LotteryDrawing {
+            $lockedDrawing = LotteryDrawing::query()->lockForUpdate()->findOrFail($drawing->id);
+
+            if ($lockedDrawing->status === LotteryDrawing::STATUS_DRAWN) {
+                return $lockedDrawing;
+            }
+
+            if ($lockedDrawing->ends_at->isAfter($drawnAt)) {
+                throw new UserErrorException('This lottery drawing has not closed yet.');
+            }
+
+            $tickets = LotteryTicket::query()
+                ->where('lottery_drawing_id', $lockedDrawing->id)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+
+            $lockedDrawing->ticket_count = $tickets->count();
+            $lockedDrawing->jackpot_amount = (float) $lockedDrawing->rollover_amount
+                + (float) $tickets->sum('jackpot_contribution');
+            $lockedDrawing->status = LotteryDrawing::STATUS_DRAWN;
+            $lockedDrawing->drawn_at = $drawnAt;
+            $lockedDrawing->winning_code = $this->randomizer->ticketCode();
+            $winner = $tickets->firstWhere('code', $lockedDrawing->winning_code);
+            $rolloverDrawingId = null;
+
+            if ($winner) {
+                $winnerAccount = Account::query()->lockForUpdate()->findOrFail($winner->account_id);
+
+                AccountService::adjustAccountBalance(
+                    $winnerAccount,
+                    [
+                        'money' => (float) $lockedDrawing->jackpot_amount,
+                        'note' => 'Weekly lottery jackpot payout',
+                    ],
+                    null,
+                    null,
+                    [
+                        'lottery_drawing_id' => $lockedDrawing->id,
+                        'lottery_ticket_id' => $winner->id,
+                        'lottery_ticket_code' => $winner->code,
+                    ],
+                );
+
+                $lockedDrawing->winning_ticket_id = $winner->id;
+            } elseif ((float) $lockedDrawing->jackpot_amount > 0) {
+                $nextDrawing = $this->drawingStartingAt($lockedDrawing->ends_at);
+                $lockedNextDrawing = LotteryDrawing::query()->lockForUpdate()->findOrFail($nextDrawing->id);
+
+                if ($lockedNextDrawing->status !== LotteryDrawing::STATUS_OPEN) {
+                    throw new \RuntimeException('The rollover destination drawing is already closed.');
+                }
+
+                $lockedNextDrawing->rollover_amount = (float) $lockedNextDrawing->rollover_amount
+                    + (float) $lockedDrawing->jackpot_amount;
+                $lockedNextDrawing->jackpot_amount = (float) $lockedNextDrawing->jackpot_amount
+                    + (float) $lockedDrawing->jackpot_amount;
+                $lockedNextDrawing->save();
+                $rolloverDrawingId = $lockedNextDrawing->id;
+            }
+
+            $lockedDrawing->save();
+
+            $this->auditLogger->recordAfterCommit(
+                category: 'lottery',
+                action: 'drawing_completed',
+                subject: $lockedDrawing,
+                context: [
+                    'ticket_count' => $lockedDrawing->ticket_count,
+                    'jackpot_amount' => $lockedDrawing->jackpot_amount,
+                    'winning_code' => $lockedDrawing->winning_code,
+                    'winning_ticket_id' => $lockedDrawing->winning_ticket_id,
+                    'rollover_drawing_id' => $rolloverDrawingId,
+                    'rolled_over_amount' => $rolloverDrawingId ? $lockedDrawing->jackpot_amount : 0,
+                ],
+                actorOverride: ['type' => 'system', 'id' => null, 'name' => 'Lottery scheduler'],
+            );
+
+            return $lockedDrawing;
+        }, attempts: 3);
+
+        return $drawnDrawing->fresh(['winningTicket.user.nation', 'winningTicket.account']) ?? $drawnDrawing;
+    }
+
+    private function utc(?CarbonInterface $at): CarbonImmutable
+    {
+        return $at
+            ? CarbonImmutable::instance($at)->utc()
+            : CarbonImmutable::now('UTC');
+    }
+}

--- a/database/factories/LotteryDrawingFactory.php
+++ b/database/factories/LotteryDrawingFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LotteryDrawing;
+use App\Models\LotteryTicket;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<LotteryDrawing>
+ */
+class LotteryDrawingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $startsAt = CarbonImmutable::instance(fake()->unique()->dateTimeBetween('-1 year', '+1 year'));
+
+        return [
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->addWeek(),
+            'status' => LotteryDrawing::STATUS_OPEN,
+            'ticket_price' => LotteryTicket::PRICE,
+            'ticket_count' => 0,
+            'allocation_seed' => bin2hex(random_bytes(32)),
+            'next_ticket_sequence' => 0,
+            'rollover_amount' => 0,
+            'jackpot_amount' => 0,
+            'winning_code' => null,
+            'drawn_at' => null,
+        ];
+    }
+
+    public function drawn(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => LotteryDrawing::STATUS_DRAWN,
+            'drawn_at' => $attributes['ends_at'],
+        ]);
+    }
+}

--- a/database/factories/LotteryTicketFactory.php
+++ b/database/factories/LotteryTicketFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Account;
+use App\Models\LotteryDrawing;
+use App\Models\LotteryTicket;
+use App\Models\Nation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<LotteryTicket>
+ */
+class LotteryTicketFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'lottery_drawing_id' => LotteryDrawing::factory(),
+            'user_id' => function (): int {
+                $nation = Nation::factory()->create();
+
+                return User::factory()->create(['nation_id' => $nation->id])->id;
+            },
+            'account_id' => function (array $attributes): int {
+                $user = User::query()->findOrFail($attributes['user_id']);
+
+                return Account::query()->create([
+                    'nation_id' => $user->nation_id,
+                    'name' => 'Lottery Account',
+                    'money' => 100000,
+                ])->id;
+            },
+            'code' => fn (): string => Str::upper(Str::random(3)),
+            'price_paid' => LotteryTicket::PRICE,
+            'jackpot_contribution' => LotteryTicket::JACKPOT_CONTRIBUTION,
+        ];
+    }
+}

--- a/database/migrations/2026_07_14_044832_create_lottery_drawings_table.php
+++ b/database/migrations/2026_07_14_044832_create_lottery_drawings_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('lottery_drawings', function (Blueprint $table) {
+            $table->id();
+            $table->dateTime('starts_at')->unique();
+            $table->dateTime('ends_at')->index();
+            $table->string('status', 20)->default('open')->index();
+            $table->decimal('ticket_price', 15, 2);
+            $table->unsignedInteger('ticket_count')->default(0);
+            $table->char('allocation_seed', 64);
+            $table->unsignedInteger('next_ticket_sequence')->default(0);
+            $table->decimal('rollover_amount', 15, 2)->default(0);
+            $table->decimal('jackpot_amount', 15, 2)->default(0);
+            $table->char('winning_code', 3)->nullable();
+            $table->dateTime('drawn_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('lottery_drawings');
+    }
+};

--- a/database/migrations/2026_07_14_044832_create_lottery_tickets_table.php
+++ b/database/migrations/2026_07_14_044832_create_lottery_tickets_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('lottery_tickets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('lottery_drawing_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('account_id')->constrained()->restrictOnDelete();
+            $table->char('code', 3);
+            $table->decimal('price_paid', 15, 2);
+            $table->decimal('jackpot_contribution', 15, 2);
+            $table->timestamps();
+
+            $table->unique(['lottery_drawing_id', 'code']);
+            $table->index(['user_id', 'lottery_drawing_id']);
+            $table->index(['account_id', 'lottery_drawing_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('lottery_tickets');
+    }
+};

--- a/database/migrations/2026_07_14_044847_add_winning_ticket_to_lottery_drawings_table.php
+++ b/database/migrations/2026_07_14_044847_add_winning_ticket_to_lottery_drawings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lottery_drawings', function (Blueprint $table) {
+            $table->foreignId('winning_ticket_id')
+                ->nullable()
+                ->after('jackpot_amount')
+                ->constrained('lottery_tickets')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lottery_drawings', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('winning_ticket_id');
+        });
+    }
+};

--- a/resources/views/livewire/app-header.blade.php
+++ b/resources/views/livewire/app-header.blade.php
@@ -215,7 +215,7 @@
                 <x-icon name="o-squares-2x2" class="size-5" />
                 <span>Overview</span>
             </a>
-            <a href="{{ route('accounts') }}" @if(request()->routeIs('accounts*', 'member-transfers.*')) aria-current="page" @endif>
+            <a href="{{ route('accounts') }}" @if(request()->routeIs('accounts*', 'member-transfers.*', 'market.*', 'lottery.*', 'loans.*')) aria-current="page" @endif>
                 <x-icon name="o-banknotes" class="size-5" />
                 <span>Finance</span>
             </a>

--- a/resources/views/lottery/index.blade.php
+++ b/resources/views/lottery/index.blade.php
@@ -1,0 +1,214 @@
+@extends('layouts.main')
+
+@section('content')
+    <div class="space-y-6">
+        <section class="overflow-hidden rounded-lg border border-base-300 bg-base-100 shadow-md">
+            <div class="grid gap-6 p-6 lg:grid-cols-[1.4fr_1fr] lg:items-center">
+                <div class="space-y-3">
+                    <p class="text-xs font-semibold uppercase tracking-[0.18em] text-primary">Weekly member lottery</p>
+                    <h1 class="text-3xl font-bold text-base-content">Three characters. One weekly draw.</h1>
+                    <p class="max-w-2xl text-sm text-base-content/70">
+                        Every ticket costs ${{ number_format($drawing->ticket_price, 0) }} and receives a random three-character
+                        uppercase alphanumeric code. {{ \App\Models\LotteryTicket::JACKPOT_PERCENTAGE }}%
+                        (${{ number_format(\App\Models\LotteryTicket::JACKPOT_CONTRIBUTION, 0) }}) from each ticket joins the jackpot.
+                    </p>
+                    <p class="max-w-2xl text-sm text-base-content/70">
+                        One code is drawn from {{ number_format(\App\Services\LotteryRandomizer::CODE_SPACE_SIZE) }} possibilities.
+                        If no sold ticket matches, the entire jackpot rolls into the next week.
+                    </p>
+                    <div class="flex flex-wrap gap-2 text-xs text-base-content/70">
+                        <span class="badge badge-outline">Draws Sunday at 00:00 UTC</span>
+                        <span class="badge badge-outline">Sales close {{ $drawing->ends_at->format('M j, Y \a\t H:i') }} UTC</span>
+                        @if ($remainingTicketCount === 0)
+                            <span class="badge badge-error badge-outline">Sold out</span>
+                        @endif
+                    </div>
+                </div>
+
+                <div class="rounded-2xl border border-primary/20 bg-primary/10 p-5">
+                    <p class="text-xs font-semibold uppercase tracking-wide text-primary">Current jackpot</p>
+                    <p class="mt-1 text-4xl font-black text-primary">${{ number_format($drawing->jackpot_amount, 2) }}</p>
+                    @if ((float) $drawing->rollover_amount > 0)
+                        <p class="mt-1 text-xs font-medium text-primary/80">
+                            Includes ${{ number_format($drawing->rollover_amount, 2) }} rolled over
+                        </p>
+                    @endif
+                    <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
+                        <div class="rounded-xl bg-base-100/80 p-3">
+                            <p class="text-xs text-base-content/60">Tickets sold</p>
+                            <p class="text-xl font-bold">{{ number_format($drawing->ticket_count) }}</p>
+                        </div>
+                        <div class="rounded-xl bg-base-100/80 p-3">
+                            <p class="text-xs text-base-content/60">Remaining</p>
+                            <p class="text-xl font-bold">{{ number_format($remainingTicketCount) }}</p>
+                        </div>
+                        <div class="rounded-xl bg-base-100/80 p-3">
+                            <p class="text-xs text-base-content/60">Your tickets</p>
+                            <p class="text-xl font-bold">{{ number_format($myTickets->count()) }}</p>
+                        </div>
+                    </div>
+                    <p class="mt-3 text-xs text-base-content/60">
+                        Chance any sold ticket wins:
+                        {{ number_format(($drawing->ticket_count / \App\Services\LotteryRandomizer::CODE_SPACE_SIZE) * 100, 5) }}%
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <div class="grid gap-6 lg:grid-cols-[1fr_1.25fr]">
+            <section class="rounded-lg border border-base-300 bg-base-100 p-6 shadow-sm">
+                <div class="mb-5">
+                    <p class="text-xs uppercase tracking-wide text-base-content/60">Enter this week's draw</p>
+                    <h2 class="text-xl font-bold">Buy tickets</h2>
+                </div>
+
+                @if ($remainingTicketCount > 0)
+                    <form method="POST" action="{{ route('lottery.tickets.store') }}" class="space-y-5">
+                        @csrf
+
+                        <label class="grid gap-2">
+                            <span class="text-sm font-medium">Pay from account</span>
+                            <select name="account_id" class="select w-full" required>
+                                <option value="" disabled @selected(! old('account_id'))>Select an account</option>
+                                @foreach ($accounts as $account)
+                                    <option
+                                        value="{{ $account->id }}"
+                                        @selected((string) old('account_id') === (string) $account->id)
+                                        @disabled($account->frozen || (float) $account->money < (float) $drawing->ticket_price)
+                                    >
+                                        {{ $account->name }} — ${{ number_format($account->money, 2) }}{{ $account->frozen ? ' (frozen)' : '' }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            @error('account_id')
+                                <p class="text-xs text-error">{{ $message }}</p>
+                            @enderror
+                        </label>
+
+                        <label class="grid gap-2">
+                            <span class="text-sm font-medium">Number of tickets</span>
+                            <input
+                                type="number"
+                                name="quantity"
+                                class="input w-full"
+                                min="1"
+                                max="{{ min(\App\Services\LotteryService::MAX_TICKETS_PER_PURCHASE, $remainingTicketCount) }}"
+                                step="1"
+                                value="{{ old('quantity', 1) }}"
+                                required
+                            >
+                            <span class="text-xs text-base-content/60">
+                                ${{ number_format($drawing->ticket_price, 0) }} each · up to
+                                {{ min(\App\Services\LotteryService::MAX_TICKETS_PER_PURCHASE, $remainingTicketCount) }} per purchase
+                            </span>
+                            @error('quantity')
+                                <p class="text-xs text-error">{{ $message }}</p>
+                            @enderror
+                        </label>
+
+                        <button type="submit" class="btn btn-primary w-full" @disabled($accounts->isEmpty())>
+                            Buy lottery tickets
+                        </button>
+
+                        @if ($accounts->isEmpty())
+                            <p class="text-center text-sm text-base-content/60">
+                                Create an account before purchasing a ticket.
+                            </p>
+                        @endif
+                    </form>
+                @else
+                    <div class="rounded-xl border border-error/30 bg-error/10 p-5 text-sm text-base-content/80">
+                        <p class="font-semibold text-error">This week's drawing is sold out.</p>
+                        <p class="mt-1">All {{ number_format(\App\Services\LotteryRandomizer::CODE_SPACE_SIZE) }} unique codes have been assigned.</p>
+                    </div>
+                @endif
+            </section>
+
+            <section class="rounded-lg border border-base-300 bg-base-100 p-6 shadow-sm">
+                <div class="mb-5 flex items-start justify-between gap-4">
+                    <div>
+                        <p class="text-xs uppercase tracking-wide text-base-content/60">Current drawing</p>
+                        <h2 class="text-xl font-bold">Your ticket codes</h2>
+                    </div>
+                    @if ($myTickets->isNotEmpty())
+                        <span class="badge badge-primary badge-outline">
+                            {{ number_format(($myTickets->count() / \App\Services\LotteryRandomizer::CODE_SPACE_SIZE) * 100, 5) }}% chance
+                        </span>
+                    @endif
+                </div>
+
+                @if ($myTickets->isNotEmpty())
+                    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+                        @foreach ($myTickets as $ticket)
+                            <div class="rounded-xl border border-base-300 bg-base-200/50 p-4 text-center">
+                                <p class="font-mono text-2xl font-black tracking-[0.18em] text-primary">{{ $ticket->code }}</p>
+                                <p class="mt-2 truncate text-xs text-base-content/60">{{ $ticket->account->name }}</p>
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <div class="rounded-xl border border-dashed border-base-300 px-6 py-12 text-center">
+                        <p class="font-semibold">You do not have a ticket in this drawing yet.</p>
+                        <p class="mt-1 text-sm text-base-content/60">Purchased codes will appear here immediately.</p>
+                    </div>
+                @endif
+            </section>
+        </div>
+
+        <section class="rounded-lg border border-base-300 bg-base-100 p-6 shadow-sm">
+            <div class="mb-5">
+                <p class="text-xs uppercase tracking-wide text-base-content/60">Completed drawings</p>
+                <h2 class="text-xl font-bold">Recent draws</h2>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Week ending</th>
+                            <th>Winning code</th>
+                            <th>Winner</th>
+                            <th class="text-right">Tickets</th>
+                            <th class="text-right">Jackpot</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($recentDrawings as $pastDrawing)
+                            <tr>
+                                <td>{{ $pastDrawing->ends_at->format('M j, Y') }}</td>
+                                <td>
+                                    @if ($pastDrawing->winning_code)
+                                        <span class="font-mono font-bold tracking-widest text-primary">
+                                            {{ $pastDrawing->winning_code }}
+                                        </span>
+                                    @else
+                                        <span class="text-base-content/50">—</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if ($pastDrawing->winningTicket)
+                                        {{ $pastDrawing->winningTicket->user?->nation?->leader_name
+                                            ?? $pastDrawing->winningTicket->user?->name
+                                            ?? 'Unknown member' }}
+                                    @elseif ((float) $pastDrawing->jackpot_amount > 0)
+                                        <span class="text-warning">No match — rolled over</span>
+                                    @else
+                                        <span class="text-base-content/50">No match</span>
+                                    @endif
+                                </td>
+                                <td class="text-right">{{ number_format($pastDrawing->ticket_count) }}</td>
+                                <td class="text-right font-semibold">${{ number_format($pastDrawing->jackpot_amount, 2) }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="5" class="py-10 text-center text-base-content/60">
+                                    No weekly drawings have been completed yet.
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </div>
+@endsection

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\DrawWeeklyLottery;
 use App\Console\Commands\ProcessDeposits;
 use App\Jobs\DispatchBeigeTurnAlertsJob;
 use App\Jobs\EvaluateAlertSubscriptionsJob;
@@ -58,6 +59,13 @@ Schedule::command('loans:process-payments')
 Schedule::command('payroll:run-daily')
     ->dailyAt('00:30')
     ->timezone('America/Chicago')
+    ->withoutOverlapping(120)
+    ->onOneServer();
+
+// Weekly lottery
+Schedule::command(DrawWeeklyLottery::class)
+    ->weeklyOn(0, '00:00')
+    ->timezone('UTC')
     ->withoutOverlapping(120)
     ->onOneServer();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\IntelReportController;
 use App\Http\Controllers\LeaderboardsController;
 use App\Http\Controllers\LoansController as UserLoansController;
+use App\Http\Controllers\LotteryController;
 use App\Http\Controllers\MarketController;
 use App\Http\Controllers\MemberTransferController;
 use App\Http\Controllers\RaidFinderController;
@@ -171,6 +172,10 @@ Route::middleware(['auth', EnsureUserIsVerified::class, DiscordVerifiedMiddlewar
     // Alliance Market
     Route::get('/market', [MarketController::class, 'index'])->name('market.index');
     Route::post('/market/sell', [MarketController::class, 'sell'])->name('market.sell');
+
+    // Weekly Lottery
+    Route::get('/lottery', [LotteryController::class, 'index'])->name('lottery.index');
+    Route::post('/lottery/tickets', [LotteryController::class, 'store'])->name('lottery.tickets.store');
 
     // Direct Deposit
     Route::post('/direct-deposit/enroll', [DirectDepositController::class, 'enroll'])->name('dd.enroll')

--- a/tests/Feature/Workflows/LotteryWorkflowTest.php
+++ b/tests/Feature/Workflows/LotteryWorkflowTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Tests\Feature\Workflows;
+
+use App\Exceptions\UserErrorException;
+use App\Http\Middleware\DiscordVerifiedMiddleware;
+use App\Http\Middleware\EnsureMfaConfigured;
+use App\Http\Middleware\EnsureUserIsVerified;
+use App\Models\Account;
+use App\Models\LotteryDrawing;
+use App\Models\LotteryTicket;
+use App\Models\Nation;
+use App\Models\User;
+use App\Services\AccountService;
+use App\Services\AllianceMembershipService;
+use App\Services\AuditLogger;
+use App\Services\LotteryRandomizer;
+use App\Services\LotteryService;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class LotteryWorkflowTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_member_can_purchase_random_three_character_tickets_for_fifty_thousand_each(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(500000);
+        $randomizer = new LotteryRandomizer;
+        $service = $this->lotteryService($randomizer, membershipChecks: 1, auditEvents: 1);
+
+        $tickets = $service->purchaseTickets($user, $account, 2, '127.0.0.1');
+
+        $drawing = LotteryDrawing::query()->sole();
+        $this->assertSame(90, LotteryTicket::JACKPOT_PERCENTAGE);
+        $this->assertSame('2026-07-05 00:00:00', $drawing->starts_at->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-07-12 00:00:00', $drawing->ends_at->format('Y-m-d H:i:s'));
+        $this->assertCount(2, $tickets->pluck('code')->unique());
+        $this->assertSame([], $tickets->reject(
+            fn (LotteryTicket $ticket): bool => preg_match('/^[0-9A-Z]{3}$/', $ticket->code) === 1,
+        )->all());
+        $this->assertSame(['45000.00', '45000.00'], $tickets->pluck('jackpot_contribution')->all());
+        $this->assertAccountMoney($account, 400000);
+        $this->assertSame(2, $drawing->ticket_count);
+        $this->assertSame(2, $drawing->next_ticket_sequence);
+        $this->assertSame('90000.00', $drawing->jackpot_amount);
+        $this->assertSame('50000.00', $drawing->ticket_price);
+        $this->assertDatabaseHas('manual_transactions', [
+            'account_id' => $account->id,
+            'admin_id' => $user->id,
+            'money' => -100000,
+            'note' => 'Weekly lottery ticket purchase',
+        ]);
+        $this->assertDatabaseCount('lottery_tickets', 2);
+    }
+
+    public function test_successive_purchases_reserve_disjoint_permutation_ranges(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(500000);
+        $randomizer = new LotteryRandomizer;
+        $service = $this->lotteryService($randomizer, membershipChecks: 2, auditEvents: 2);
+
+        $firstTickets = $service->purchaseTickets($user, $account, 2);
+        $secondTickets = $service->purchaseTickets($user, $account, 2);
+        $drawing = LotteryDrawing::query()->sole();
+        $expectedCodes = $randomizer->ticketCodesForRange($drawing->allocation_seed, 0, 4);
+
+        $this->assertSame($expectedCodes, $firstTickets->concat($secondTickets)->pluck('code')->all());
+        $this->assertCount(4, LotteryTicket::query()->where('lottery_drawing_id', $drawing->id)->get()->unique('code'));
+        $this->assertSame(4, $drawing->next_ticket_sequence);
+        $this->assertSame('180000.00', $drawing->jackpot_amount);
+        $this->assertAccountMoney($account, 300000);
+    }
+
+    public function test_insufficient_funds_are_rejected_without_creating_a_ticket_or_moving_money(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(49999.99);
+        $service = $this->lotteryService(new LotteryRandomizer, membershipChecks: 1, auditEvents: 0);
+
+        try {
+            $service->purchaseTickets($user, $account, 1);
+            $this->fail('The lottery accepted a purchase without sufficient funds.');
+        } catch (ValidationException $exception) {
+            $this->assertSame(
+                ['The selected account does not have enough money for this purchase.'],
+                $exception->errors()['account_id'],
+            );
+        }
+
+        $this->assertAccountMoney($account, 49999.99);
+        $this->assertDatabaseCount('lottery_tickets', 0);
+        $this->assertDatabaseCount('manual_transactions', 0);
+    }
+
+    public function test_frozen_account_is_rejected_without_creating_a_ticket(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(500000, frozen: true);
+        $service = $this->lotteryService(new LotteryRandomizer, membershipChecks: 1, auditEvents: 0);
+
+        try {
+            $service->purchaseTickets($user, $account, 1);
+            $this->fail('The lottery accepted a purchase from a frozen account.');
+        } catch (UserErrorException $exception) {
+            $this->assertSame('Frozen accounts cannot be used to buy lottery tickets.', $exception->getMessage());
+        }
+
+        $this->assertAccountMoney($account, 500000);
+        $this->assertDatabaseCount('lottery_tickets', 0);
+    }
+
+    public function test_request_validation_rejects_another_members_account(): void
+    {
+        [$user] = $this->createParticipant(500000);
+        [, $otherAccount] = $this->createParticipant(500000);
+
+        $response = $this->actingAs($user)
+            ->withoutMiddleware([
+                EnsureUserIsVerified::class,
+                DiscordVerifiedMiddleware::class,
+                EnsureMfaConfigured::class,
+            ])
+            ->post(route('lottery.tickets.store'), [
+                'account_id' => $otherAccount->id,
+                'quantity' => 1,
+            ]);
+
+        $response->assertSessionHasErrors('account_id');
+        $this->assertDatabaseCount('lottery_tickets', 0);
+    }
+
+    public function test_expired_drawing_pays_the_matching_ticket_and_is_idempotent(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$firstUser, $firstAccount] = $this->createParticipant(500000);
+        [$secondUser, $secondAccount] = $this->createParticipant(500000);
+        $randomizer = Mockery::mock(LotteryRandomizer::class)->makePartial();
+        $service = $this->lotteryService($randomizer, membershipChecks: 2, auditEvents: 3);
+
+        $service->purchaseTickets($firstUser, $firstAccount, 1);
+        $winningTicket = $service->purchaseTickets($secondUser, $secondAccount, 2)->last();
+        $randomizer->shouldReceive('ticketCode')->once()->andReturn($winningTicket->code);
+
+        CarbonImmutable::setTestNow('2026-07-12 00:00:00 UTC');
+        $drawings = $service->drawExpiredDrawings();
+        $drawing = $drawings->sole();
+
+        $this->assertSame(LotteryDrawing::STATUS_DRAWN, $drawing->status);
+        $this->assertSame($winningTicket->code, $drawing->winning_code);
+        $this->assertSame($winningTicket->code, $drawing->winningTicket->code);
+        $this->assertSame('135000.00', $drawing->jackpot_amount);
+        $this->assertAccountMoney($firstAccount, 450000);
+        $this->assertAccountMoney($secondAccount, 535000);
+        $this->assertDatabaseCount('manual_transactions', 3);
+
+        $this->assertCount(0, $service->drawExpiredDrawings());
+        $this->assertAccountMoney($secondAccount, 535000);
+        $this->assertDatabaseCount('manual_transactions', 3);
+    }
+
+    public function test_unmatched_code_rolls_the_full_pool_into_the_next_week(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(500000);
+        $randomizer = Mockery::mock(LotteryRandomizer::class)->makePartial();
+        $service = $this->lotteryService($randomizer, membershipChecks: 2, auditEvents: 3);
+        $purchasedTickets = $service->purchaseTickets($user, $account, 2);
+        $unmatchedCode = collect(['000', '001', '002'])
+            ->first(fn (string $code): bool => ! $purchasedTickets->contains('code', $code));
+        $randomizer->shouldReceive('ticketCode')->once()->andReturn($unmatchedCode);
+
+        CarbonImmutable::setTestNow('2026-07-12 00:00:00 UTC');
+        $completedDrawing = $service->drawExpiredDrawings()->sole();
+        $nextDrawing = LotteryDrawing::query()
+            ->where('starts_at', $completedDrawing->ends_at)
+            ->sole();
+
+        $this->assertSame($unmatchedCode, $completedDrawing->winning_code);
+        $this->assertNull($completedDrawing->winning_ticket_id);
+        $this->assertSame('90000.00', $completedDrawing->jackpot_amount);
+        $this->assertSame(LotteryDrawing::STATUS_OPEN, $nextDrawing->status);
+        $this->assertSame('90000.00', $nextDrawing->rollover_amount);
+        $this->assertSame('90000.00', $nextDrawing->jackpot_amount);
+        $this->assertAccountMoney($account, 400000);
+        $this->assertDatabaseCount('manual_transactions', 1);
+
+        $nextTicket = $service->purchaseTickets($user, $account, 1)->sole();
+
+        $this->assertSame(
+            $randomizer->ticketCodeForSequence($nextDrawing->allocation_seed, 0),
+            $nextTicket->code,
+        );
+        $this->assertSame('45000.00', $nextTicket->jackpot_contribution);
+        $this->assertSame('135000.00', $nextDrawing->refresh()->jackpot_amount);
+        $this->assertSame('90000.00', $nextDrawing->rollover_amount);
+        $this->assertSame(1, $nextDrawing->ticket_count);
+        $this->assertAccountMoney($account, 350000);
+        $this->assertDatabaseCount('manual_transactions', 2);
+    }
+
+    public function test_expired_drawing_with_no_tickets_closes_without_a_payout(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        $randomizer = Mockery::mock(LotteryRandomizer::class)->makePartial();
+        $randomizer->shouldReceive('ticketCode')->once()->andReturn('XYZ');
+        $service = $this->lotteryService($randomizer, membershipChecks: 0, auditEvents: 1);
+        $drawing = $service->currentDrawing();
+
+        CarbonImmutable::setTestNow('2026-07-12 00:00:00 UTC');
+        $drawnDrawing = $service->drawExpiredDrawings()->sole();
+
+        $this->assertTrue($drawing->is($drawnDrawing));
+        $this->assertSame(LotteryDrawing::STATUS_DRAWN, $drawnDrawing->status);
+        $this->assertSame('XYZ', $drawnDrawing->winning_code);
+        $this->assertNull($drawnDrawing->winning_ticket_id);
+        $this->assertSame('0.00', $drawnDrawing->jackpot_amount);
+        $this->assertDatabaseCount('lottery_drawings', 1);
+        $this->assertDatabaseCount('manual_transactions', 0);
+    }
+
+    public function test_final_available_code_is_allocated_and_later_purchases_are_rejected_as_sold_out(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(100000);
+        $randomizer = new LotteryRandomizer;
+        $drawing = LotteryDrawing::factory()->create([
+            'starts_at' => CarbonImmutable::parse('2026-07-05 00:00:00 UTC'),
+            'ends_at' => CarbonImmutable::parse('2026-07-12 00:00:00 UTC'),
+            'ticket_count' => LotteryRandomizer::CODE_SPACE_SIZE - 1,
+            'next_ticket_sequence' => LotteryRandomizer::CODE_SPACE_SIZE - 1,
+        ]);
+        $expectedFinalCode = $randomizer->ticketCodeForSequence(
+            $drawing->allocation_seed,
+            LotteryRandomizer::CODE_SPACE_SIZE - 1,
+        );
+        $service = $this->lotteryService($randomizer, membershipChecks: 2, auditEvents: 1);
+
+        $ticket = $service->purchaseTickets($user, $account, 1)->sole();
+
+        $this->assertSame($expectedFinalCode, $ticket->code);
+        $this->assertSame(LotteryRandomizer::CODE_SPACE_SIZE, $drawing->refresh()->ticket_count);
+        $this->assertSame(LotteryRandomizer::CODE_SPACE_SIZE, $drawing->next_ticket_sequence);
+        $this->assertAccountMoney($account, 50000);
+
+        try {
+            $service->purchaseTickets($user, $account, 1);
+            $this->fail('The lottery sold a ticket after exhausting the code space.');
+        } catch (ValidationException $exception) {
+            $this->assertSame(['This lottery drawing is sold out.'], $exception->errors()['quantity']);
+        }
+
+        $this->assertDatabaseCount('lottery_tickets', 1);
+        $this->assertDatabaseCount('manual_transactions', 1);
+        $this->assertAccountMoney($account, 50000);
+    }
+
+    public function test_account_with_an_open_ticket_cannot_be_deleted_before_the_draw(): void
+    {
+        CarbonImmutable::setTestNow('2026-07-06 12:00:00 UTC');
+        [$user, $account] = $this->createParticipant(50000);
+        $service = $this->lotteryService(new LotteryRandomizer, membershipChecks: 1, auditEvents: 1);
+        $service->purchaseTickets($user, $account, 1);
+
+        try {
+            AccountService::deleteAccount($account, $user->nation_id);
+            $this->fail('An account with an open lottery ticket was deleted.');
+        } catch (UserErrorException $exception) {
+            $this->assertSame('The account has tickets in an open lottery drawing.', $exception->getMessage());
+        }
+
+        $this->assertNotSoftDeleted($account);
+    }
+
+    /**
+     * @return array{0: User, 1: Account}
+     */
+    private function createParticipant(float $money, bool $frozen = false): array
+    {
+        $nation = Nation::factory()->create([
+            'alliance_id' => 777,
+            'alliance_position' => 'MEMBER',
+            'alliance_position_id' => 2,
+            'vacation_mode_turns' => 0,
+        ]);
+        $user = User::factory()->create(['nation_id' => $nation->id]);
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Lottery Account '.$nation->id;
+        $account->money = $money;
+        $account->frozen = $frozen;
+        $account->save();
+
+        return [$user, $account];
+    }
+
+    private function lotteryService(
+        LotteryRandomizer $randomizer,
+        int $membershipChecks,
+        int $auditEvents,
+    ): LotteryService {
+        $membershipService = Mockery::mock(AllianceMembershipService::class);
+        $membershipExpectation = $membershipService->shouldReceive('contains');
+
+        if ($membershipChecks > 0) {
+            $membershipExpectation->times($membershipChecks)->with(777)->andReturnTrue();
+        } else {
+            $membershipExpectation->never();
+        }
+
+        $auditLogger = Mockery::mock(AuditLogger::class);
+        $auditExpectation = $auditLogger->shouldReceive('recordAfterCommit');
+
+        if ($auditEvents > 0) {
+            $auditExpectation->times($auditEvents);
+        } else {
+            $auditExpectation->never();
+        }
+
+        return new LotteryService($membershipService, $auditLogger, $randomizer);
+    }
+
+    private function assertAccountMoney(Account $account, float $expected): void
+    {
+        $this->assertSame(
+            number_format($expected, 2, '.', ''),
+            number_format((float) $account->refresh()->money, 2, '.', ''),
+        );
+    }
+}

--- a/tests/Unit/Services/LotteryRandomizerTest.php
+++ b/tests/Unit/Services/LotteryRandomizerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\LotteryRandomizer;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class LotteryRandomizerTest extends TestCase
+{
+    public function test_seeded_permutation_allocates_the_entire_code_space_without_duplicates(): void
+    {
+        $randomizer = new LotteryRandomizer;
+        $codes = $randomizer->ticketCodesForRange(
+            str_repeat('0123456789abcdef', 4),
+            0,
+            LotteryRandomizer::CODE_SPACE_SIZE,
+        );
+
+        $this->assertCount(LotteryRandomizer::CODE_SPACE_SIZE, $codes);
+        $this->assertCount(LotteryRandomizer::CODE_SPACE_SIZE, array_unique($codes));
+        $this->assertSame([], array_filter(
+            $codes,
+            fn (string $code): bool => preg_match('/^[0-9A-Z]{3}$/', $code) !== 1,
+        ));
+    }
+
+    public function test_same_seed_and_sequence_always_return_the_same_code(): void
+    {
+        $randomizer = new LotteryRandomizer;
+        $seed = str_repeat('abcdef0123456789', 4);
+
+        $this->assertSame(
+            $randomizer->ticketCodeForSequence($seed, 12345),
+            $randomizer->ticketCodeForSequence($seed, 12345),
+        );
+        $this->assertNotSame(
+            $randomizer->ticketCodeForSequence($seed, 12345),
+            $randomizer->ticketCodeForSequence(str_repeat('1', 64), 12345),
+        );
+    }
+
+    public function test_range_cannot_extend_beyond_the_code_space(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new LotteryRandomizer)->ticketCodesForRange(
+            str_repeat('a', 64),
+            LotteryRandomizer::CODE_SPACE_SIZE - 1,
+            2,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a weekly lottery where alliance members purchase $50,000 tickets with unique three-character alphanumeric codes
- contribute 90% ($45,000) of every ticket to the jackpot and roll the full pool into the following week when no sold code wins
- allocate all 46,656 possible codes through a seeded permutation and locked cursor, avoiding collision retries even near sellout
- draw every Sunday at 00:00 UTC and expose ticket purchases, capacity, odds, jackpot, rollover, and recent results in the member UI
- protect account purchases and payouts with ownership checks, frozen-account checks, row locks, transactional balance changes, and audit records

## Operational impact

- run the new database migrations during deployment
- this adds the scheduled `lottery:draw` command; ensure the Laravel scheduler is active
- no cache clear or queue worker restart is required

## Validation

- `php artisan test tests/Feature/Workflows/LotteryWorkflowTest.php` — 10 tests, 91 assertions
- `php artisan test tests/Unit/Services/LotteryRandomizerTest.php` — 3 tests, 6 assertions
- `vendor/bin/pint --dirty`
- `npm run build`
- `php artisan schedule:list` confirmed cron `0 0 * * 0`
- live browser verification covered a batched 25-ticket purchase and the Sunday midnight display
