### PR TITLE
Add city-based raid activity filter

### DIFF
--- a/app/Http/Controllers/Admin/RaidController.php
+++ b/app/Http/Controllers/Admin/RaidController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UpdateRaidFinderSettingsRequest;
 use App\Models\NoRaidList;
 use App\Services\AuditLogger;
 use App\Services\RaidFinderCache;
@@ -39,6 +40,8 @@ class RaidController extends Controller
         return view('admin.defense.raids', [
             'noRaidList' => $noRaidList,
             'topCap' => $topCap,
+            'activityCityThreshold' => SettingService::getRaidActivityCityThreshold(),
+            'minimumInactiveTurns' => SettingService::getRaidMinimumInactiveTurns(),
         ]);
     }
 
@@ -105,34 +108,51 @@ class RaidController extends Controller
     }
 
     /**
-     * @return RedirectResponse
-     *
      * @throws AuthorizationException
      */
-    public function updateTopCap(Request $request)
+    public function updateTopCap(UpdateRaidFinderSettingsRequest $request): RedirectResponse
     {
         $this->authorize('manage-raids');
 
-        $previous = SettingService::getTopRaidable();
-        $request->validate(['top_cap' => 'required|integer|min:1|max:1000']);
+        $validated = $request->validated();
+        $previous = [
+            'raid_top_alliance_cap' => SettingService::getTopRaidable(),
+            'raid_activity_city_threshold' => SettingService::getRaidActivityCityThreshold(),
+            'raid_minimum_inactive_turns' => SettingService::getRaidMinimumInactiveTurns(),
+        ];
+        $updated = [
+            'raid_top_alliance_cap' => (int) $validated['top_cap'],
+            'raid_activity_city_threshold' => (int) ($validated['raid_activity_city_threshold'] ?? $previous['raid_activity_city_threshold']),
+            'raid_minimum_inactive_turns' => (int) ($validated['raid_minimum_inactive_turns'] ?? $previous['raid_minimum_inactive_turns']),
+        ];
 
-        SettingService::setTopRaidable($request->input('top_cap'));
+        SettingService::setTopRaidable($updated['raid_top_alliance_cap']);
+        SettingService::setRaidActivityCityThreshold($updated['raid_activity_city_threshold']);
+        SettingService::setRaidMinimumInactiveTurns($updated['raid_minimum_inactive_turns']);
         $this->raidFinderCache->invalidatePolicy();
 
         $this->auditLogger->success(
             category: 'settings',
-            action: 'raid_top_cap_updated',
+            action: 'raid_finder_settings_updated',
             context: [
                 'changes' => [
                     'raid_top_alliance_cap' => [
-                        'from' => $previous,
-                        'to' => (int) $request->input('top_cap'),
+                        'from' => $previous['raid_top_alliance_cap'],
+                        'to' => $updated['raid_top_alliance_cap'],
+                    ],
+                    'raid_activity_city_threshold' => [
+                        'from' => $previous['raid_activity_city_threshold'],
+                        'to' => $updated['raid_activity_city_threshold'],
+                    ],
+                    'raid_minimum_inactive_turns' => [
+                        'from' => $previous['raid_minimum_inactive_turns'],
+                        'to' => $updated['raid_minimum_inactive_turns'],
                     ],
                 ],
             ],
-            message: 'Raid top cap updated.'
+            message: 'Raid finder settings updated.'
         );
 
-        return redirect()->route('admin.raids.index')->with('alert-message', 'Top alliance cap updated')->with('alert-type', 'success');
+        return redirect()->route('admin.raids.index')->with('alert-message', 'Raid finder settings updated')->with('alert-type', 'success');
     }
 }

