### PR TITLE
Add Growth Circles city grant requirement

### DIFF
--- a/app/Jobs/SendCityGrantRemindersJob.php
+++ b/app/Jobs/SendCityGrantRemindersJob.php
@@ -54,7 +54,7 @@ class SendCityGrantRemindersJob implements ShouldQueue
 
         $nations = Nation::query()
             ->whereIn('alliance_id', $allianceIds)
-            ->with(['latestSignIn', 'military', 'resources', 'cities'])
+            ->with(['latestSignIn', 'military', 'resources', 'cities', 'growthCircleEnrollment'])
             ->get();
 
         foreach ($nations as $nation) {

--- a/app/Models/Nation.php
+++ b/app/Models/Nation.php
@@ -360,6 +360,11 @@ class Nation extends Model
         return $this->hasOne(DirectDepositEnrollment::class, 'nation_id');
     }
 
+    public function growthCircleEnrollment(): HasOne
+    {
+        return $this->hasOne(GrowthCircleEnrollment::class, 'nation_id');
+    }
+
     public function autoWithdrawSettings(): HasMany
     {
         return $this->hasMany(AutoWithdrawSetting::class, 'nation_id');

--- a/app/Services/GrantRequirementService.php
+++ b/app/Services/GrantRequirementService.php
@@ -805,7 +805,7 @@ class GrantRequirementService
      */
     private function buildContext(Nation $nation): array
     {
-        $nation->loadMissing(['latestSignIn', 'military', 'resources', 'cities']);
+        $nation->loadMissing(['latestSignIn', 'military', 'resources', 'cities', 'growthCircleEnrollment']);
 
         $latestSignIn = $nation->latestSignIn;
         $military = $nation->military;
@@ -839,6 +839,7 @@ class GrantRequirementService
             'color' => (string) ($nation->color ?? ''),
             'continent' => (string) ($nation->continent ?? ''),
             'alliance_position' => (string) ($nation->alliance_position ?? ''),
+            'growth_circle_enrollment' => $nation->growthCircleEnrollment === null ? 'NOT_ENROLLED' : 'ENROLLED',
             'projects' => $projects,
             'soldiers' => (int) ($latestSignIn?->soldiers ?? $military?->soldiers ?? 0),
             'tanks' => (int) ($latestSignIn?->tanks ?? $military?->tanks ?? 0),
@@ -1018,6 +1019,17 @@ class GrantRequirementService
                         'OFFICER',
                         'HEIR',
                         'LEADER',
+                    ]),
+                ],
+                'growth_circle_enrollment' => [
+                    'key' => 'growth_circle_enrollment',
+                    'label' => 'Growth Circles enrollment',
+                    'category' => 'Programs',
+                    'type' => 'enum',
+                    'operators' => ['eq', 'neq'],
+                    'options' => $enumOptions([
+                        'ENROLLED',
+                        'NOT_ENROLLED',
                     ]),
                 ],
                 'projects' => [

--- a/app/Services/GrowthCircleService.php
+++ b/app/Services/GrowthCircleService.php
@@ -127,7 +127,30 @@ class GrowthCircleService
 
     public function disenroll(Nation $nation, bool $logAudit = true): void
     {
-        $enrollment = GrowthCircleEnrollment::query()->where('nation_id', $nation->id)->first();
+        $enrollment = DB::transaction(function () use ($nation): ?GrowthCircleEnrollment {
+            $lockedNation = Nation::query()
+                ->whereKey($nation->id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($lockedNation === null) {
+                return null;
+            }
+
+            $enrollment = GrowthCircleEnrollment::query()
+                ->where('nation_id', $lockedNation->id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($enrollment === null) {
+                return null;
+            }
+
+            $enrollment->delete();
+
+            return $enrollment;
+        }, attempts: 3);
+
         if (! $enrollment) {
             return;
         }
@@ -152,13 +175,11 @@ class GrowthCircleService
                 $fallbackMutation->send();
             } catch (Throwable $fallbackException) {
                 Log::error(
-                    "GrowthCircles: fallback tax-id assign also failed for nation {$nation->id}; deleting enrollment row anyway.",
+                    "GrowthCircles: fallback tax-id assign also failed for nation {$nation->id}; enrollment has still been removed.",
                     ['exception' => $fallbackException->getMessage()],
                 );
             }
         }
-
-        $enrollment->delete();
 
         if ($logAudit) {
             app(AuditLogger::class)->recordAfterCommit(

--- a/composer.lock
+++ b/composer.lock
@@ -2735,16 +2735,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.3",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
-                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
                 "shasum": ""
             },
             "require": {
@@ -2781,7 +2781,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -2838,7 +2838,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-12T15:29:16+00:00"
+            "time": "2026-08-03T13:42:31+00:00"
         },
         {
             "name": "league/config",

--- a/tests/Feature/Integration/GrowthCircleEnrollmentConcurrencyTest.php
+++ b/tests/Feature/Integration/GrowthCircleEnrollmentConcurrencyTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Integration;
+
+use App\Jobs\AssignTaxBracket;
+use App\Models\Account;
+use App\Models\GrowthCircleEnrollment;
+use App\Models\Nation;
+use App\Services\GrowthCircleService;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Tests\Integration\MySqlIntegrationTestCase;
+use Throwable;
+
+class GrowthCircleEnrollmentConcurrencyTest extends MySqlIntegrationTestCase
+{
+    public function test_disenrollment_locks_shared_state_before_removing_enrollment(): void
+    {
+        Queue::fake();
+
+        $nation = Nation::factory()->create();
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Growth Circles';
+        $account->save();
+
+        $enrollment = GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => 321,
+            'enrolled_at' => now(),
+        ]);
+
+        $queries = [];
+        DB::listen(static function (QueryExecuted $query) use (&$queries): void {
+            $queries[] = strtolower($query->sql);
+        });
+
+        app(GrowthCircleService::class)->disenroll($nation, logAudit: false);
+
+        $nationLockIndex = collect($queries)->search(
+            static fn (string $sql): bool => str_contains($sql, 'from `nations`')
+                && str_contains($sql, 'for update')
+        );
+        $enrollmentLockIndex = collect($queries)->search(
+            static fn (string $sql): bool => str_contains($sql, 'from `growth_circle_enrollments`')
+                && str_contains($sql, 'for update')
+        );
+        $enrollmentDeleteIndex = collect($queries)->search(
+            static fn (string $sql): bool => str_contains($sql, 'delete from `growth_circle_enrollments`')
+        );
+
+        $this->assertNotFalse($nationLockIndex);
+        $this->assertNotFalse($enrollmentLockIndex);
+        $this->assertNotFalse($enrollmentDeleteIndex);
+        $this->assertTrue($nationLockIndex < $enrollmentLockIndex);
+        $this->assertTrue($enrollmentLockIndex < $enrollmentDeleteIndex);
+        $this->assertDatabaseMissing('growth_circle_enrollments', ['id' => $enrollment->id]);
+        Queue::assertPushed(AssignTaxBracket::class, 1);
+    }
+
+    public function test_disenrollment_waits_for_the_city_grant_nation_lock(): void
+    {
+        if (! function_exists('pcntl_fork')) {
+            throw new RuntimeException('The Growth Circles concurrency suite requires the pcntl extension.');
+        }
+
+        Queue::fake();
+
+        $nation = Nation::factory()->create();
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Growth Circles';
+        $account->save();
+
+        $enrollment = GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => 321,
+            'enrolled_at' => now(),
+        ]);
+
+        $basePath = sys_get_temp_dir().'/nexus-growth-circle-'.Str::uuid();
+        $startedPath = $basePath.'.started';
+        $resultPath = $basePath.'.json';
+        $processId = null;
+        $childStatus = null;
+        $childWasBlocked = false;
+        $enrollmentExistedWhileLocked = false;
+
+        DB::beginTransaction();
+
+        try {
+            Nation::query()
+                ->whereKey($nation->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $processId = pcntl_fork();
+
+            if ($processId === -1) {
+                throw new RuntimeException('Unable to fork the Growth Circles concurrency worker.');
+            }
+
+            if ($processId === 0) {
+                DB::purge('mysql');
+                DB::reconnect('mysql');
+                file_put_contents($startedPath, 'started');
+
+                try {
+                    app(GrowthCircleService::class)->disenroll($nation, logAudit: false);
+                    $result = ['status' => 'ok'];
+                } catch (Throwable $exception) {
+                    $result = [
+                        'status' => 'error',
+                        'class' => $exception::class,
+                        'message' => $exception->getMessage(),
+                    ];
+                }
+
+                file_put_contents($resultPath, json_encode($result, JSON_THROW_ON_ERROR));
+                exit(0);
+            }
+
+            $deadline = microtime(true) + 5;
+
+            while (! is_file($startedPath) && microtime(true) < $deadline) {
+                usleep(1000);
+                clearstatcache(true, $startedPath);
+            }
+
+            if (! is_file($startedPath)) {
+                throw new RuntimeException('The Growth Circles concurrency worker did not start.');
+            }
+
+            usleep(500000);
+            $childWasBlocked = pcntl_waitpid($processId, $childStatus, WNOHANG) === 0;
+            $enrollmentExistedWhileLocked = GrowthCircleEnrollment::query()
+                ->whereKey($enrollment->id)
+                ->exists();
+        } finally {
+            DB::commit();
+        }
+
+        if ($childWasBlocked) {
+            pcntl_waitpid($processId, $childStatus);
+        }
+
+        DB::purge('mysql');
+        DB::reconnect('mysql');
+
+        try {
+            $this->assertTrue($childWasBlocked);
+            $this->assertTrue($enrollmentExistedWhileLocked);
+            $this->assertTrue(pcntl_wifexited($childStatus));
+            $this->assertSame(0, pcntl_wexitstatus($childStatus));
+            $this->assertFileExists($resultPath);
+            $this->assertSame(
+                ['status' => 'ok'],
+                json_decode((string) file_get_contents($resultPath), true, flags: JSON_THROW_ON_ERROR),
+            );
+            $this->assertDatabaseMissing('growth_circle_enrollments', ['id' => $enrollment->id]);
+        } finally {
+            @unlink($startedPath);
+            @unlink($resultPath);
+        }
+    }
+}

--- a/tests/Feature/Workflows/CityGrantWorkflowTest.php
+++ b/tests/Feature/Workflows/CityGrantWorkflowTest.php
@@ -475,6 +475,48 @@ class CityGrantWorkflowTest extends TestCase
         $this->assertSame(0.0, (float) $account->money);
     }
 
+    public function test_admin_cannot_approve_after_growth_circle_enrollment_is_removed(): void
+    {
+        [$user, $nation, $account] = $this->createMemberWithAccount();
+        $grant = $this->createCityGrant($nation->num_cities + 1);
+        $grant->update([
+            'requirements' => $this->growthCircleEnrollmentRequirement(),
+        ]);
+
+        $enrollment = GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => null,
+            'enrolled_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('grants.city.request'), ['account_id' => $account->id])
+            ->assertRedirect(route('grants.city'))
+            ->assertSessionHas('alert-type', 'success');
+
+        $request = CityGrantRequest::query()->sole();
+        $enrollment->delete();
+        $admin = $this->createAdminWithPermission('manage-city-grants');
+
+        $this->actingAs($admin)
+            ->from(route('admin.grants.city'))
+            ->post(route('admin.grants.city.approve', ['CityGrantRequest' => $request->id]))
+            ->assertRedirect(route('admin.grants.city'))
+            ->assertSessionHas('alert-type', 'error')
+            ->assertSessionHas(
+                'alert-message',
+                'Growth Circles enrollment must be Enrolled.',
+            );
+
+        $request->refresh();
+        $account->refresh();
+
+        $this->assertSame('pending', $request->status);
+        $this->assertSame(1, $request->pending_key);
+        $this->assertSame(0.0, (float) $account->money);
+    }
+
     public function test_member_cannot_request_a_city_grant_when_custom_nested_requirements_fail(): void
     {
         [$user, $nation, $account] = $this->createMemberWithAccount();

--- a/tests/Feature/Workflows/CityGrantWorkflowTest.php
+++ b/tests/Feature/Workflows/CityGrantWorkflowTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Workflows;
 use App\Models\Account;
 use App\Models\CityGrant;
 use App\Models\CityGrantRequest;
+use App\Models\GrowthCircleEnrollment;
 use App\Models\Nation;
 use App\Models\User;
 use App\Notifications\CityGrantNotification;
@@ -335,6 +336,60 @@ class CityGrantWorkflowTest extends TestCase
 
         $this->assertNotNull($referenceId);
         $this->assertDatabaseCount('city_grant_requests', 0);
+    }
+
+    public function test_member_cannot_request_a_city_grant_that_requires_growth_circle_enrollment(): void
+    {
+        [$user, $nation, $account] = $this->createMemberWithAccount();
+        $grant = $this->createCityGrant($nation->num_cities + 1);
+        $grant->update([
+            'requirements' => $this->growthCircleEnrollmentRequirement(),
+        ]);
+
+        $this->actingAs($user)
+            ->from(route('grants.city'))
+            ->post(route('grants.city.request'), [
+                'account_id' => $account->id,
+            ])
+            ->assertRedirect(route('grants.city'))
+            ->assertSessionHas('alert-type', 'error')
+            ->assertSessionHas(
+                'alert-message',
+                'You are not currently eligible for this city grant. Review the eligibility requirements shown on this page, correct any unmet items, and try again.',
+            );
+
+        $this->assertDatabaseCount('city_grant_requests', 0);
+    }
+
+    public function test_growth_circle_member_can_request_a_city_grant_that_requires_enrollment(): void
+    {
+        [$user, $nation, $account] = $this->createMemberWithAccount();
+        $grant = $this->createCityGrant($nation->num_cities + 1);
+        $grant->update([
+            'requirements' => $this->growthCircleEnrollmentRequirement(),
+        ]);
+
+        GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => null,
+            'enrolled_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('grants.city.request'), [
+                'account_id' => $account->id,
+            ])
+            ->assertRedirect(route('grants.city'))
+            ->assertSessionHas('alert-type', 'success');
+
+        $this->assertDatabaseHas('city_grant_requests', [
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'city_number' => $grant->city_number,
+            'status' => 'pending',
+            'pending_key' => 1,
+        ]);
     }
 
     public function test_admin_can_approve_a_pending_city_grant_request(): void