--- a/app/Http/Requests/Admin/UpdateRaidFinderSettingsRequest.php
+++ b/app/Http/Requests/Admin/UpdateRaidFinderSettingsRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Services\SettingService;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRaidFinderSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasPermission('manage-raids') ?? false;
+    }
+
+    /** @return array<string, array<int, string>> */
+    public function rules(): array
+    {
+        return [
+            'top_cap' => ['required', 'integer', 'min:1', 'max:1000'],
+            'raid_activity_city_threshold' => [
+                'sometimes',
+                'required',
+                'integer',
+                'min:0',
+                'max:'.SettingService::MAX_RAID_ACTIVITY_CITY_THRESHOLD,
+            ],
+            'raid_minimum_inactive_turns' => [
+                'sometimes',
+                'required',
+                'integer',
+                'min:0',
+                'max:'.SettingService::MAX_RAID_MINIMUM_INACTIVE_TURNS,
+            ],
+        ];
+    }
+
+    /** @return array<string, string> */
+    public function messages(): array
+    {
+        return [
+            'raid_activity_city_threshold.max' => 'The activity city threshold may not exceed 1,000 cities.',
+            'raid_minimum_inactive_turns.max' => 'The inactivity requirement may not exceed 4,380 turns.',
+        ];
+    }
+}

--- a/app/Services/RaidFinderService.php
+++ b/app/Services/RaidFinderService.php
@@ -17,6 +17,7 @@ class RaidFinderService
         protected LootCalculatorService $lootCalculator,
         protected AllianceMembershipService $membershipService,
         protected RaidPolicyService $raidPolicy,