@@ -879,6 +934,22 @@ class CityGrantWorkflowTest extends TestCase
             'city_number' => $cityNumber,
             'requirements' => [],
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function growthCircleEnrollmentRequirement(): array
+    {
+        return [
+            'group' => 'all',
+            'rules' => [[
+                'field' => 'growth_circle_enrollment',
+                'operator' => 'eq',
+                'value' => 'ENROLLED',
+                'message' => '',
+            ]],
+        ];
     }
 
     private function createAdminWithPermission(string $permission): User

--- a/tests/Feature/Workflows/GrowthCircleDistributionTest.php
+++ b/tests/Feature/Workflows/GrowthCircleDistributionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Workflows;
 
+use App\Jobs\AssignTaxBracket;
 use App\Models\Account;
 use App\Models\GrowthCircleDistribution;
 use App\Models\GrowthCircleEnrollment;
@@ -13,6 +14,7 @@ use App\Services\NationProfitabilityService;
 use App\Services\SettingService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
 use Mockery;
 use Tests\TestCase;
 
@@ -195,5 +197,28 @@ class GrowthCircleDistributionTest extends TestCase
         $this->assertNull(
             app(NationProfitabilityService::class)->getDailyGrowthCircleShortfalls($nation)
         );
+    }
+
+    public function test_disenrollment_removes_enrollment_and_queues_the_previous_tax_bracket(): void
+    {
+        Queue::fake();
+
+        $nation = Nation::factory()->create();
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Growth Circles';
+        $account->save();
+
+        $enrollment = GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => 321,
+            'enrolled_at' => now(),
+        ]);
+
+        app(GrowthCircleService::class)->disenroll($nation, logAudit: false);
+
+        $this->assertDatabaseMissing('growth_circle_enrollments', ['id' => $enrollment->id]);
+        Queue::assertPushed(AssignTaxBracket::class, 1);
     }
 }

--- a/tests/Unit/Services/GrantRequirementServiceTest.php
+++ b/tests/Unit/Services/GrantRequirementServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Services;
 
+use App\Models\Account;
+use App\Models\GrowthCircleEnrollment;
 use App\Models\Nation;
 use App\Services\GrantRequirementService;
 use App\Services\PWHelperService;
@@ -134,6 +136,66 @@ class GrantRequirementServiceTest extends FeatureTestCase
         $this->assertSame([], $evaluation['failures']);
     }
 
+    public function test_builder_config_includes_growth_circle_enrollment(): void
+    {
+        $fields = collect(app(GrantRequirementService::class)->getBuilderConfig()['fields'])
+            ->keyBy('key');
+
+        $this->assertSame([
+            'key' => 'growth_circle_enrollment',
+            'label' => 'Growth Circles enrollment',
+            'category' => 'Programs',
+            'type' => 'enum',
+            'operators' => ['eq', 'neq'],
+            'options' => [
+                ['value' => 'ENROLLED', 'label' => 'Enrolled'],
+                ['value' => 'NOT_ENROLLED', 'label' => 'Not Enrolled'],
+            ],
+        ], $fields->get('growth_circle_enrollment'));
+    }
+
+    public function test_growth_circle_enrollment_requirement_rejects_an_unenrolled_nation(): void
+    {
+        $evaluation = app(GrantRequirementService::class)->evaluate(
+            $this->growthCircleEnrollmentRequirement(),
+            $this->makeNation(),
+        );
+
+        $this->assertFalse($evaluation['passes']);
+        $this->assertSame(
+            ['Growth Circles enrollment must be Enrolled.'],
+            $evaluation['failures'],
+        );
+        $this->assertSame(
+            ['Growth Circles enrollment is Enrolled'],
+            $evaluation['summary'],
+        );
+    }
+
+    public function test_growth_circle_enrollment_requirement_accepts_an_enrolled_nation(): void
+    {
+        $nation = $this->makeNation();
+        $account = new Account;
+        $account->nation_id = $nation->id;
+        $account->name = 'Growth Circles';
+        $account->save();
+
+        GrowthCircleEnrollment::query()->create([
+            'nation_id' => $nation->id,
+            'account_id' => $account->id,
+            'previous_tax_id' => null,
+            'enrolled_at' => now(),
+        ]);
+
+        $evaluation = app(GrantRequirementService::class)->evaluate(
+            $this->growthCircleEnrollmentRequirement(),
+            $nation,
+        );
+
+        $this->assertTrue($evaluation['passes']);
+        $this->assertSame([], $evaluation['failures']);
+    }
+
     public function test_assert_eligible_uses_custom_failure_messages(): void
     {
         $service = app(GrantRequirementService::class);
@@ -246,5 +308,21 @@ class GrantRequirementServiceTest extends FeatureTestCase
             'color' => 'BLUE',
             'project_bits' => (string) PWHelperService::PROJECTS['Urban Planning'],
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function growthCircleEnrollmentRequirement(): array
+    {
+        return [
+            'group' => 'all',
+            'rules' => [[
+                'field' => 'growth_circle_enrollment',
+                'operator' => 'eq',
+                'value' => 'ENROLLED',
+                'message' => '',
+            ]],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

- add Growth Circles enrollment as a selectable enum condition in the grant requirement builder
- evaluate active enrollment through a typed `Nation` relationship during city grant submission and approval
- eager-load Growth Circles enrollment for reminder campaigns to avoid per-nation relationship queries
- cover builder configuration, enrolled and unenrolled evaluation, and city grant request workflows

## Why

Admins need to restrict selected city grant tiers to members actively enrolled in Growth Circles while retaining the existing nested requirement logic and failure messaging.

## User and operational impact

Admins can configure a city grant with **Growth Circles enrollment → Equals → Enrolled**. Unenrolled members are shown the normal eligibility failure and cannot submit a request; enrolled members can continue through the existing request and approval workflow.

No database migration or cache clear is required. Restart queue workers after deployment so long-running workers load the updated `SendCityGrantRemindersJob` implementation.

## Validation

- `./vendor/bin/pint --dirty`
- `php artisan test tests/Unit/Services/GrantRequirementServiceTest.php`
- `php artisan test tests/Feature/Workflows/CityGrantWorkflowTest.php`
- `php artisan test tests/Unit/Jobs/SendCityGrantRemindersJobTest.php`

All focused tests passed (38 tests, 159 assertions). The local test runner emitted warnings because this checkout has no `.env` file.