+        protected RaidTargetActivityFilter $activityFilter,
     ) {}
 
     /**
@@ -36,7 +37,9 @@ class RaidFinderService
         $maxScore = $ownNation->score * 1.75;
 
         // Load all raidable nations
-        $nations = $this->queryRaidableNations($minScore, $maxScore);
+        $nations = $this->activityFilter->filter(
+            $this->queryRaidableNations($minScore, $maxScore),
+        );
 
         $targets = collect();
 

--- a/app/Services/RaidTargetActivityFilter.php
+++ b/app/Services/RaidTargetActivityFilter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use App\GraphQL\Models\Nation;
+use App\Services\Settings\DataSyncSettings;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class RaidTargetActivityFilter
+{
+    private const HOURS_PER_TURN = 2;
+
+    public function __construct(private readonly DataSyncSettings $settings) {}
+
+    /**
+     * @param  Collection<int, Nation>  $nations
+     * @return Collection<int, Nation>
+     */
+    public function filter(Collection $nations): Collection
+    {
+        $minimumInactiveTurns = $this->settings->getRaidMinimumInactiveTurns();
+
+        if ($minimumInactiveTurns === 0) {
+            return $nations->values();
+        }
+
+        $cityThreshold = $this->settings->getRaidActivityCityThreshold();
+        $inactiveCutoff = CarbonImmutable::now('UTC')
+            ->subHours($minimumInactiveTurns * self::HOURS_PER_TURN);
+
+        return $nations
+            ->filter(fn (Nation $nation): bool => $this->isEligible($nation, $cityThreshold, $inactiveCutoff))
+            ->values();
+    }
+
+    private function isEligible(Nation $nation, int $cityThreshold, CarbonImmutable $inactiveCutoff): bool
+    {
+        if ($nation->num_cities === null) {
+            return false;
+        }
+
+        if ($nation->num_cities <= $cityThreshold) {
+            return true;
+        }
+
+        if ($nation->last_active === null) {
+            return false;
+        }
+
+        try {
+            return CarbonImmutable::parse($nation->last_active, 'UTC')->lessThanOrEqualTo($inactiveCutoff);
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/app/Services/SettingService.php
+++ b/app/Services/SettingService.php
@@ -32,6 +32,14 @@ class SettingService
 
     public const MAX_LOTTERY_TICKETS_PER_NATION = FinancePolicySettings::MAX_LOTTERY_TICKETS_PER_NATION;
 
+    public const DEFAULT_RAID_ACTIVITY_CITY_THRESHOLD = DataSyncSettings::DEFAULT_RAID_ACTIVITY_CITY_THRESHOLD;
+
+    public const DEFAULT_RAID_MINIMUM_INACTIVE_TURNS = DataSyncSettings::DEFAULT_RAID_MINIMUM_INACTIVE_TURNS;
+
+    public const MAX_RAID_ACTIVITY_CITY_THRESHOLD = DataSyncSettings::MAX_RAID_ACTIVITY_CITY_THRESHOLD;
+
+    public const MAX_RAID_MINIMUM_INACTIVE_TURNS = DataSyncSettings::MAX_RAID_MINIMUM_INACTIVE_TURNS;
+
     public static function getLastScannedBankRecordId(): int
     {
         return app(DataSyncSettings::class)->getLastScannedBankRecordId();
@@ -303,6 +311,26 @@ class SettingService
     public static function setTopRaidable(int $topN): void
     {
         app(DataSyncSettings::class)->setTopRaidable($topN);
+    }
+
+    public static function getRaidActivityCityThreshold(): int
+    {
+        return app(DataSyncSettings::class)->getRaidActivityCityThreshold();
+    }
+
+    public static function setRaidActivityCityThreshold(int $cityThreshold): void
+    {
+        app(DataSyncSettings::class)->setRaidActivityCityThreshold($cityThreshold);
+    }
+
+    public static function getRaidMinimumInactiveTurns(): int
+    {
+        return app(DataSyncSettings::class)->getRaidMinimumInactiveTurns();
+    }
+
+    public static function setRaidMinimumInactiveTurns(int $inactiveTurns): void
+    {
+        app(DataSyncSettings::class)->setRaidMinimumInactiveTurns($inactiveTurns);
     }
 
     public static function getDirectDepositId(): int

--- a/app/Services/Settings/DataSyncSettings.php
+++ b/app/Services/Settings/DataSyncSettings.php
@@ -6,6 +6,14 @@ use Illuminate\Support\Carbon;
 
 class DataSyncSettings
 {
+    public const DEFAULT_RAID_ACTIVITY_CITY_THRESHOLD = 0;
+
+    public const DEFAULT_RAID_MINIMUM_INACTIVE_TURNS = 0;
+
+    public const MAX_RAID_ACTIVITY_CITY_THRESHOLD = 1000;
+
+    public const MAX_RAID_MINIMUM_INACTIVE_TURNS = 4380;
+
     public function __construct(private readonly SettingValueStore $settings) {}
 
     public function getLastScannedBankRecordId(): int
@@ -66,6 +74,48 @@ class DataSyncSettings
     public function setTopRaidable(int $topN): void
     {
         $this->settings->set('raid_top_alliance_cap', $topN);
+    }
+
+    public function getRaidActivityCityThreshold(): int
+    {
+        $value = $this->settings->get('raid_activity_city_threshold');
+
+        if (is_null($value)) {
+            $this->setRaidActivityCityThreshold(self::DEFAULT_RAID_ACTIVITY_CITY_THRESHOLD);
+
+            return self::DEFAULT_RAID_ACTIVITY_CITY_THRESHOLD;
+        }
+
+        return (int) $value;
+    }
+
+    public function setRaidActivityCityThreshold(int $cityThreshold): void
+    {
+        $this->settings->set(
+            'raid_activity_city_threshold',
+            max(0, min(self::MAX_RAID_ACTIVITY_CITY_THRESHOLD, $cityThreshold)),
+        );
+    }
+
+    public function getRaidMinimumInactiveTurns(): int
+    {
+        $value = $this->settings->get('raid_minimum_inactive_turns');
+
+        if (is_null($value)) {
+            $this->setRaidMinimumInactiveTurns(self::DEFAULT_RAID_MINIMUM_INACTIVE_TURNS);
+
+            return self::DEFAULT_RAID_MINIMUM_INACTIVE_TURNS;
+        }
+
+        return (int) $value;
+    }
+
+    public function setRaidMinimumInactiveTurns(int $inactiveTurns): void
+    {
+        $this->settings->set(
+            'raid_minimum_inactive_turns',
+            max(0, min(self::MAX_RAID_MINIMUM_INACTIVE_TURNS, $inactiveTurns)),
+        );
     }
 
     public function getLastNationSyncBatchId(): string

--- a/resources/views/admin/defense/raids.blade.php
+++ b/resources/views/admin/defense/raids.blade.php
@@ -2,27 +2,67 @@
 
 @section('content')
     <x-header title="Raid Finder" separator use-h1>
-        <x-slot:subtitle>Manage the global no-raid alliance list and the top-alliance exclusion cap.</x-slot:subtitle>
+        <x-slot:subtitle>Manage target eligibility, the global no-raid alliance list, and the top-alliance exclusion cap.</x-slot:subtitle>
     </x-header>
 
     <div class="mb-6 grid gap-6 xl:grid-cols-[minmax(0,24rem)_minmax(0,1fr)]">
-        <x-card title="Top Alliance Cap" subtitle="Exclude the top-ranked alliances from raid recommendations.">
-            <form method="POST" action="{{ route('admin.raids.top-cap.update') }}" class="flex flex-wrap items-end gap-3">
+        <x-card title="Raid Target Policy" subtitle="Set the global alliance and activity requirements for raid recommendations.">
+            <form method="POST" action="{{ route('admin.raids.top-cap.update') }}" class="grid gap-4">
                 @csrf
-                <label class="block w-full max-w-xs space-y-2">
+                <label class="grid gap-2">
                     <span class="text-sm font-medium">Exclude top alliances</span>
                     <input
                         type="number"
                         class="input"
                         name="top_cap"
                         id="top_cap"
-                        value="{{ $topCap }}"
+                        value="{{ old('top_cap', $topCap) }}"
                         min="1"
-                        max="100"
+                        max="1000"
                         required
                     >
                 </label>
-                <button class="btn btn-primary" type="submit">Update</button>
+
+                <div class="grid gap-3 rounded-box border border-base-300 p-4">
+                    <div class="grid gap-1">
+                        <h3 class="font-semibold">Target activity</h3>
+                        <p class="text-sm nexus-text-muted">
+                            Targets above the city threshold must have been inactive for the required number of turns. Each turn is two hours.
+                        </p>
+                    </div>
+
+                    <label class="grid gap-2">
+                        <span class="text-sm font-medium">Apply inactivity above city count</span>
+                        <input
+                            type="number"
+                            class="input"
+                            name="raid_activity_city_threshold"
+                            id="raid_activity_city_threshold"
+                            value="{{ old('raid_activity_city_threshold', $activityCityThreshold) }}"
+                            min="0"
+                            max="1000"
+                            required
+                        >
+                        <span class="text-xs nexus-text-muted">Targets at or below this city count bypass the activity requirement.</span>
+                    </label>
+
+                    <label class="grid gap-2">
+                        <span class="text-sm font-medium">Minimum inactive turns</span>
+                        <input
+                            type="number"
+                            class="input"
+                            name="raid_minimum_inactive_turns"
+                            id="raid_minimum_inactive_turns"
+                            value="{{ old('raid_minimum_inactive_turns', $minimumInactiveTurns) }}"
+                            min="0"
+                            max="4380"
+                            required
+                        >
+                        <span class="text-xs nexus-text-muted">Set this to 0 to disable the activity filter.</span>
+                    </label>
+                </div>
+
+                <button class="btn btn-primary justify-self-start" type="submit">Update raid policy</button>
             </form>
         </x-card>
 

--- a/tests/Feature/Admin/RaidFinderSettingsTest.php
+++ b/tests/Feature/Admin/RaidFinderSettingsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Services\RaidFinderCache;
+use App\Services\SettingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\Concerns\BuildsTestUsers;
+use Tests\TestCase;
+
+class RaidFinderSettingsTest extends TestCase
+{
+    use BuildsTestUsers;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function test_raid_view_exposes_the_activity_policy_controls(): void
+    {
+        SettingService::setRaidActivityCityThreshold(15);
+        SettingService::setRaidMinimumInactiveTurns(18);
+        $admin = $this->createAdmin(['view-raids']);
+
+        $this->actingAs($admin)
+            ->get(route('admin.raids.index'))
+            ->assertOk()
+            ->assertSee('Target activity')
+            ->assertSee('name="raid_activity_city_threshold"', false)
+            ->assertSee('value="15"', false)
+            ->assertSee('name="raid_minimum_inactive_turns"', false)
+            ->assertSee('value="18"', false);
+    }
+
+    public function test_manager_can_update_the_activity_policy_and_invalidate_cached_targets(): void
+    {
+        $admin = $this->createAdmin(['view-raids', 'manage-raids']);
+        $cache = app(RaidFinderCache::class);
+
+        $this->assertSame('raid-finder:v1:4242', $cache->key(4242));
+
+        $this->actingAs($admin)
+            ->post(route('admin.raids.top-cap.update'), [
+                'top_cap' => 35,
+                'raid_activity_city_threshold' => 12,
+                'raid_minimum_inactive_turns' => 24,
+            ])
+            ->assertRedirect(route('admin.raids.index'));
+
+        $this->assertSame(35, SettingService::getTopRaidable());
+        $this->assertSame(12, SettingService::getRaidActivityCityThreshold());
+        $this->assertSame(24, SettingService::getRaidMinimumInactiveTurns());
+        $this->assertSame('raid-finder:v2:4242', $cache->key(4242));
+        $this->assertDatabaseHas('audit_logs', [
+            'actor_id' => $admin->id,
+            'category' => 'settings',
+            'action' => 'raid_finder_settings_updated',
+            'outcome' => 'success',
+        ]);
+    }
+
+    public function test_activity_policy_rejects_values_outside_the_supported_range(): void
+    {
+        $admin = $this->createAdmin(['view-raids', 'manage-raids']);
+
+        $this->actingAs($admin)
+            ->from(route('admin.raids.index'))
+            ->post(route('admin.raids.top-cap.update'), [
+                'top_cap' => 35,
+                'raid_activity_city_threshold' => 1001,
+                'raid_minimum_inactive_turns' => 4381,
+            ])
+            ->assertRedirect(route('admin.raids.index'))
+            ->assertSessionHasErrors([
+                'raid_activity_city_threshold',
+                'raid_minimum_inactive_turns',
+            ]);
+
+        $this->assertDatabaseMissing('settings', ['key' => 'raid_activity_city_threshold']);
+        $this->assertDatabaseMissing('settings', ['key' => 'raid_minimum_inactive_turns']);
+    }
+
+    public function test_legacy_top_cap_update_preserves_the_activity_policy(): void
+    {
+        SettingService::setRaidActivityCityThreshold(16);
+        SettingService::setRaidMinimumInactiveTurns(30);
+        $admin = $this->createAdmin(['view-raids', 'manage-raids']);
+
+        $this->actingAs($admin)
+            ->post(route('admin.raids.top-cap.update'), ['top_cap' => 25])
+            ->assertRedirect(route('admin.raids.index'));
+
+        $this->assertSame(25, SettingService::getTopRaidable());
+        $this->assertSame(16, SettingService::getRaidActivityCityThreshold());
+        $this->assertSame(30, SettingService::getRaidMinimumInactiveTurns());
+    }
+
+    public function test_viewer_cannot_update_the_activity_policy(): void
+    {
+        $admin = $this->createAdmin(['view-raids']);
+
+        $this->actingAs($admin)
+            ->post(route('admin.raids.top-cap.update'), [
+                'top_cap' => 35,
+                'raid_activity_city_threshold' => 12,
+                'raid_minimum_inactive_turns' => 24,
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('settings', ['key' => 'raid_activity_city_threshold']);
+        $this->assertDatabaseMissing('settings', ['key' => 'raid_minimum_inactive_turns']);
+    }
+
+    /** @param array<int, string> $permissions */
+    private function createAdmin(array $permissions): User
+    {
+        $admin = $this->createVerifiedAdmin();
+        $this->attachDiscordAccount($admin);
+
+        return $this->grantPermissions($admin, $permissions);
+    }
+}

--- a/tests/Feature/Services/Settings/SettingDomainServicesTest.php
+++ b/tests/Feature/Services/Settings/SettingDomainServicesTest.php
@@ -53,9 +53,13 @@ class SettingDomainServicesTest extends TestCase
 
         SettingService::setLastNationSyncBatchId('manual-2');
         SettingService::setTopRaidable(55);
+        $settings->setRaidActivityCityThreshold(-1);
+        SettingService::setRaidMinimumInactiveTurns(SettingService::MAX_RAID_MINIMUM_INACTIVE_TURNS + 1);
 
         $this->assertSame('manual-2', $settings->getLastManualNationSyncBatchId());
         $this->assertSame(55, $settings->getTopRaidable());
+        $this->assertSame(0, SettingService::getRaidActivityCityThreshold());
+        $this->assertSame(SettingService::MAX_RAID_MINIMUM_INACTIVE_TURNS, $settings->getRaidMinimumInactiveTurns());
     }
 
     public function test_public_site_service_and_compatibility_facade_share_values_without_persisting_defaults(): void

--- a/tests/Feature/Services/Settings/SettingServiceCharacterizationTest.php
+++ b/tests/Feature/Services/Settings/SettingServiceCharacterizationTest.php
@@ -24,6 +24,10 @@ class SettingServiceCharacterizationTest extends TestCase
         $this->assertSame(1_000_000_000, SettingService::MAX_LOTTERY_TICKET_PRICE_CENTS);
         $this->assertSame(500, SettingService::MAX_LOTTERY_TICKETS_PER_PURCHASE);
         $this->assertSame(10_000, SettingService::MAX_LOTTERY_TICKETS_PER_NATION);
+        $this->assertSame(0, SettingService::DEFAULT_RAID_ACTIVITY_CITY_THRESHOLD);
+        $this->assertSame(0, SettingService::DEFAULT_RAID_MINIMUM_INACTIVE_TURNS);
+        $this->assertSame(1000, SettingService::MAX_RAID_ACTIVITY_CITY_THRESHOLD);
+        $this->assertSame(4380, SettingService::MAX_RAID_MINIMUM_INACTIVE_TURNS);
     }
 
     public function test_data_sync_defaults_and_manual_nation_aliases_are_preserved(): void
@@ -34,6 +38,10 @@ class SettingServiceCharacterizationTest extends TestCase
         $this->assertNull(SettingService::getCityAverageUpdatedAt());
         $this->assertSame(40, SettingService::getTopRaidable());
         $this->assertSame('40', $this->storedValue('raid_top_alliance_cap'));
+        $this->assertSame(0, SettingService::getRaidActivityCityThreshold());
+        $this->assertSame('0', $this->storedValue('raid_activity_city_threshold'));
+        $this->assertSame(0, SettingService::getRaidMinimumInactiveTurns());
+        $this->assertSame('0', $this->storedValue('raid_minimum_inactive_turns'));
 
         $this->assertSame('', SettingService::getLastNationSyncBatchId());
         $this->assertSame('', $this->storedValue('last_nation_sync_batch_id'));

--- a/tests/Unit/Services/RaidFinderServiceTest.php
+++ b/tests/Unit/Services/RaidFinderServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Nation;
+use App\Models\TradePrice;
+use App\Services\AllianceMembershipService;
+use App\Services\GraphQLQueryBuilder;
+use App\Services\LootCalculatorService;
+use App\Services\QueryService;
+use App\Services\RaidFinderService;
+use App\Services\RaidPolicyService;
+use App\Services\SettingService;
+use App\Services\TradePriceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class RaidFinderServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_target_generation_applies_the_configured_activity_policy(): void
+    {
+        $this->travelTo('2026-08-12 12:00:00 UTC');
+        SettingService::setRaidActivityCityThreshold(10);
+        SettingService::setRaidMinimumInactiveTurns(12);
+
+        $ownNation = Nation::factory()->create([
+            'alliance_id' => 777,
+            'score' => 1000,
+        ]);
+
+        $queryService = Mockery::mock(QueryService::class);
+        $queryService->shouldReceive('sendQuery')
+            ->once()
+            ->withArgs(fn (GraphQLQueryBuilder $query): bool => str_contains($query->build(), 'last_active'))
+            ->andReturn((object) [
+                $this->targetPayload(1001, '2026-08-12 11:00:00'),
+                $this->targetPayload(1002, '2026-08-11 12:00:00'),
+            ]);
+        $this->app->instance(QueryService::class, $queryService);
+
+        $prices = Mockery::mock(TradePriceService::class);
+        $prices->shouldReceive('get24hAverage')->once()->andReturn(new TradePrice);
+        $this->app->instance(TradePriceService::class, $prices);
+
+        $loot = Mockery::mock(LootCalculatorService::class);
+        $loot->shouldReceive('calculateFromGraphQLWar')->once()->andReturn(1_000_000);
+        $this->app->instance(LootCalculatorService::class, $loot);
+
+        $membership = Mockery::mock(AllianceMembershipService::class);
+        $membership->shouldReceive('contains')->once()->with(777)->andReturnTrue();
+        $this->app->instance(AllianceMembershipService::class, $membership);
+
+        $policy = Mockery::mock(RaidPolicyService::class);
+        $policy->shouldReceive('raidableAllianceIds')->once()->andReturn([123]);
+        $this->app->instance(RaidPolicyService::class, $policy);
+
+        $targets = app(RaidFinderService::class)->findTargets($ownNation->id);
+
+        $this->assertSame([1002], $targets->pluck('nation.id')->all());
+        $this->assertSame([1_000_000], $targets->pluck('value')->all());
+    }
+
+    /** @return array<string, mixed> */
+    private function targetPayload(int $id, string $lastActive): array
+    {
+        return [
+            'id' => $id,
+            'leader_name' => 'Target '.$id,
+            'alliance_id' => 123,
+            'last_active' => $lastActive,
+            'score' => 1000,
+            'num_cities' => 11,
+            'alliance' => [
+                'id' => 123,
+                'name' => 'Raidable Alliance',
+                'acronym' => 'RAID',
+                'score' => 1000,
+                'color' => 'gray',
+                'accept_members' => false,
+                'rank' => 100,
+            ],
+            'wars' => [[
+                'id' => $id + 5000,
+                'date' => '2026-08-01 00:00:00',
+                'def_id' => $id,
+                'winner_id' => 999999,
+                'turns_left' => 0,
+                'attacks' => [],
+            ]],
+        ];
+    }
+}

--- a/tests/Unit/Services/RaidTargetActivityFilterTest.php
+++ b/tests/Unit/Services/RaidTargetActivityFilterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\GraphQL\Models\Nation;
+use App\Services\RaidTargetActivityFilter;
+use App\Services\SettingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RaidTargetActivityFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_zero_inactive_turns_preserves_every_target(): void
+    {
+        SettingService::setRaidActivityCityThreshold(10);
+        SettingService::setRaidMinimumInactiveTurns(0);
+
+        $target = $this->target(1, null, null);
+
+        $this->assertSame(
+            [1],
+            app(RaidTargetActivityFilter::class)->filter(collect([$target]))->pluck('id')->all(),
+        );
+    }
+
+    public function test_inactivity_applies_only_above_the_city_threshold(): void
+    {
+        $this->travelTo('2026-08-12 12:00:00');
+        SettingService::setRaidActivityCityThreshold(10);
+        SettingService::setRaidMinimumInactiveTurns(12);
+
+        $targets = collect([
+            $this->target(1, 9, '2026-08-12 12:00:00'),
+            $this->target(2, 10, '2026-08-12 12:00:00'),
+            $this->target(3, 11, '2026-08-11 13:00:00'),
+            $this->target(4, 12, '2026-08-11 12:00:00'),
+            $this->target(5, 13, null),
+            $this->target(6, null, '2026-08-01 12:00:00'),
+        ]);
+
+        $eligibleIds = app(RaidTargetActivityFilter::class)
+            ->filter($targets)
+            ->pluck('id')
+            ->all();
+
+        $this->assertSame([1, 2, 4], $eligibleIds);
+    }
+
+    private function target(int $id, ?int $cityCount, ?string $lastActive): Nation
+    {
+        $nation = new Nation;
+        $nation->id = $id;
+        $nation->num_cities = $cityCount;
+        $nation->last_active = $lastActive;
+
+        return $nation;
+    }
+}


### PR DESCRIPTION
## Summary

- add administrator-configurable city and inactivity thresholds to the raid finder policy
- require targets above the configured city threshold to have been inactive for the configured number of two-hour turns
- preserve existing behavior when the inactivity setting is zero and preserve the existing top-cap-only update contract
- validate and audit policy updates, then invalidate cached raid-finder results
- add focused coverage for settings persistence, authorization, threshold boundaries, and target generation

## User and operational impact

Raid managers can tune activity requirements from the existing admin Raid Finder page. Targets at or below the city threshold bypass the inactivity requirement; targets above it must meet the configured inactivity period. Unknown city or activity data fails closed when the filter is enabled.

No migration, cache clear, or worker restart is required. Saving the policy advances the raid-finder cache version automatically.

## Validation

- `./vendor/bin/pint --dirty`
- 44 focused PHPUnit tests passed with 392 assertions
- full `php artisan test --compact` run completed with no raid-finder failures; its 16 failures were pre-existing/local-environment issues: two stale route-contract assertions, ten tests requiring the unavailable PHP Redis extension, and four tenant stream tests affected by Redis absence and SQLite transaction state
